### PR TITLE
Consider the size of "Up next" when initializing `NextUpWindow`.

### DIFF
--- a/FluentFlyoutWPF/Windows/NextUpWindow.xaml
+++ b/FluentFlyoutWPF/Windows/NextUpWindow.xaml
@@ -43,7 +43,7 @@
         </Grid.ColumnDefinitions>
         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
             <ui:SymbolIcon Symbol="MusicNote120" Filled="True" Width="14" Height="14" FontSize="14" VerticalAlignment="Center" Margin="0,0,2,0"/>
-            <TextBlock Text="{DynamicResource NextUpWindow_UpNextText}" FontSize="12" VerticalAlignment="Center" FontFamily="Segoe UI Variable" FontWeight="Medium"/>
+            <TextBlock x:Name="UpNextTextBlock" Text="{DynamicResource NextUpWindow_UpNextText}" FontSize="12" VerticalAlignment="Center" FontFamily="Segoe UI Variable" FontWeight="Medium"/>
         </StackPanel>
         <Border Grid.Column="1" Name="SongImageBorder" CornerRadius="6" Margin="12,1,0,0" ClipToBounds="True" Width="38" Height="38">
             <ui:SymbolIcon Name="SongImagePlaceholder" Symbol="MusicNote220" FontSize="40" Filled="True" Foreground="{DynamicResource MicaWPF.Brushes.SystemAccentColorLight2}" Visibility="Collapsed" />

--- a/FluentFlyoutWPF/Windows/NextUpWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/NextUpWindow.xaml.cs
@@ -35,11 +35,12 @@ public partial class NextUpWindow : MicaWindow
             WindowBlurHelper.DisableBlur(this);
         }
 
+        var upNextWidth = StringWidth.GetStringWidth(UpNextTextBlock.Text);
         var titleWidth = StringWidth.GetStringWidth(title);
         var artistWidth = StringWidth.GetStringWidth(artist);
-        
-        if (titleWidth > artistWidth) Width = titleWidth + 142;
-        else Width = artistWidth + 142;
+
+        if (titleWidth > artistWidth) Width = titleWidth + 76 + upNextWidth;
+        else Width = artistWidth + 76 + upNextWidth;
         if (Width > 400) Width = 400; // max width to prevent window from being too wide
         SongTitle.Text = title;
         SongArtist.Text = artist;


### PR DESCRIPTION
In the current version, `NextUpWindow` only takes into account the size of the `Artist` and the `Title`, but the text `Up next` is not taken into account. At the same time, `Up next` can change its width depending on the localization.

#### Old (with Russian):

https://github.com/user-attachments/assets/a82d243b-306d-4dc4-92e3-4a4f5039daaa

<img width="250" height="148" alt="image" src="https://github.com/user-attachments/assets/20b730a1-2e94-44cd-9c0f-6f0cd6c9c837" />

#### New:

https://github.com/user-attachments/assets/cf8f1ddc-a1ed-4f73-837e-8b7b3c83aeaa

<img width="253" height="142" alt="image" src="https://github.com/user-attachments/assets/1305cdc0-7fa4-41a4-8cc2-c141b5762ba5" />
