### PR TITLE
Add seekbar, duration, and enable/disable toggle button

### DIFF
--- a/FluentFlyoutWPF/Classes/Settings/UserSettings.cs
+++ b/FluentFlyoutWPF/Classes/Settings/UserSettings.cs
@@ -23,6 +23,7 @@ public class UserSettings
     public bool DisableIfFullscreen { get; set; }
     public bool LockKeysBoldUI { get; set; }
     public string LastKnownVersion { get; set; }
+    public bool SeekbarEnabled { get; set; }
 
 
     public UserSettings()
@@ -48,5 +49,6 @@ public class UserSettings
         DisableIfFullscreen = true;
         LockKeysBoldUI = true;
         LastKnownVersion = "";
+        SeekbarEnabled = true;
     }
 }

--- a/FluentFlyoutWPF/MainWindow.xaml
+++ b/FluentFlyoutWPF/MainWindow.xaml
@@ -37,67 +37,71 @@
         <Grid.RenderTransform>
             <ScaleTransform x:Name="ScaleTransform"/>
         </Grid.RenderTransform>
-        <StackPanel Margin="12" Orientation="Horizontal">
-            <Border Name="SongImageBorder" CornerRadius="6" BorderThickness="1" BorderBrush="#26FFFFFF" Margin="0" ClipToBounds="True" Width="78" Height="78">
-                <ui:SymbolIcon Name="SongImagePlaceholder" Symbol="MusicNote220" FontSize="40" Filled="True" Foreground="{DynamicResource MicaWPF.Brushes.SystemAccentColorLight2}" Visibility="Collapsed" />
-                <Border.Background>
-                    <ImageBrush x:Name="SongImage" Stretch="UniformToFill"/>
-                </Border.Background>
-            </Border>
-            <StackPanel Name="BodyStackPanel" Orientation="Vertical" VerticalAlignment="Center" Width="194">
-                <StackPanel Orientation="Horizontal">
-                    <StackPanel Name="SongInfoStackPanel" Margin="12,0,0,0" Orientation="Vertical" VerticalAlignment="Center" Width="182">
-                        <TextBlock Name="SongTitle" Text="Song Title" FontSize="14" FontFamily="Segoe UI Variable" FontWeight="Medium" TextTrimming="CharacterEllipsis"/>
-                        <TextBlock Name="SongArtist" Text="Artist Name" FontSize="14" FontFamily="Segoe UI Variable" FontWeight="Medium" Opacity="0.5" TextTrimming="CharacterEllipsis"/>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <StackPanel Grid.Row="0" Margin="12" Orientation="Horizontal">
+                <Border Name="SongImageBorder" CornerRadius="6" BorderThickness="1" BorderBrush="#26FFFFFF" Margin="0" ClipToBounds="True" Width="78" Height="78">
+                    <ui:SymbolIcon Name="SongImagePlaceholder" Symbol="MusicNote220" FontSize="40" Filled="True" Foreground="{DynamicResource MicaWPF.Brushes.SystemAccentColorLight2}" Visibility="Collapsed" />
+                    <Border.Background>
+                        <ImageBrush x:Name="SongImage" Stretch="UniformToFill"/>
+                    </Border.Background>
+                </Border>
+                <StackPanel Name="BodyStackPanel" Orientation="Vertical" VerticalAlignment="Center" Width="194">
+                    <StackPanel Orientation="Horizontal">
+                        <StackPanel Name="SongInfoStackPanel" Margin="12,0,0,0" Orientation="Vertical" VerticalAlignment="Center" Width="182">
+                            <TextBlock Name="SongTitle" Text="Song Title" FontSize="14" FontFamily="Segoe UI Variable" FontWeight="Medium" TextTrimming="CharacterEllipsis"/>
+                            <TextBlock Name="SongArtist" Text="Artist Name" FontSize="14" FontFamily="Segoe UI Variable" FontWeight="Medium" Opacity="0.5" TextTrimming="CharacterEllipsis"/>
+                        </StackPanel>
                     </StackPanel>
