### PR TITLE
Add GitHub Release build configuration and prepare for v2.3

### DIFF
--- a/FluentFlyout.sln
+++ b/FluentFlyout.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.11.35327.3
+# Visual Studio Version 18
+VisualStudioVersion = 18.3.11222.16 d18.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentFlyout", "FluentFlyoutWPF\FluentFlyout.csproj", "{A3576152-7AF6-4136-992A-1B3C1091652A}"
 EndProject
@@ -14,6 +14,11 @@ Global
 		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		GitHub Release|Any CPU = GitHub Release|Any CPU
+		GitHub Release|ARM = GitHub Release|ARM
+		GitHub Release|ARM64 = GitHub Release|ARM64
+		GitHub Release|x64 = GitHub Release|x64
+		GitHub Release|x86 = GitHub Release|x86
 		Release|Any CPU = Release|Any CPU
 		Release|ARM = Release|ARM
 		Release|ARM64 = Release|ARM64
@@ -31,6 +36,16 @@ Global
 		{A3576152-7AF6-4136-992A-1B3C1091652A}.Debug|x64.Build.0 = Debug|x64
 		{A3576152-7AF6-4136-992A-1B3C1091652A}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{A3576152-7AF6-4136-992A-1B3C1091652A}.Debug|x86.Build.0 = Debug|Any CPU
+		{A3576152-7AF6-4136-992A-1B3C1091652A}.GitHub Release|Any CPU.ActiveCfg = GitHub Release|x64
+		{A3576152-7AF6-4136-992A-1B3C1091652A}.GitHub Release|Any CPU.Build.0 = GitHub Release|x64
+		{A3576152-7AF6-4136-992A-1B3C1091652A}.GitHub Release|ARM.ActiveCfg = GitHub Release|x64
+		{A3576152-7AF6-4136-992A-1B3C1091652A}.GitHub Release|ARM.Build.0 = GitHub Release|x64
+		{A3576152-7AF6-4136-992A-1B3C1091652A}.GitHub Release|ARM64.ActiveCfg = GitHub Release|x64
+		{A3576152-7AF6-4136-992A-1B3C1091652A}.GitHub Release|ARM64.Build.0 = GitHub Release|x64
+		{A3576152-7AF6-4136-992A-1B3C1091652A}.GitHub Release|x64.ActiveCfg = GitHub Release|x64
+		{A3576152-7AF6-4136-992A-1B3C1091652A}.GitHub Release|x64.Build.0 = GitHub Release|x64
+		{A3576152-7AF6-4136-992A-1B3C1091652A}.GitHub Release|x86.ActiveCfg = GitHub Release|x64
+		{A3576152-7AF6-4136-992A-1B3C1091652A}.GitHub Release|x86.Build.0 = GitHub Release|x64
 		{A3576152-7AF6-4136-992A-1B3C1091652A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3576152-7AF6-4136-992A-1B3C1091652A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A3576152-7AF6-4136-992A-1B3C1091652A}.Release|ARM.ActiveCfg = Release|Any CPU
@@ -56,6 +71,21 @@ Global
 		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.Debug|x86.ActiveCfg = Debug|x86
 		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.Debug|x86.Build.0 = Debug|x86
 		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.Debug|x86.Deploy.0 = Debug|x86
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|Any CPU.ActiveCfg = GitHub Release|Any CPU
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|Any CPU.Build.0 = GitHub Release|Any CPU
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|Any CPU.Deploy.0 = GitHub Release|Any CPU
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|ARM.ActiveCfg = GitHub Release|ARM
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|ARM.Build.0 = GitHub Release|ARM
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|ARM.Deploy.0 = GitHub Release|ARM
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|ARM64.ActiveCfg = GitHub Release|ARM64
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|ARM64.Build.0 = GitHub Release|ARM64
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|ARM64.Deploy.0 = GitHub Release|ARM64
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|x64.ActiveCfg = GitHub Release|x64
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|x64.Build.0 = GitHub Release|x64
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|x64.Deploy.0 = GitHub Release|x64
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|x86.ActiveCfg = GitHub Release|x86
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|x86.Build.0 = GitHub Release|x86
+		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.GitHub Release|x86.Deploy.0 = GitHub Release|x86
 		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7C7CB0B2-26B9-4B8B-B5E8-30ABF5E2B331}.Release|Any CPU.Deploy.0 = Release|Any CPU

--- a/FluentFlyoutMSIX/FluentFlyoutMSIX.wapproj
+++ b/FluentFlyoutMSIX/FluentFlyoutMSIX.wapproj
@@ -8,6 +8,26 @@
       <Configuration>Debug</Configuration>
       <Platform>x86</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="GitHub Release|AnyCPU">
+      <Configuration>GitHub Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="GitHub Release|ARM">
+      <Configuration>GitHub Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="GitHub Release|ARM64">
+      <Configuration>GitHub Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="GitHub Release|x64">
+      <Configuration>GitHub Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="GitHub Release|x86">
+      <Configuration>GitHub Release</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x86">
       <Configuration>Release</Configuration>
       <Platform>x86</Platform>
