### PR TITLE
Update version and fix moveAnimation properties

### DIFF
--- a/FluentFlyoutMSIX/Package.appxmanifest
+++ b/FluentFlyoutMSIX/Package.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="unchihugo.FluentFlyout"
     Publisher="CN=49793F74-1457-4B66-A672-4ED3A640FC76"
-    Version="1.2.4.0" />
+    Version="1.3.1.0" />
 
   <Properties>
     <DisplayName>FluentFlyout</DisplayName>

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -142,18 +142,18 @@ public partial class MainWindow : MicaWindow
             {
                 window.Left = SystemParameters.WorkArea.Width / 2 - window.Width / 2;
                 if (Settings.Default.FlyoutAnimationSpeed == 0)
-                    moveAnimation.To = SystemParameters.WorkArea.Height - window.Height - 80;
+                    moveAnimation.From = SystemParameters.WorkArea.Height - window.Height - 80;
                 else
-                    moveAnimation.To = SystemParameters.WorkArea.Height - window.Height - 60;
+                    moveAnimation.From = SystemParameters.WorkArea.Height - window.Height - 60;
                 moveAnimation.To = SystemParameters.WorkArea.Height - window.Height - 80;
             }
             else if (_position == 2)
             {
                 window.Left = SystemParameters.WorkArea.Width - window.Width - 16;
                 if (Settings.Default.FlyoutAnimationSpeed == 0)
-                    moveAnimation.To = SystemParameters.WorkArea.Height - window.Height - 16;
+                    moveAnimation.From = SystemParameters.WorkArea.Height - window.Height - 16;
                 else
-                    moveAnimation.To = SystemParameters.WorkArea.Height - window.Height + 4;
+                    moveAnimation.From = SystemParameters.WorkArea.Height - window.Height + 4;
                 moveAnimation.To = SystemParameters.WorkArea.Height - window.Height - 16;
             }
             else if (_position == 3)
@@ -188,9 +188,9 @@ public partial class MainWindow : MicaWindow
         {
             window.Left = SystemParameters.WorkArea.Width / 2 - window.Width / 2;
             if (Settings.Default.FlyoutAnimationSpeed == 0)
-                moveAnimation.To = SystemParameters.WorkArea.Height - window.Height - 16;
+                moveAnimation.From = SystemParameters.WorkArea.Height - window.Height - 16;
             else
-                moveAnimation.To = SystemParameters.WorkArea.Height - window.Height + 4;
+                moveAnimation.From = SystemParameters.WorkArea.Height - window.Height + 4;
             moveAnimation.To = SystemParameters.WorkArea.Height - window.Height - 16;
         }
 


### PR DESCRIPTION
Updated the version number in `Package.appxmanifest` from `1.2.4.0` to `1.3.1.0`. Replaced `moveAnimation.To` with `moveAnimation.From` in `MainWindow.xaml.cs` to correct animation behavior based on `_position` and `FlyoutAnimationSpeed` settings.