-                </StackPanel>
-                <StackPanel Name="ControlsStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" Height="35" Width="184" Margin="12,8,0,0">
-                    <!--<ui:Button Name="ControlBack" Icon="{ui:SymbolIcon Previous20, Filled=True}" Width="28" Height="28" Padding="0" CornerRadius="999" Margin="0,0,8,0" Click="Back_Click" Focusable="False"/>-->
-                    <controls:Button
-                    Height="28" Width="28" Name="ControlBack"
-                    Margin="2,0,8,0" Click="Back_Click" Focusable="False"
-                    Style="{StaticResource MicaWPF.Styles.TransparentButton}" VerticalAlignment="Center">
-                        <ui:SymbolIcon Name="SymbolBack" Symbol="Previous20" Filled="True"/>
-                    </controls:Button>
-                    <controls:Button
-                    Height="32" Width="32" Name="ControlPlayPause"
-                    Margin="0,0,8,0" Click="PlayPause_Click" Focusable="False"
-                    Style="{StaticResource MicaWPF.Styles.AccentedButton}" VerticalAlignment="Center">
-                        <ui:SymbolIcon Name="SymbolPlayPause" Symbol="Pause16" Filled="True"/>
-                    </controls:Button>
-                    <controls:Button
-                    Height="28" Width="28" Name="ControlForward"
-                    Margin="0,0,8,0" Click="Forward_Click" Focusable="False"
-                    Style="{StaticResource MicaWPF.Styles.TransparentButton}" VerticalAlignment="Center">
-                        <ui:SymbolIcon Name="SymbolForward" Symbol="Next20" Filled="True"/>
-                    </controls:Button>
-                    <controls:Button
-                        Height="28" Width="28" Name="ControlRepeat"
-                        Margin="0,0,8,0" Click="Repeat_Click" Focusable="False"
+                    <StackPanel Name="ControlsStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" Height="35" Width="184" Margin="12,8,0,0">
+                        <!--<ui:Button Name="ControlBack" Icon="{ui:SymbolIcon Previous20, Filled=True}" Width="28" Height="28" Padding="0" CornerRadius="999" Margin="0,0,8,0" Click="Back_Click" Focusable="False"/>-->
+                        <controls:Button
+                        Height="28" Width="28" Name="ControlBack"
+                        Margin="2,0,8,0" Click="Back_Click" Focusable="False"
                         Style="{StaticResource MicaWPF.Styles.TransparentButton}" VerticalAlignment="Center">
-                        <ui:SymbolIcon Name="SymbolRepeat" Symbol="ArrowRepeatAllOff24" Filled="false" Opacity="0.5" FontSize="18"/>
-                    </controls:Button>
-                    <controls:Button
-                        Height="28" Width="28" Name="ControlShuffle"
-                        Margin="0,0,8,0" Click="Shuffle_Click" Focusable="False"
+                            <ui:SymbolIcon Name="SymbolBack" Symbol="Previous20" Filled="True"/>
+                        </controls:Button>
+                        <controls:Button
+                        Height="32" Width="32" Name="ControlPlayPause"
+                        Margin="0,0,8,0" Click="PlayPause_Click" Focusable="False"
+                        Style="{StaticResource MicaWPF.Styles.AccentedButton}" VerticalAlignment="Center">
+                            <ui:SymbolIcon Name="SymbolPlayPause" Symbol="Pause16" Filled="True"/>
+                        </controls:Button>
+                        <controls:Button
+                        Height="28" Width="28" Name="ControlForward"
+                        Margin="0,0,8,0" Click="Forward_Click" Focusable="False"
                         Style="{StaticResource MicaWPF.Styles.TransparentButton}" VerticalAlignment="Center">
