### PR TITLE
Add Insert key popup toggle and update insert flyout behavior

### DIFF
--- a/FluentFlyoutWPF/Classes/Settings/UserSettings.cs
+++ b/FluentFlyoutWPF/Classes/Settings/UserSettings.cs
@@ -22,8 +22,9 @@ public class UserSettings
     public bool nIconSymbol { get; set; }
     public bool DisableIfFullscreen { get; set; }
     public bool LockKeysBoldUI { get; set; }
-    public string LastKnownVersion { get; set; }
+    public string LastKnownVersion { get; set; } // for determining if user had updated to a new version
     public bool SeekbarEnabled { get; set; }
+    public bool LockKeysInsertEnabled { get; set; } // whether pressing insert key should display the LockKeys flyout
 
 
     public UserSettings()
@@ -50,5 +51,6 @@ public class UserSettings
         LockKeysBoldUI = true;
         LastKnownVersion = "";
         SeekbarEnabled = false;
+        LockKeysInsertEnabled = true;
     }
 }

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -383,7 +383,7 @@ public partial class MainWindow : MicaWindow
                     lockWindow ??= new LockWindow();
                     lockWindow.ShowLockFlyout("Scroll Lock", Keyboard.IsKeyToggled(Key.Scroll));
                 }
-                else if (vkCode == 0x2D) // Insert
+                else if (vkCode == 0x2D && SettingsManager.Current.LockKeysInsertEnabled) // Insert
                 {
                     lockWindow ??= new LockWindow();
                     lockWindow.ShowLockFlyout("Insert", Keyboard.IsKeyToggled(Key.Insert));

--- a/FluentFlyoutWPF/SettingsWindow.xaml
+++ b/FluentFlyoutWPF/SettingsWindow.xaml
@@ -183,6 +183,7 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
                             <ui:Image Source="/Resources/FluentFlyoutDemo5.1.png" Width="128"/>
@@ -221,6 +222,15 @@
                                 </StackPanel>
                             </ui:CardControl.Header>
                             <controls:ToggleSwitch Name="LockKeysBoldUISwitch" Click="LockKeysBoldUISwitch_Click"/>
+                        </ui:CardControl>
+                        <ui:CardControl Grid.Row="4" Icon="{ui:SymbolIcon Info24}" Margin="0,0,0,3">
+                            <ui:CardControl.Header>
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="Enable Insert Key Popup" FontSize="14" FontWeight="Regular" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Determines whether pressing insert/overwrite will show the flyout" FontSize="12" Opacity="0.5"/>
+                                </StackPanel>
+                            </ui:CardControl.Header>
+                            <controls:ToggleSwitch Name="LockKeysEnableInsertSwitch" Click="LockKeysEnableInsertSwitch_Click"/>
                         </ui:CardControl>
                     </Grid>
 
@@ -349,7 +359,7 @@
                             <TextBlock Text="or leave a review on Microsoft Store!" HorizontalAlignment="Center" FontSize="12" Opacity="0.5" VerticalAlignment="Center" Margin="4,0,0,0"/>
                         </StackPanel>
                         <ui:Anchor Content="GitHub Repository" Icon="{ui:SymbolIcon Link24}" NavigateUri="https://github.com/unchihugo/FluentFlyout" Margin="12,0,0,0"/>
-                        <controls:Button Name="SaveButton" Style="{StaticResource MicaWPF.Styles.AccentedButton}" Content="Save &#38; Close" Padding="12,0,12,0" Height="32" Click="SaveButton_Click" Margin="8,24,24,24" HorizontalAlignment="Left" FontWeight="SemiBold"/>
+                        <controls:Button Name="SaveButton" Style="{StaticResource MicaWPF.Styles.AccentedButton}" Content="Close" Padding="12,0,12,0" Height="32" Click="SaveButton_Click" Margin="8,24,24,24" HorizontalAlignment="Left" FontWeight="SemiBold"/>
                     </StackPanel>
                 </DockPanel>
             </StackPanel>

--- a/FluentFlyoutWPF/SettingsWindow.xaml.cs
+++ b/FluentFlyoutWPF/SettingsWindow.xaml.cs
@@ -341,4 +341,9 @@ public partial class SettingsWindow : MicaWindow
     {
         SettingsManager.Current.LockKeysBoldUI = LockKeysBoldUISwitch.IsChecked ?? false;
     }
+
+    private void LockKeysEnableInsertSwitch_Click(object sender, RoutedEventArgs e)
+    {
+        SettingsManager.Current.LockKeysInsertEnabled = LockKeysEnableInsertSwitch.IsChecked ?? false;
+    }
 }

--- a/FluentFlyoutWPF/Windows/LockWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/LockWindow.xaml.cs
@@ -41,8 +41,10 @@ public partial class LockWindow : MicaWindow
             if (key == "Insert")
             {
                 // not sure how to properly check if overwrite or insert as every program has different behavior
-                if (isOn) LockTextBlock.Text = "Insert mode";
-                else LockTextBlock.Text = "Overwrite mode";
+                //if (isOn) LockTextBlock.Text = "Insert mode";
+                //else LockTextBlock.Text = "Overwrite mode";
+                LockTextBlock.Text = "Insert pressed";
+                isOn = true;
             }
             else LockTextBlock.Text = key + " is " + (isOn ? "on" : "off");
 


### PR DESCRIPTION
**New feature: Insert key popup control**

* Added a `LockKeysInsertEnabled` property to the `UserSettings` class, allowing users to enable or disable the Insert key popup.
* Updated the settings UI (`SettingsWindow.xaml`) to include a toggle switch for the new Insert key popup option, with explanatory text.
* Implemented the toggle switch logic in `SettingsWindow.xaml.cs` to update the setting when clicked.
* Modified the Insert key handler in `MainWindow.xaml.cs` to only show the flyout if `LockKeysInsertEnabled` is true.

**UI and text adjustments**

* Changed the Insert key flyout message in `LockWindow.xaml.cs` to always say "Insert pressed" instead of attempting to distinguish insert/overwrite mode.
* Updated the Save button text in the settings window to "Close" for clarity.

Closes #71 and #91 