### PR TITLE
Implement media flyout debounce

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -38,7 +38,7 @@ public partial class MainWindow : MicaWindow
     private LowLevelKeyboardProc _hookProc;
 
     private CancellationTokenSource cts; // to close the flyout after a certain time
-    private DateTime _flyoutDebounceTime = DateTime.MinValue;
+    private long _lastFlyoutTime = 0;
 
     private static readonly WindowsMediaController.MediaManager mediaManager = new();
 
@@ -520,12 +520,16 @@ public partial class MainWindow : MicaWindow
             if (vkCode == 0xB3 || vkCode == 0xB0 || vkCode == 0xB1 || vkCode == 0xB2 // Play/Pause, next, previous, stop
                 || vkCode == 0xAD || vkCode == 0xAE || vkCode == 0xAF) // Mute, Volume Down, Volume Up
             {
-                // debouce to prevent hangs with rapid key presses
-                if ((DateTime.Now - _flyoutDebounceTime).TotalMilliseconds < 500)
+                long currentTime = Environment.TickCount64;
+
+                // debounce to prevent hangs with rapid key presses
+                if ((currentTime - _lastFlyoutTime) < 500) // 500ms debounce time
                 { 
                     return CallNextHookEx(_hookId, nCode, wParam, lParam);
                 }
-                _flyoutDebounceTime = DateTime.Now;
+
+                _lastFlyoutTime = currentTime;
+
                 ShowMediaFlyout();
             }
 


### PR DESCRIPTION
Introduces a debounce mechanism to the media flyout feature in `MainWindow.xaml.cs` aiming to prevent hangs caused by rapid key presses of media or volume keys.