-                        <ui:SymbolIcon Name="SymbolShuffle" Symbol="ArrowShuffleOff24" Filled="false" Opacity="0.5" FontSize="18"/>
-                    </controls:Button>
-                    <StackPanel Name="MediaIdStackPanel" Orientation="Horizontal" Width="72">
-                        <ui:SymbolIcon Symbol="MusicNote120" Width="12" Height="12" FontSize="12" Filled="True" Opacity="0.25"/>
-                        <TextBlock Name="MediaId" VerticalAlignment="Center" FontSize="10" Margin="2,0,0,0" FontFamily="Segoe UI Variable" FontWeight="Medium" Opacity="0.35" TextTrimming="CharacterEllipsis"/>
+                            <ui:SymbolIcon Name="SymbolForward" Symbol="Next20" Filled="True"/>
+                        </controls:Button>
+                        <controls:Button
+                            Height="28" Width="28" Name="ControlRepeat"
+                            Margin="0,0,8,0" Click="Repeat_Click" Focusable="False"
+                            Style="{StaticResource MicaWPF.Styles.TransparentButton}" VerticalAlignment="Center">
+                            <ui:SymbolIcon Name="SymbolRepeat" Symbol="ArrowRepeatAllOff24" Filled="false" Opacity="0.5" FontSize="18"/>
+                        </controls:Button>
+                        <controls:Button
+                            Height="28" Width="28" Name="ControlShuffle"
+                            Margin="0,0,8,0" Click="Shuffle_Click" Focusable="False"
+                            Style="{StaticResource MicaWPF.Styles.TransparentButton}" VerticalAlignment="Center">
+                            <ui:SymbolIcon Name="SymbolShuffle" Symbol="ArrowShuffleOff24" Filled="false" Opacity="0.5" FontSize="18"/>
+                        </controls:Button>
+                        <StackPanel Name="MediaIdStackPanel" Orientation="Horizontal" Width="72">
+                            <ui:SymbolIcon Symbol="MusicNote120" Width="12" Height="12" FontSize="12" Filled="True" Opacity="0.25"/>
+                            <TextBlock Name="MediaId" VerticalAlignment="Center" FontSize="10" Margin="2,0,0,0" FontFamily="Segoe UI Variable" FontWeight="Medium" Opacity="0.35" TextTrimming="CharacterEllipsis"/>
+                        </StackPanel>
+    
                     </StackPanel>
-
-                    <!--<StackPanel Margin="8,0,0,0" Orientation="Vertical" VerticalAlignment="Center">
-                    <TextBlock Text="0:00" Foreground="Gray" FontSize="12" />
-                </StackPanel>
-                <Slider Name="SongProgress" Value="0" Maximum="100" Minimum="0" Width="126" Height="4" Margin="2,0,0,0"/>
-                <StackPanel Margin="2,0,0,0" Orientation="Vertical" VerticalAlignment="Center">
-                    <TextBlock Text="9:99" Foreground="Gray" FontSize="12" />
-                </StackPanel>-->
                 </StackPanel>
             </StackPanel>
-        </StackPanel>
+            <DockPanel Grid.Row="1" x:Name="SeekbarWrapper" HorizontalAlignment="Stretch" Margin="16,0,16,12" LastChildFill="True" VerticalAlignment="Center">
+                <TextBlock Name="SeekbarCurrentDuration" Text="-:--" Foreground="Gray" FontSize="12" DockPanel.Dock="Left" Width="45" Margin="0,0,2,0" TextAlignment="Left" VerticalAlignment="Center" Height="18"/>
+                <TextBlock Name="SeekbarMaxDuration" Text="-:--" Foreground="Gray" FontSize="12" DockPanel.Dock="Right" Width="45" Margin="2,0,0,0" TextAlignment="Right" VerticalAlignment="Center" Height="18"/>
+                <Slider Name="Seekbar" Value="0" Maximum="100" Minimum="0" HorizontalAlignment="Stretch" VerticalAlignment="Center" VerticalContentAlignment="Center" Height="18" PreviewMouseLeftButtonDown="Seekbar_OnPreviewMouseLeftButtonDown" PreviewMouseLeftButtonUp="Seekbar_OnPreviewMouseLeftButtonUp" ValueChanged="Seekbar_OnValueChanged"/>
+            </DockPanel>
+        </Grid>
 
         <tray:NotifyIcon
             LeftClick="nIcon_LeftClick" FocusOnLeftClick="False"

--- a/FluentFlyoutWPF/MainWindow.xaml
+++ b/FluentFlyoutWPF/MainWindow.xaml
@@ -34,9 +34,6 @@
     </Window.Triggers>
 
     <Grid>
-        <Grid.RenderTransform>
-            <ScaleTransform x:Name="ScaleTransform"/>
-        </Grid.RenderTransform>
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -598,7 +598,7 @@ public partial class MainWindow : MicaWindow
         if (SettingsManager.Current.SeekbarEnabled)
             SeekbarWrapper.Visibility = Visibility.Visible;
         else
-            SeekbarWrapper.Visibility = Visibility.Visible;
+            SeekbarWrapper.Visibility = Visibility.Collapsed;
 
         _layout = SettingsManager.Current.CompactLayout;
         _repeatEnabled = SettingsManager.Current.RepeatEnabled;

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
@@ -44,10 +45,16 @@ public partial class MainWindow : MicaWindow
     private bool _shuffleEnabled = SettingsManager.Current.ShuffleEnabled;
     private bool _playerInfoEnabled = SettingsManager.Current.PlayerInfoEnabled;
     private bool _centerTitleArtist = SettingsManager.Current.CenterTitleArtist;
