### PR TITLE
Corrected FullscreenDetector logic

### DIFF
--- a/FluentFlyoutMSIX/Package.appxmanifest
+++ b/FluentFlyoutMSIX/Package.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="unchihugo.FluentFlyout"
     Publisher="CN=49793F74-1457-4B66-A672-4ED3A640FC76"
-    Version="1.3.1.0" />
+    Version="1.3.2.0" />
 
   <Properties>
     <DisplayName>FluentFlyout</DisplayName>

--- a/FluentFlyoutWPF/Classes/FullscreenDetector.cs
+++ b/FluentFlyoutWPF/Classes/FullscreenDetector.cs
@@ -32,7 +32,7 @@ internal class FullscreenDetector
     /// </returns>
     public static bool IsFullscreenApplicationRunning()
     {
-        if (Settings.Default.DisableIfFullscreen) return false;
+        if (!Settings.Default.DisableIfFullscreen) return false;
         try
         {
             QUERY_USER_NOTIFICATION_STATE state;


### PR DESCRIPTION
Corrected the logic in `FullscreenDetector.cs` to properly handle the `DisableIfFullscreen` setting by inverting the condition.

Mentioned in #14 