### PR TITLE
Add SongImagePlaceholder icon, Remove unnecessary Topmost properties

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml
+++ b/FluentFlyoutWPF/MainWindow.xaml
@@ -9,7 +9,7 @@
         xmlns:controls="clr-namespace:MicaWPF.Controls;assembly=MicaWPF"
         Height="116" Width="310"
         WindowStyle="None" mc:Ignorable="d" ShowInTaskbar="False"
-        Topmost="True" ResizeMode="NoResize" MouseEnter="MicaWindow_MouseEnter"
+        ResizeMode="NoResize" MouseEnter="MicaWindow_MouseEnter"
         ChangeTitleColorWhenInactive="False"
         TextOptions.TextRenderingMode="ClearType" TextOptions.TextFormattingMode="Ideal" Loaded="MicaWindow_Loaded"
         >
@@ -37,6 +37,7 @@
     <Grid>
         <StackPanel Margin="12" Orientation="Horizontal">
             <Border Name="SongImageBorder" CornerRadius="6" BorderThickness="1" BorderBrush="#26FFFFFF" Margin="0" ClipToBounds="True" Width="78" Height="78">
+                <ui:SymbolIcon Name="SongImagePlaceholder" Symbol="MusicNote220" FontSize="40" Filled="True" Foreground="{DynamicResource MicaWPF.Brushes.SystemAccentColorLight2}" Visibility="Collapsed" />
                 <Border.Background>
                     <ImageBrush x:Name="SongImage" Stretch="UniformToFill"/>
                 </Border.Background>
@@ -52,7 +53,7 @@
                     <!--<ui:Button Name="ControlBack" Icon="{ui:SymbolIcon Previous20, Filled=True}" Width="28" Height="28" Padding="0" CornerRadius="999" Margin="0,0,8,0" Click="Back_Click" Focusable="False"/>-->
                     <controls:Button
                     Height="28" Width="28" Name="ControlBack"
-                    Margin="0,0,8,0" Click="Back_Click" Focusable="False"
+                    Margin="2,0,8,0" Click="Back_Click" Focusable="False"
                     Style="{StaticResource MicaWPF.Styles.TransparentButton}" VerticalAlignment="Center">
                         <ui:SymbolIcon Name="SymbolBack" Symbol="Previous20" Filled="True"/>
                     </controls:Button>

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -51,7 +51,7 @@ namespace FluentFlyoutWPF
         private NextUpWindow? nextUpWindow = null; // to prevent multiple instances of NextUpWindow
         private string currentTitle = ""; // to prevent NextUpWindow from showing the same song
 
-        private LockWindow lockWindow;
+        private LockWindow? lockWindow;
 
         public MainWindow()
         {
@@ -346,7 +346,6 @@ namespace FluentFlyoutWPF
             cts = new CancellationTokenSource();
             var token = cts.Token;
             Visibility = Visibility.Visible;
-            Topmost = true;
 
             try
             {
@@ -380,7 +379,6 @@ namespace FluentFlyoutWPF
                 _playerInfoEnabled != Settings.Default.PlayerInfoEnabled ||
                 _centerTitleArtist != Settings.Default.CenterTitleArtist)
                 UpdateUILayout();
-
 
             Dispatcher.Invoke(() =>
             {
@@ -474,6 +472,8 @@ namespace FluentFlyoutWPF
                     SongTitle.Text = songInfo.Title;
                     SongArtist.Text = songInfo.Artist;
                     SongImage.ImageSource = Helper.GetThumbnail(songInfo.Thumbnail);
+                    if (SongImage.ImageSource == null) SongImagePlaceholder.Visibility = Visibility.Visible;
+                    else SongImagePlaceholder.Visibility = Visibility.Collapsed;
                 }
             });
         }

--- a/FluentFlyoutWPF/Windows/LockWindow.xaml
+++ b/FluentFlyoutWPF/Windows/LockWindow.xaml
@@ -8,7 +8,7 @@
     xmlns:controls="clr-namespace:MicaWPF.Controls;assembly=MicaWPF"
     mc:Ignorable="d" 
     Height="50" Width="160" 