-
+    private bool _seekBarEnabled = SettingsManager.Current.SeekbarEnabled;
+    
     static Mutex singleton = new Mutex(true, "FluentFlyout"); // to prevent multiple instances of the app
     private NextUpWindow? nextUpWindow = null; // to prevent multiple instances of NextUpWindow
     private string currentTitle = ""; // to prevent NextUpWindow from showing the same song
+    
+    private readonly int _seekbarUpdateInterval = 300;
+    private readonly Timer _positionTimer;
+    private bool _isActive;
+    private bool _isDragging;
 
     private LockWindow? lockWindow;
 
@@ -94,6 +101,13 @@ public partial class MainWindow : MicaWindow
 
         mediaManager.OnAnyMediaPropertyChanged += MediaManager_OnAnyMediaPropertyChanged;
         mediaManager.OnAnyPlaybackStateChanged += CurrentSession_OnPlaybackStateChanged;
+        mediaManager.OnAnyTimelinePropertyChanged += MediaManager_OnAnyTimelinePropertyChanged;
+        
+        _positionTimer = new Timer(SeekbarUpdateUi, null, Timeout.Infinite, Timeout.Infinite);
+        if (_seekBarEnabled && mediaManager.GetFocusedSession() is { } session)
+        {
+            UpdateSeekbarCurrentDuration(session.ControlSession.GetTimelineProperties().Position);
+        }
     }
 
     private void openSettings(object? sender, EventArgs e)
@@ -286,6 +300,7 @@ public partial class MainWindow : MicaWindow
     private void CurrentSession_OnPlaybackStateChanged(MediaSession mediaSession, GlobalSystemMediaTransportControlsSessionPlaybackInfo? playbackInfo = null)
     {
         UpdateUI(mediaManager.GetFocusedSession());
+        HandlePlayBackState(mediaManager.GetFocusedSession().ControlSession.GetPlaybackInfo().PlaybackStatus);
     }
 
     private void MediaManager_OnAnyMediaPropertyChanged(MediaSession mediaSession, GlobalSystemMediaTransportControlsSessionMediaProperties mediaProperties)
@@ -307,8 +322,17 @@ public partial class MainWindow : MicaWindow
                 });
             }
         }
-
         UpdateUI(mediaManager.GetFocusedSession());
+        HandlePlayBackState(mediaManager.GetFocusedSession().ControlSession.GetPlaybackInfo().PlaybackStatus);
+    }
+    
+    private void MediaManager_OnAnyTimelinePropertyChanged(MediaSession mediaSession, GlobalSystemMediaTransportControlsSessionTimelineProperties timelineProperties)
+    {
+        if (mediaManager.GetFocusedSession() is not { } session) return;
+        
+        if (_seekBarEnabled && !IsActive)
+            UpdateSeekbarCurrentDuration(session.ControlSession.GetTimelineProperties().Position);
+        HandlePlayBackState(session.ControlSession.GetPlaybackInfo().PlaybackStatus);
     }
 
     private static IntPtr SetHook(LowLevelKeyboardProc proc) // set the keyboard hook
@@ -364,6 +388,8 @@ public partial class MainWindow : MicaWindow
             FullscreenDetector.IsFullscreenApplicationRunning())
             return;
         UpdateUI(mediaManager.GetFocusedSession());
+        if (_seekBarEnabled)
+            HandlePlayBackState(mediaManager.GetFocusedSession().ControlSession.GetPlaybackInfo().PlaybackStatus);
 
         if (nextUpWindow != null) // close NextUpWindow if it's open
         {
@@ -379,7 +405,7 @@ public partial class MainWindow : MicaWindow
         cts = new CancellationTokenSource();
         var token = cts.Token;
         Visibility = Visibility.Visible;
-
+        
         try
         {
             while (!token.IsCancellationRequested)
@@ -393,6 +419,8 @@ public partial class MainWindow : MicaWindow
                         CloseAnimation(this);
                         await Task.Delay(getDuration());
                         Hide();
+                        if (_seekBarEnabled) 
+                            HandlePlayBackState(GlobalSystemMediaTransportControlsSessionPlaybackStatus.Paused);
                         break;
                     }
                 }