@@ -54,8 +74,8 @@
     <TargetPlatformVersion>10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
-	<AppxBundleAutoResourcePackageQualifiers>DXFeatureLevel</AppxBundleAutoResourcePackageQualifiers>
-	<AppxDefaultResourceQualifiers>Language=EN-US;EL;ES;HE;KO;NL;PT-BR;RU;TR;VI;ZH-CN</AppxDefaultResourceQualifiers>
+    <AppxBundleAutoResourcePackageQualifiers>DXFeatureLevel</AppxBundleAutoResourcePackageQualifiers>
+    <AppxDefaultResourceQualifiers>Language=EN-US;EL;ES;HE;KO;NL;PT-BR;RU;TR;VI;ZH-CN</AppxDefaultResourceQualifiers>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
     <NoWarn>$(NoWarn);NU1702</NoWarn>
     <EntryPointProjectUniqueName>..\FluentFlyoutWPF\FluentFlyout.csproj</EntryPointProjectUniqueName>
@@ -70,34 +90,49 @@
     <PackageCertificateThumbprint>3532AC4C797E73A7A7442147A806ED8035BCC681</PackageCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
-    <AppxBundle>Always</AppxBundle>
+    <AppxBundle>Never</AppxBundle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='GitHub Release|ARM'">
+    <AppxBundle>Never</AppxBundle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AppxBundle>Always</AppxBundle>
+    <AppxBundle>Never</AppxBundle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
-    <AppxBundle>Always</AppxBundle>
+    <AppxBundle>Never</AppxBundle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='GitHub Release|x86'">
+    <AppxBundle>Never</AppxBundle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <AppxBundle>Always</AppxBundle>
+    <AppxBundle>Never</AppxBundle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <AppxBundle>Always</AppxBundle>
+    <AppxBundle>Never</AppxBundle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='GitHub Release|x64'">
+    <AppxBundle>Never</AppxBundle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <AppxBundle>Always</AppxBundle>
+    <AppxBundle>Never</AppxBundle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='GitHub Release|AnyCPU'">
+    <AppxBundle>Never</AppxBundle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <AppxBundle>Always</AppxBundle>
+    <AppxBundle>Never</AppxBundle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='GitHub Release|ARM64'">
+    <AppxBundle>Never</AppxBundle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <AppxBundle>Always</AppxBundle>
+    <AppxBundle>Never</AppxBundle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
-    <AppxBundle>Always</AppxBundle>
+    <AppxBundle>Never</AppxBundle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <AppxBundle>Always</AppxBundle>
+    <AppxBundle>Never</AppxBundle>
   </PropertyGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">

--- a/FluentFlyoutMSIX/Package.appxmanifest
+++ b/FluentFlyoutMSIX/Package.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="unchihugo.FluentFlyout"
     Publisher="CN=49793F74-1457-4B66-A672-4ED3A640FC76"
-    Version="2.1.0.0" />
+    Version="2.3.0.0" />
 
   <Properties>
     <DisplayName>FluentFlyout</DisplayName>

--- a/FluentFlyoutWPF/Classes/LicenseManager.cs
+++ b/FluentFlyoutWPF/Classes/LicenseManager.cs
@@ -69,6 +69,12 @@ public class LicenseManager
             
         try
         {
+#if GITHUB_RELEASE
+            _isStoreVersion = false;
+            _isPremiumUnlocked = true;
+            _isInitialized = true;
+            return;
+#endif
             // Get Store context
             _storeContext = StoreContext.GetDefault();
             

--- a/FluentFlyoutWPF/FluentFlyout.csproj
+++ b/FluentFlyoutWPF/FluentFlyout.csproj
@@ -13,6 +13,10 @@
     <Platforms>x64</Platforms>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <LangVersion>preview</LangVersion>
+    <Configurations>Debug;Release;GitHub Release</Configurations>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'GitHub Release'">
+    <DefineConstants>GITHUB_RELEASE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Content Remove="C:\Users\hu8go\.nuget\packages\dubya.windowsmediacontroller\2.5.5\contentFiles\any\net6.0-windows10.0.22000\Icon.ico" />


### PR DESCRIPTION
Introduced a new `GitHub Release` build configuration to support non-Microsoft Store distribution. Updated `FluentFlyout.sln` and project files to include `GitHub Release` for all platforms (`Any CPU`, `ARM`, `ARM64`, `x64`, `x86`).

Modified `LicenseManager.cs` to bypass Microsoft Store license checks when `GITHUB_RELEASE` is defined. Updated `FluentFlyoutMSIX.wapproj` to disable app bundle generation for all configurations.

Incremented app version to `2.3.0.0` in `Package.appxmanifest`. Added support for Visual Studio Version 18.