-    Topmost="True" ResizeMode="NoResize"
+    ResizeMode="NoResize"
     WindowStyle="None" ShowInTaskbar="False"
     SystemBackdropType="Mica" ChangeTitleColorWhenInactive="False"
     TextOptions.TextRenderingMode="ClearType" TextOptions.TextFormattingMode="Ideal">

--- a/FluentFlyoutWPF/Windows/LockWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/LockWindow.xaml.cs
@@ -62,7 +62,7 @@ namespace FluentFlyout.Windows
             cts = new CancellationTokenSource();
             var token = cts.Token;
             Visibility = Visibility.Visible;
-            Topmost = true;
+
             try
             {
                 while (!token.IsCancellationRequested)

--- a/FluentFlyoutWPF/Windows/NextUpWindow.xaml
+++ b/FluentFlyoutWPF/Windows/NextUpWindow.xaml
@@ -8,7 +8,7 @@
       xmlns:controls="clr-namespace:MicaWPF.Controls;assembly=MicaWPF"
       mc:Ignorable="d" 
       Height="50" Width="310"
-      Topmost="True" ResizeMode="NoResize"
+      ResizeMode="NoResize"
       WindowStyle="None" ShowInTaskbar="False"
       SystemBackdropType="Mica" ChangeTitleColorWhenInactive="False"
       TextOptions.TextRenderingMode="ClearType" TextOptions.TextFormattingMode="Ideal"
@@ -45,6 +45,7 @@
             <TextBlock Text="Up next:" FontSize="12" VerticalAlignment="Center" FontFamily="Segoe UI Variable" FontWeight="Medium"/>
         </StackPanel>
         <Border Grid.Column="1" Name="SongImageBorder" CornerRadius="6" Margin="12,1,0,0" ClipToBounds="True" Width="38" Height="38">
+            <ui:SymbolIcon Name="SongImagePlaceholder" Symbol="MusicNote220" FontSize="40" Filled="True" Foreground="{DynamicResource MicaWPF.Brushes.SystemAccentColorLight2}" Visibility="Collapsed" />
             <Border.Background>
                 <ImageBrush x:Name="SongImage" Stretch="UniformToFill"/>
             </Border.Background>

--- a/FluentFlyoutWPF/Windows/NextUpWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/NextUpWindow.xaml.cs
@@ -18,7 +18,8 @@ namespace FluentFlyout
         public NextUpWindow(string title, string artist, BitmapImage thumbnail)
         {
             WindowStartupLocation = WindowStartupLocation.Manual;
-            Left = -Width - 20;
+            Left = -Width - 9999; // move window out of bounds to prevent flickering, maybe needs better solution
+            Top = 9999;
             WindowHelper.SetNoActivate(this);
             InitializeComponent();
             WindowHelper.SetTopmost(this);
@@ -32,6 +33,8 @@ namespace FluentFlyout
             SongTitle.Text = title;
             SongArtist.Text = artist;
             SongImage.ImageSource = thumbnail;
+            if (SongImage.ImageSource == null) SongImagePlaceholder.Visibility = Visibility.Visible;
+            else SongImagePlaceholder.Visibility = Visibility.Collapsed;
             Show();
             mainWindow.OpenAnimation(this);
 


### PR DESCRIPTION
- Removed `Topmost` property from several XAML files.
- Added `SymbolIcon` named `SongImagePlaceholder` to `MainWindow.xaml` and `NextUpWindow.xaml` for displaying a placeholder icon when no song image is available.
- Adjusted `Margin` property of `ControlBack` button in `MainWindow.xaml`.
- Changed `lockWindow` field to nullable type (`LockWindow?`) in `MainWindow.xaml.cs` to suppress warning.
- Moved initial position of `NextUpWindow` out of bounds to prevent flickering.
- Added logic to show/hide `SongImagePlaceholder` based on the validity of `SongImage` source in `MainWindow.xaml.cs` and `NextUpWindow.xaml.cs`.