@@ -410,7 +438,8 @@ public partial class MainWindow : MicaWindow
             _shuffleEnabled != SettingsManager.Current.ShuffleEnabled ||
             _repeatEnabled != SettingsManager.Current.ShuffleEnabled ||
             _playerInfoEnabled != SettingsManager.Current.PlayerInfoEnabled ||
-            _centerTitleArtist != SettingsManager.Current.CenterTitleArtist)
+            _centerTitleArtist != SettingsManager.Current.CenterTitleArtist ||
+            _seekBarEnabled != SettingsManager.Current.SeekbarEnabled)
             UpdateUILayout();
 
         Dispatcher.Invoke(() =>
@@ -507,6 +536,12 @@ public partial class MainWindow : MicaWindow
                 SongImage.ImageSource = Helper.GetThumbnail(songInfo.Thumbnail);
                 if (SongImage.ImageSource == null) SongImagePlaceholder.Visibility = Visibility.Visible;
                 else SongImagePlaceholder.Visibility = Visibility.Collapsed;
+                if (_seekBarEnabled)
+                {
+                    var timeline = mediaSession.ControlSession.GetTimelineProperties();
+                    Seekbar.Maximum = timeline.MaxSeekTime.TotalSeconds;
+                    SeekbarMaxDuration.Text = timeline.MaxSeekTime.ToString(timeline.MaxSeekTime.Hours > 0 ? @"hh\:mm\:ss" : @"mm\:ss");
+                }
             }
         });
     }
@@ -518,9 +553,10 @@ public partial class MainWindow : MicaWindow
             int extraWidth = SettingsManager.Current.RepeatEnabled ? 36 : 0;
             extraWidth += SettingsManager.Current.ShuffleEnabled ? 36 : 0;
             extraWidth += SettingsManager.Current.PlayerInfoEnabled ? 72 : 0;
+            int extraHeight = SettingsManager.Current.SeekbarEnabled ? 36 : 0;
             if (SettingsManager.Current.CompactLayout) // compact layout
             {
-                Height = 60;
+                Height = 60 + extraHeight;
                 Width = 400;
                 BodyStackPanel.Orientation = Orientation.Horizontal;
                 BodyStackPanel.Width = 300;
@@ -534,7 +570,7 @@ public partial class MainWindow : MicaWindow
             }
             else // normal layout
             {
-                Height = 116;
+                Height = 116 + extraHeight;
                 Width = 310 - 72 + extraWidth;
                 BodyStackPanel.Orientation = Orientation.Vertical;
                 BodyStackPanel.Width = 194 - 72 + extraWidth;
@@ -558,12 +594,18 @@ public partial class MainWindow : MicaWindow
             SongTitle.HorizontalAlignment = HorizontalAlignment.Left;
             SongArtist.HorizontalAlignment = HorizontalAlignment.Left;
         }
+        
+        if (SettingsManager.Current.SeekbarEnabled)
+            SeekbarWrapper.Visibility = Visibility.Visible;
+        else
+            SeekbarWrapper.Visibility = Visibility.Visible;
 
         _layout = SettingsManager.Current.CompactLayout;
         _repeatEnabled = SettingsManager.Current.RepeatEnabled;
         _shuffleEnabled = SettingsManager.Current.ShuffleEnabled;
         _playerInfoEnabled = SettingsManager.Current.PlayerInfoEnabled;
         _centerTitleArtist = SettingsManager.Current.CenterTitleArtist;
+        _seekBarEnabled = SettingsManager.Current.SeekbarEnabled;
     }
 
     private async void Back_Click(object sender, RoutedEventArgs e)
