### PR TITLE
Fix Media Player ID

### DIFF
--- a/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
+++ b/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
@@ -28,11 +28,7 @@ public static class MediaPlayerData
 
         string mediaTitle = mediaPlayerId;
         ImageSource? mediaIcon = null;
-
-        if (mediaPlayerId.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
-        {
-            mediaPlayerId = Path.GetFileNameWithoutExtension(mediaPlayerId);
-        }
+        
         // get sanitized media title name
         string[] mediaSessionIdVariants = mediaPlayerId.Split('.');
 
@@ -40,6 +36,7 @@ public static class MediaPlayerData
         var variants = mediaSessionIdVariants.Select(variant =>
             variant.Replace("com", "", StringComparison.OrdinalIgnoreCase)
                    .Replace("github", "", StringComparison.OrdinalIgnoreCase)
+                   .Replace("exe", "", StringComparison.OrdinalIgnoreCase)
                    .Trim()
         ).Where(variant => !string.IsNullOrWhiteSpace(variant)).ToList();
 


### PR DESCRIPTION
### Previous behavior

Process lookups could incorrectly match unrelated executables.

Example: `Spotify.exe` was mistakenly resolved to `explorer.exe`.

### Root cause:

mediaPlayerId was split on `.`, producing `.` as a variant keyword.

Since `exe` appears in many process paths, this caused false positives.

### Resolution

`.exe` extensions are removed from mediaPlayerId before generating match variants.

Only meaningful substrings (e.g., `Spotify`) are used for process matching.

This prevents false matches with generic executables like `explorer.exe`.

Ensures `Spotify.exe` correctly resolves to the `Spotify` process.

### Issues

- https://github.com/unchihugo/FluentFlyout/issues/143