### PR TITLE
Add new settings for DirectX exclusive fullscreen detection and lock flyout

### DIFF
--- a/FluentFlyoutWPF/App.config
+++ b/FluentFlyoutWPF/App.config
@@ -61,6 +61,12 @@
             <setting name="nIconSymbol" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="DisableIfFullscreen" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="LockKeysBoldUI" serializeAs="String">
+                <value>True</value>
+            </setting>
         </FluentFlyout.Properties.Settings>
     </userSettings>
 </configuration>

--- a/FluentFlyoutWPF/Classes/FullscreenDetector.cs
+++ b/FluentFlyoutWPF/Classes/FullscreenDetector.cs
@@ -1,0 +1,54 @@
+﻿using FluentFlyout.Properties;
+using System.Runtime.InteropServices;
+
+
+namespace FluentFlyoutWPF.Classes;
+
+internal class FullscreenDetector
+{
+    /// <summary>
+    /// Represents the different states of user notification returned by the Windows Shell API.
+    /// </summary>
+    public enum QUERY_USER_NOTIFICATION_STATE
+    {
+        QUNS_NOT_PRESENT = 1,
+        QUNS_BUSY = 2,
+        QUNS_RUNNING_D3D_FULL_SCREEN = 3,
+        QUNS_PRESENTATION_MODE = 4,
+        QUNS_ACCEPTS_NOTIFICATIONS = 5,
+        QUNS_QUIET_TIME = 6,
+        QUNS_APP = 7
+    }
+
+    [DllImport("shell32.dll")]
+    private static extern int SHQueryUserNotificationState(out QUERY_USER_NOTIFICATION_STATE pquns);
+
+    /// <summary>
+    /// Checks if a DirectX exclusive fullscreen application or game is currently running.
+    /// </summary>
+    /// <returns>
+    /// true if a fullscreen DirectX application is running;
+    /// false if no fullscreen application is detected, DisableIfFullscreen setting is false, or if the check fails
+    /// </returns>
+    public static bool IsFullscreenApplicationRunning()
+    {
+        if (Settings.Default.DisableIfFullscreen) return false;
+        try
+        {
+            QUERY_USER_NOTIFICATION_STATE state;
+            int result = SHQueryUserNotificationState(out state);
+
+            if (result != 0) // 0 means SUCCESS
+            {
+                throw new Exception($"SHQueryUserNotificationState failed with error code: {result}");
+            }
+
+            return state == QUERY_USER_NOTIFICATION_STATE.QUNS_RUNNING_D3D_FULL_SCREEN;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error detecting fullscreen state: {ex.Message}");
+            return false;
+        }
+    }
+}

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -260,7 +260,7 @@ public partial class MainWindow : MicaWindow
     private void MediaManager_OnAnyMediaPropertyChanged(MediaSession mediaSession, GlobalSystemMediaTransportControlsSessionMediaProperties mediaProperties)
     {
         if (mediaManager.GetFocusedSession() == null) return;
-        if (Settings.Default.NextUpEnabled == true) // show NextUpWindow if enabled in settings
+        if (Settings.Default.NextUpEnabled || !FullscreenDetector.IsFullscreenApplicationRunning()) // show NextUpWindow if enabled in settings
         {
             var songInfo = mediaSession.ControlSession.TryGetMediaPropertiesAsync().GetAwaiter().GetResult();
             if (nextUpWindow == null && IsVisible == false && songInfo.Thumbnail != null && currentTitle != songInfo.Title)
@@ -303,7 +303,7 @@ public partial class MainWindow : MicaWindow
                 ShowMediaFlyout();
             }
 
-            if (Settings.Default.LockKeysEnabled == true)
+            if (Settings.Default.LockKeysEnabled || !FullscreenDetector.IsFullscreenApplicationRunning())
             {
                 if (vkCode == 0x14) // Caps Lock
                 {
@@ -326,10 +326,13 @@ public partial class MainWindow : MicaWindow
         return CallNextHookEx(_hookId, nCode, wParam, lParam);
     }
 
-        private async void ShowMediaFlyout()
-        {
-            if (mediaManager.GetFocusedSession() == null || !Settings.Default.MediaFlyoutEnabled) return;
-            UpdateUI(mediaManager.GetFocusedSession());
+    private async void ShowMediaFlyout()
+    {
+        if (mediaManager.GetFocusedSession() == null ||
+            !Settings.Default.MediaFlyoutEnabled ||
+            FullscreenDetector.IsFullscreenApplicationRunning())
+            return;
+        UpdateUI(mediaManager.GetFocusedSession());
 
         if (nextUpWindow != null) // close NextUpWindow if it's open
         {
@@ -691,7 +694,8 @@ public partial class MainWindow : MicaWindow
 
     private void nIcon_LeftClick(Wpf.Ui.Tray.Controls.NotifyIcon sender, RoutedEventArgs e) // change the behavior of the tray icon
     {
-        if (Settings.Default.nIconLeftClick == 0) {
+        if (Settings.Default.nIconLeftClick == 0)
+        {
             openSettings(sender, e);
             //Wpf.Ui.Appearance.ApplicationThemeManager.Apply(ApplicationTheme.Light, WindowBackdropType.Mica); // to change the theme
             //ThemeService themeService = new ThemeService();

--- a/FluentFlyoutWPF/Properties/Settings.Designer.cs
+++ b/FluentFlyoutWPF/Properties/Settings.Designer.cs
@@ -238,5 +238,29 @@ namespace FluentFlyout.Properties {
                 this["nIconSymbol"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool DisableIfFullscreen {
+            get {
+                return ((bool)(this["DisableIfFullscreen"]));
+            }
+            set {
+                this["DisableIfFullscreen"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool LockKeysBoldUI {
+            get {
+                return ((bool)(this["LockKeysBoldUI"]));
+            }
+            set {
+                this["LockKeysBoldUI"] = value;
+            }
+        }
     }
 }

--- a/FluentFlyoutWPF/Properties/Settings.settings
+++ b/FluentFlyoutWPF/Properties/Settings.settings
@@ -56,5 +56,11 @@
     <Setting Name="nIconSymbol" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="DisableIfFullscreen" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="LockKeysBoldUI" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/FluentFlyoutWPF/SettingsWindow.xaml
+++ b/FluentFlyoutWPF/SettingsWindow.xaml
@@ -147,7 +147,7 @@
                             <ui:CardControl.Header>
                                 <StackPanel Orientation="Vertical">
                                     <TextBlock Text="Enable Next Up Flyout (Experimental)" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
-                                    <TextBlock Text="Shows what's next when a song/video ends, very compact" FontSize="12" Opacity="0.5"/>
+                                    <TextBlock Text="Shows what's next when a song/video ends" FontSize="12" Opacity="0.5"/>
                                 </StackPanel>
                             </ui:CardControl.Header>
                             <controls:ToggleSwitch Name="NextUpSwitch" Click="NextUpSwitch_Click"/>
@@ -169,6 +169,7 @@
                     <TextBlock Text="Lock Keys Customization" FontSize="20" FontWeight="SemiBold" FontFamily="Segoe UI Variable" Margin="0,36,0,0"/>
                     <Grid Margin="0,12,0,0">
                         <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
@@ -202,11 +203,21 @@
                                 <TextBlock Text="ms" FontSize="14" FontWeight="Regular" Margin="10,0,0,0" VerticalAlignment="Center"/>
                             </StackPanel>
                         </ui:CardControl>
+                        <ui:CardControl Grid.Row="3" Icon="{ui:SymbolIcon TextBold24}" Margin="0,0,0,3">
+                            <ui:CardControl.Header>
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="Bold Symbol and Font" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Emphasizes the flyout symbol and font" FontSize="12" Opacity="0.5"/>
+                                </StackPanel>
+                            </ui:CardControl.Header>
+                            <controls:ToggleSwitch Name="LockKeysBoldUISwitch" Click="LockKeysBoldUISwitch_Click"/>
+                        </ui:CardControl>
                     </Grid>
 
                     <TextBlock Text="System" FontSize="18" FontWeight="SemiBold" Margin="0,36,0,0"/>
                     <Grid Margin="0,12,0,0">
                         <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
@@ -229,7 +240,19 @@
                             </ui:CardControl.Header>
                             <controls:ToggleSwitch Name="StartupSwitch" Click="StartupSwitch_Click"/>
                         </ui:CardControl>
-                        <ui:CardControl Grid.Row="1" Icon="{ui:SymbolIcon CursorHover24}" Margin="0,0,0,3">
+                        <ui:CardControl Grid.Row="1" Icon="{ui:SymbolIcon Color24}" Margin="0,0,0,3">
+                            <ui:CardControl.Header>
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="App Theme" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </ui:CardControl.Header>
+                            <ComboBox Name="AppThemeComboBox" SelectionChanged="AppThemeComboBox_SelectionChanged" IsReadOnly="False">
+                                <ComboBoxItem Content=" Windows Default"/>
+                                <ComboBoxItem Content=" Light"/>
+                                <ComboBoxItem Content=" Dark"/>
+                            </ComboBox>
+                        </ui:CardControl>
+                        <ui:CardControl Grid.Row="2" Icon="{ui:SymbolIcon CursorHover24}" Margin="0,0,0,3">
                             <ui:CardControl.Header>
                                 <StackPanel Orientation="Vertical">
                                     <TextBlock Text="Tray Icon Left Click Behavior" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
@@ -242,7 +265,7 @@
                                 </ComboBox>
                             </StackPanel>
                         </ui:CardControl>
-                        <ui:CardControl Grid.Row="2" Icon="{ui:SymbolIcon PaintBrush24}" Margin="0,0,0,3">
+                        <ui:CardControl Grid.Row="3" Icon="{ui:SymbolIcon PaintBrush24}" Margin="0,0,0,3">
                             <ui:CardControl.Header>
                                 <StackPanel Orientation="Vertical">
                                     <TextBlock Text="Windows 11-like Tray Icon" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
@@ -251,7 +274,7 @@
                             </ui:CardControl.Header>
                             <controls:ToggleSwitch Name="nIconSymbolSwitch" Click="nIconSymbolSwitch_Click"/>
                         </ui:CardControl>
-                        <ui:CardExpander Grid.Row="3" Icon="{ui:SymbolIcon Wrench24}" ContentPadding="6" Margin="0,0,0,3">
+                        <ui:CardExpander Grid.Row="4" Icon="{ui:SymbolIcon Wrench24}" ContentPadding="6" Margin="0,0,0,3">
                             <ui:CardExpander.Header>
                                 <StackPanel Orientation="Vertical">
                                     <TextBlock Text="Animation Settings" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
@@ -296,17 +319,14 @@
                                 <ui:InfoBar Title="For the native Windows 11 experience, the settings should be kept at default." IsOpen="True" Severity="Informational" IsClosable="False"/>
                             </StackPanel>
                         </ui:CardExpander>
-                        <ui:CardControl Grid.Row="4" Icon="{ui:SymbolIcon Color24}" Margin="0,0,0,3">
+                        <ui:CardControl Grid.Row="5" Icon="{ui:SymbolIcon ArrowMinimize24}" Margin="0,0,0,3">
                             <ui:CardControl.Header>
                                 <StackPanel Orientation="Vertical">
-                                    <TextBlock Text="App Theme" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Disable Flyouts if DirectX fullscreen program is detected" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Prevents DirectX games in exclusive fullscreen from minimizing if a flyout pops up" FontSize="12" Opacity="0.5"/>
                                 </StackPanel>
                             </ui:CardControl.Header>
-                            <ComboBox Name="AppThemeComboBox" SelectionChanged="AppThemeComboBox_SelectionChanged" IsReadOnly="False">
-                                <ComboBoxItem Content=" Windows Default"/>
-                                <ComboBoxItem Content=" Light"/>
-                                <ComboBoxItem Content=" Dark"/>
-                            </ComboBox>
+                            <controls:ToggleSwitch Name="DisableIfFullscreenSwitch" Click="DisableIfFullscreenSwitch_Click"/>
                         </ui:CardControl>
                     </Grid>
                 </StackPanel>

--- a/FluentFlyoutWPF/SettingsWindow.xaml.cs
+++ b/FluentFlyoutWPF/SettingsWindow.xaml.cs
@@ -55,6 +55,8 @@ public partial class SettingsWindow : MicaWindow
         AppThemeComboBox.SelectedIndex = Settings.Default.AppTheme;
         MediaFlyoutEnabledSwitch.IsChecked = Settings.Default.MediaFlyoutEnabled;
         nIconSymbolSwitch.IsChecked = Settings.Default.nIconSymbol;
+        DisableIfFullscreenSwitch.IsChecked = Settings.Default.DisableIfFullscreen;
+        LockKeysBoldUISwitch.IsChecked = Settings.Default.LockKeysBoldUI;
 
         try // gets the version of the app, works only in release mode
         {
@@ -333,5 +335,17 @@ public partial class SettingsWindow : MicaWindow
         Settings.Default.nIconSymbol = nIconSymbolSwitch.IsChecked ?? false;
         Settings.Default.Save();
         ThemeManager.UpdateTrayIcon();
+    }
+
+    private void DisableIfFullscreenSwitch_Click(object sender, RoutedEventArgs e)
+    {
+        Settings.Default.DisableIfFullscreen = DisableIfFullscreenSwitch.IsChecked ?? false;
+        Settings.Default.Save();
+    }
+
+    private void LockKeysBoldUISwitch_Click(object sender, RoutedEventArgs e)
+    {
+        Settings.Default.LockKeysBoldUI = LockKeysBoldUISwitch.IsChecked ?? false;
+        Settings.Default.Save();
     }
 }

--- a/FluentFlyoutWPF/Windows/LockWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/LockWindow.xaml.cs
@@ -38,15 +38,20 @@ public partial class LockWindow : MicaWindow
             this.EnableBackdrop();
 
             LockTextBlock.Text = key + " is " + (isOn ? "on" : "off");
+            if (Settings.Default.LockKeysBoldUI) LockTextBlock.FontWeight = FontWeights.Medium;
+            else LockTextBlock.FontWeight = FontWeights.Normal;
+
             if (isOn)
             {
                 LockIndicatorRectangle.Opacity = 1;
-                LockSymbol.Symbol = Wpf.Ui.Controls.SymbolRegular.LockClosed24;
+                if (Settings.Default.LockKeysBoldUI) LockSymbol.Symbol = Wpf.Ui.Controls.SymbolRegular.LockClosed24;
+                else LockSymbol.Symbol = Wpf.Ui.Controls.SymbolRegular.LockClosed20;
             }
             else
             {
                 LockIndicatorRectangle.Opacity = 0.2;
-                LockSymbol.Symbol = Wpf.Ui.Controls.SymbolRegular.LockOpen24;
+                if (Settings.Default.LockKeysBoldUI) LockSymbol.Symbol = Wpf.Ui.Controls.SymbolRegular.LockOpen24;
+                else LockSymbol.Symbol = Wpf.Ui.Controls.SymbolRegular.LockOpen20;
             }
         });
     }


### PR DESCRIPTION
Added setting to disable flyouts when a DirectX exclusive fullscreen application is detected (on by default), implemented a fullscreen detector class, and added setting to disable "boldness" of lock flyout.

* Added `DisableIfFullscreen` and `LockKeysBoldUI` settings to `App.config` and `Settings.settings` files, allowing users to control the behavior of the application when a fullscreen application is running. [[1]](diffhunk://#diff-11f9f3c4eb2c527e9223b604b3792543978eaba5cfa5a6e0892a3d157756f476R64-R69) [[2]](diffhunk://#diff-60de683ce4bdb0dfbbfa5e918dc21ad851d8ccf3659c9be08bc096278dc0a6e1R59-R64)
* Implemented the `FullscreenDetector` class to check if a DirectX exclusive fullscreen application is running.
* Modified `MainWindow.xaml.cs` to use the new `FullscreenDetector` for various features, such as showing the media flyout and handling lock keys. [[1]](diffhunk://#diff-1dc2a643641d41f9375d1d0eaccc42727996fa317cc8a151618c7f81d682978aL263-R263) [[2]](diffhunk://#diff-1dc2a643641d41f9375d1d0eaccc42727996fa317cc8a151618c7f81d682978aL306-R306) [[3]](diffhunk://#diff-1dc2a643641d41f9375d1d0eaccc42727996fa317cc8a151618c7f81d682978aL331-R334)
* Updated `SettingsWindow.xaml` to include new UI elements for the `DisableIfFullscreen` and `LockKeysBoldUI` settings. [[1]](diffhunk://#diff-a5acb4ccfdf0bb87710e2e89abbe424fcb728520ddc67c9d3abe298f30dd6545R206-R214) [[2]](diffhunk://#diff-a5acb4ccfdf0bb87710e2e89abbe424fcb728520ddc67c9d3abe298f30dd6545L232-R255) [[3]](diffhunk://#diff-a5acb4ccfdf0bb87710e2e89abbe424fcb728520ddc67c9d3abe298f30dd6545L299-R329)
* Enhanced the `LockWindow.xaml.cs` to adjust the font weight and symbol size based on the `LockKeysBoldUI` setting.

Fixes #14 where fullscreen games minimize when any flyout shows up.