### PR TITLE
Refactor flyout conditions

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml
+++ b/FluentFlyoutWPF/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
         xmlns:tray="http://schemas.lepo.co/wpfui/2022/xaml/tray"
         xmlns:controls="clr-namespace:MicaWPF.Controls;assembly=MicaWPF"
-        Height="116" Width="310"
+        Height="116" Width="310" Top="-9999"
         WindowStyle="None" mc:Ignorable="d" ShowInTaskbar="False"
         ResizeMode="NoResize" MouseEnter="MicaWindow_MouseEnter"
         ChangeTitleColorWhenInactive="False"
@@ -34,6 +34,9 @@
     </Window.Triggers>
 
     <Grid>
+        <Grid.RenderTransform>
+            <ScaleTransform x:Name="ScaleTransform"/>
+        </Grid.RenderTransform>
         <StackPanel Margin="12" Orientation="Horizontal">
             <Border Name="SongImageBorder" CornerRadius="6" BorderThickness="1" BorderBrush="#26FFFFFF" Margin="0" ClipToBounds="True" Width="78" Height="78">
                 <ui:SymbolIcon Name="SongImagePlaceholder" Symbol="MusicNote220" FontSize="40" Filled="True" Foreground="{DynamicResource MicaWPF.Brushes.SystemAccentColorLight2}" Visibility="Collapsed" />

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -281,7 +281,7 @@ public partial class MainWindow : MicaWindow
     private void MediaManager_OnAnyMediaPropertyChanged(MediaSession mediaSession, GlobalSystemMediaTransportControlsSessionMediaProperties mediaProperties)
     {
         if (mediaManager.GetFocusedSession() == null) return;
-        if (Settings.Default.NextUpEnabled || !FullscreenDetector.IsFullscreenApplicationRunning()) // show NextUpWindow if enabled in settings
+        if (Settings.Default.NextUpEnabled && !FullscreenDetector.IsFullscreenApplicationRunning()) // show NextUpWindow if enabled in settings
         {
             var songInfo = mediaSession.ControlSession.TryGetMediaPropertiesAsync().GetAwaiter().GetResult();
             if (nextUpWindow == null && IsVisible == false && songInfo.Thumbnail != null && currentTitle != songInfo.Title)
@@ -324,7 +324,7 @@ public partial class MainWindow : MicaWindow
                 ShowMediaFlyout();
             }
 
-            if (Settings.Default.LockKeysEnabled || !FullscreenDetector.IsFullscreenApplicationRunning())
+            if (Settings.Default.LockKeysEnabled && !FullscreenDetector.IsFullscreenApplicationRunning())
             {
                 if (vkCode == 0x14) // Caps Lock
                 {


### PR DESCRIPTION
- Modified conditions in `MediaManager_OnAnyMediaPropertyChanged` and key event handler in `MainWindow.xaml.cs` to use logical AND (`&&`) instead of logical OR (`||`) for checking `Settings.Default` properties and fullscreen status.
- Added `Top="-9999"` to `Window` in `MainWindow.xaml` to position the window off-screen initially.

fixes #35 