### PR TITLE
Improve flyout focus/topmost behavior to prevent stealing focus

### DIFF
--- a/FluentFlyoutWPF/Classes/WindowHelper.cs
+++ b/FluentFlyoutWPF/Classes/WindowHelper.cs
@@ -1,0 +1,40 @@
+﻿using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace FluentFlyout.Classes
+{
+    class WindowHelper
+    {
+        private const int GWL_EXSTYLE = -20;
+        private const int WS_EX_NOACTIVATE = 0x08000000;
+        private const int HWND_TOPMOST = -1;
+        private const int SWP_NOSIZE = 0x0001;
+        private const int SWP_NOMOVE = 0x0002;
+        private const int SWP_SHOWWINDOW = 0x0040;
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
+        [DllImport("user32.dll")]
+        private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool SetWindowPos(IntPtr hWnd, int hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
+
+        public static void SetTopmost(Window window) // workaround to set window even more topmost
+        {
+            var handle = new WindowInteropHelper(window).Handle;
+            SetWindowPos(handle, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+        }
+
+        public static void SetNoActivate(Window window) // prevent window from stealing focus
+        {
+            window.SourceInitialized += (sender, e) =>
+            {
+                var helper = new WindowInteropHelper(window);
+                SetWindowLong(helper.Handle, GWL_EXSTYLE, GetWindowLong(helper.Handle, GWL_EXSTYLE) | WS_EX_NOACTIVATE);
+            };
+        }
+    }
+}

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -17,9 +17,7 @@ using System.Drawing;
 using System.Windows.Controls;
 using Wpf.Ui.Controls;
 using Wpf.Ui.Appearance;
-using MicaWPF.Styles;
-using MicaWPF.Core.Styles;
-using MicaWPF.Core.Services;
+using FluentFlyout.Classes;
 
 
 namespace FluentFlyoutWPF
@@ -53,10 +51,11 @@ namespace FluentFlyoutWPF
         private NextUpWindow? nextUpWindow = null; // to prevent multiple instances of NextUpWindow
         private string currentTitle = ""; // to prevent NextUpWindow from showing the same song
 
-
         public MainWindow()
         {
+            WindowHelper.SetNoActivate(this); // prevents some fullscreen apps from minimizing
             InitializeComponent();
+            WindowHelper.SetTopmost(this); // more prevention of fullscreen apps minimizing
 
             if (!singleton.WaitOne(TimeSpan.Zero, true)) // if another instance is already running, close this one
             {

--- a/FluentFlyoutWPF/SettingsWindow.xaml
+++ b/FluentFlyoutWPF/SettingsWindow.xaml
@@ -7,13 +7,13 @@
       xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
       xmlns:controls="clr-namespace:MicaWPF.Controls;assembly=MicaWPF"
       mc:Ignorable="d" 
-      Height="6000" Width="660" MinHeight="300" MinWidth="660"
+      Height="600" Width="660" MinHeight="300" MinWidth="660"
       Title="Settings" Icon="/Resources/FluentFlyout2.ico"
       TextOptions.TextRenderingMode="ClearType" TextOptions.TextFormattingMode="Ideal"
       >
 
     <Grid>
-        <ScrollViewer HorizontalScrollBarVisibility="Auto">
+        <ui:PassiveScrollViewer HorizontalScrollBarVisibility="Auto">
             <StackPanel>
                 <StackPanel Orientation="Vertical" Margin="16,12,16,24">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="12,0,0,0">
@@ -40,8 +40,9 @@
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
                             <ui:Image Source="/Resources/FluentFlyoutDemo3.1.png" Width="128"/>
                             <TextBlock FontSize="14" FontWeight="Regular" HorizontalAlignment="Stretch" Opacity="0.75" Margin="12,0,0,0">
-                                When listening to media, press any media or volume control key<LineBreak />
-                                (play/pause, volume up/down, etc.) on your keyboard to display the flyout.
+                                Main flyout. When listening to media, press any media or volume key<LineBreak />
+                                (play/pause, volume up/down, etc.) on your keyboard to display the flyout.<LineBreak />
+                                Displays media info, along with playback controls and more.
                             </TextBlock>
                         </StackPanel>
                         <ui:CardControl Grid.Row="1" Icon="{ui:SymbolIcon ArrowAutofitWidth24}" Margin="0,0,0,3">
@@ -137,7 +138,7 @@
                             <ui:CardControl.Header>
                                 <StackPanel Orientation="Vertical">
                                     <TextBlock Text="Enable Next Up Flyout (Experimental)" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
-                                    <TextBlock Text="Shows what's next when a song/video ends" FontSize="12" Opacity="0.5"/>
+                                    <TextBlock Text="Shows what's next when a song/video ends, very compact" FontSize="12" Opacity="0.5"/>
                                 </StackPanel>
                             </ui:CardControl.Header>
                             <controls:ToggleSwitch Name="NextUpSwitch" Click="NextUpSwitch_Click" IsChecked="False"/>
@@ -215,6 +216,6 @@
                     </StackPanel>
                 </DockPanel>
             </StackPanel>
-        </ScrollViewer>
+        </ui:PassiveScrollViewer>
     </Grid>
 </controls:MicaWindow>

--- a/FluentFlyoutWPF/SettingsWindow.xaml.cs
+++ b/FluentFlyoutWPF/SettingsWindow.xaml.cs
@@ -3,7 +3,6 @@ using MicaWPF.Controls;
 using Microsoft.Win32;
 using System.Reflection;
 using System.Windows;
-using System.Windows.Documents;
 using Windows.ApplicationModel;
 
 

--- a/FluentFlyoutWPF/Windows/NextUpWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/NextUpWindow.xaml.cs
@@ -1,21 +1,11 @@
-﻿using FluentFlyout.Properties;
+﻿using FluentFlyout.Classes;
+using FluentFlyout.Properties;
 using FluentFlyoutWPF;
 using MicaWPF.Controls;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using Wpf.Ui.Controls;
+
 
 namespace FluentFlyout
 {
@@ -29,7 +19,9 @@ namespace FluentFlyout
         {
             WindowStartupLocation = WindowStartupLocation.Manual;
             Left = -Width - 20;
+            WindowHelper.SetNoActivate(this);
             InitializeComponent();
+            WindowHelper.SetTopmost(this);
 
             var titleWidth = GetStringWidth(title);
             var artistWidth = GetStringWidth(artist);


### PR DESCRIPTION
**Fixes cases of bug #5 where fullscreen games close due to flyout behavior**

- Modified constructors to prevent windows from minimizing or stealing focus. 
- Corrected SettingsWindow height and replaced ScrollViewer for better Wpf.Ui integration. 
- Updated text descriptions in SettingsWindow.xaml. 
- Introduced WindowHelper class to manage window positioning and activation.