@@ -639,6 +681,88 @@ public partial class MainWindow : MicaWindow
         {
             SymbolShuffle.Dispatcher.Invoke(() => SymbolShuffle.Symbol = Wpf.Ui.Controls.SymbolRegular.ArrowShuffle24);
             await mediaManager.GetFocusedSession().ControlSession.TryChangeShuffleActiveAsync(true);
+        }
+    }
+
+    private void Seekbar_OnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (_isDragging) return;
+        _isDragging = true;
+        
+        Slider slider = (Slider)sender;
+        System.Windows.Point clickPosition = e.GetPosition(slider);
+        double thumbWidth = slider.Template.FindName("Thumb", slider) is Thumb thumb ? thumb.ActualWidth : 0;
+        double ratio = (clickPosition.X - thumbWidth / 2) / (slider.ActualWidth - thumbWidth);
+        ratio = Math.Max(0, Math.Min(1, ratio));
+        double targetSeconds = ratio * slider.Maximum;
+        // Bug: if the position is 0, then it will cause the position to not change when changing playback position
+        if (targetSeconds == 0) targetSeconds = 1;
+        Dispatcher.Invoke(() =>
+        {
+            Seekbar.Value = TimeSpan.FromSeconds(targetSeconds).TotalSeconds;
+        });
+    }
+
+    private async void Seekbar_OnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (mediaManager.GetFocusedSession() is { } session)
+        {
+            var seekPosition = TimeSpan.FromSeconds(Seekbar.Value);
+            if (seekPosition == TimeSpan.Zero) seekPosition = TimeSpan.FromSeconds(1);
+            await session.ControlSession.TryChangePlaybackPositionAsync(seekPosition.Ticks);
+        }
+        _isDragging = false;
+    }
+
+    private void Seekbar_OnValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (!_isDragging) return;
+        var timespan = TimeSpan.FromSeconds(e.NewValue);
+        Dispatcher.Invoke(() =>
+        {
+            SeekbarCurrentDuration.Text = timespan.ToString(timespan.Hours > 0 ? @"hh\:mm\:ss" : @"mm\:ss");
+        });
+    }
+    
+    private void SeekbarUpdateUi(object? sender)
+    {
+        if (!_seekBarEnabled || Visibility != Visibility.Visible || _isDragging) return;
+        if (mediaManager.GetFocusedSession() is not { } session) return;
+        
+        var timeline = session.ControlSession.GetTimelineProperties();
+        var pos = timeline.Position + (DateTime.Now - timeline.LastUpdatedTime.DateTime);
+        if (pos > timeline.EndTime)
+        {
+            HandlePlayBackState(GlobalSystemMediaTransportControlsSessionPlaybackStatus.Closed);
+            return;
+        }
+
+        UpdateSeekbarCurrentDuration(pos);
+    }
+
+    private void UpdateSeekbarCurrentDuration(TimeSpan pos)
+    {
+        Dispatcher.Invoke(() =>
+        {
+            Seekbar.Value = pos.TotalSeconds;
+            SeekbarCurrentDuration.Text = pos.ToString(pos.Hours > 0 ? @"hh\:mm\:ss" : @"mm\:ss");
+        });
+    }
+
+    private void HandlePlayBackState(GlobalSystemMediaTransportControlsSessionPlaybackStatus? status)
+    {
+        if (status == null) return;
+        if (status == GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing)
+        {
+            if (_isActive) return;
+            _isActive = true;
+            _positionTimer.Change(0, _seekbarUpdateInterval);
+        }
+        else
+        {
+            if (!_isActive) return;
+            _isActive = false;
+            _positionTimer.Change(Timeout.Infinite, Timeout.Infinite);
         }
     }
 

--- a/FluentFlyoutWPF/SettingsWindow.xaml
+++ b/FluentFlyoutWPF/SettingsWindow.xaml
@@ -35,6 +35,7 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -100,7 +101,7 @@
                             </ui:CardControl.Header>
                             <controls:ToggleSwitch Name="CenterTitleArtistSwitch" Click="CenterTitleArtistSwitch_Click"/>
                         </ui:CardControl>
-                        <ui:CardControl Grid.Row="6" Icon="{ui:SymbolIcon Subtitles24}" Margin="0,0,0,12">
+                        <ui:CardControl Grid.Row="6" Icon="{ui:SymbolIcon Subtitles24}" Margin="0,0,0,3">
                             <ui:CardControl.Header>
                                 <StackPanel Orientation="Vertical">
                                     <TextBlock Text="Show Media Player name" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
@@ -108,7 +109,15 @@
                             </ui:CardControl.Header>
                             <controls:ToggleSwitch Name="PlayerInfoSwitch" Click="PlayerInfoSwitch_Click"/>
                         </ui:CardControl>
-                        <ui:CardControl Grid.Row="7" Icon="{ui:SymbolIcon ArrowRepeatAll24}" Margin="0,0,0,3">
+                        <ui:CardControl Grid.Row="7" Icon="{ui:SymbolIcon SlideArrowRight24}" Margin="0,0,0,12">
+                            <ui:CardControl.Header>
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="Show Seekbar" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </ui:CardControl.Header>
+                            <controls:ToggleSwitch Name="SeekbarSwitch" Click="SeekbarSwitch_Click"/>
+                        </ui:CardControl>
+                        <ui:CardControl Grid.Row="8" Icon="{ui:SymbolIcon ArrowRepeatAll24}" Margin="0,0,0,3">
                             <ui:CardControl.Header>
                                 <StackPanel Orientation="Vertical">
                                     <TextBlock Text="Repeat Button" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
@@ -117,7 +126,7 @@
                             </ui:CardControl.Header>
                             <controls:ToggleSwitch Name="RepeatSwitch" Click="RepeatSwitch_Click"/>
                         </ui:CardControl>
-                        <ui:CardControl Grid.Row="8" Icon="{ui:SymbolIcon ArrowShuffle24}" Margin="0,0,0,3">
+                        <ui:CardControl Grid.Row="9" Icon="{ui:SymbolIcon ArrowShuffle24}" Margin="0,0,0,3">
                             <ui:CardControl.Header>
                                 <StackPanel Orientation="Vertical">
                                     <TextBlock Text="Shuffle Button" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
@@ -126,7 +135,7 @@
                             </ui:CardControl.Header>
                             <controls:ToggleSwitch Name="ShuffleSwitch" Click="ShuffleSwitch_Click"/>
                         </ui:CardControl>
-                        <ui:InfoBar Grid.Row="9" Title="Some browsers/players do not support repeat and shuffle control." IsOpen="True" Severity="Warning" IsClosable="False"/>
+                        <ui:InfoBar Grid.Row="10" Title="Some browsers/players do not support repeat and shuffle control." IsOpen="True" Severity="Warning" IsClosable="False"/>
                     </Grid>
 
                     <TextBlock Text="Next Up Customization" FontSize="20" FontWeight="SemiBold" FontFamily="Segoe UI Variable" Margin="0,36,0,0"/>

--- a/FluentFlyoutWPF/SettingsWindow.xaml.cs
+++ b/FluentFlyoutWPF/SettingsWindow.xaml.cs
@@ -57,6 +57,7 @@ public partial class SettingsWindow : MicaWindow
         nIconSymbolSwitch.IsChecked = SettingsManager.Current.nIconSymbol;
         DisableIfFullscreenSwitch.IsChecked = SettingsManager.Current.DisableIfFullscreen;
         LockKeysBoldUISwitch.IsChecked = SettingsManager.Current.LockKeysBoldUI;
+        SeekbarSwitch.IsChecked = SettingsManager.Current.SeekbarEnabled;
 
         try // gets the version of the app, works only in release mode
         {
@@ -208,6 +209,11 @@ public partial class SettingsWindow : MicaWindow
     private void PlayerInfoSwitch_Click(object sender, RoutedEventArgs e)
     {
         SettingsManager.Current.PlayerInfoEnabled = PlayerInfoSwitch.IsChecked ?? false;
+    }
+    
+    private void SeekbarSwitch_Click(object sender, RoutedEventArgs e)
+    {
+        SettingsManager.Current.SeekbarEnabled = SeekbarSwitch.IsChecked ?? false;
     }
 
     private void nIconLeftClickComboBox_SelectionChanged(object sender,


### PR DESCRIPTION
Added seekbar, current duration and max duration, toggle seekbar button in settings.
* Added `SeekBarEnabled` in `UserSettings.cs` with a default of `True`.
* Updated `Settings.xaml` to include a toggle for enabling/disabling the seekbar.
* Updated `Settings.xaml.cs` to handle seek bar toggle button in `Settings.xaml`.
* Changed `MainWindow.xaml` to create space below the thumbnail and media buttons for seekbar.
* Changed `MainWindows.xaml.cs`
	* Added timer to update slider every 300 milliseconds because `MediaManager_OnAnyTimelinePropertyChanged` only invoked every ~5 seconds when the media application is not focused (maybe I missed something?).
	* Stops timer from running when Main Window isn't active to stop unnecessary updates.

![seekbar_preview](https://github.com/user-attachments/assets/4cd2252c-f947-4962-94fe-58de32a9abf4)

 
Should close #17 if everything looks good.