### PR TITLE
Fixed thumbnail loading if they are loaded later.

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -28,7 +28,7 @@ namespace FluentFlyoutWPF;
 public partial class MainWindow : MicaWindow
 {
     private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
-    
+
     [DllImport("user32.dll")]
     public static extern void keybd_event(byte virtualKey, byte scanCode, uint flags, IntPtr extraInfo);
 
@@ -420,6 +420,7 @@ public partial class MainWindow : MicaWindow
 
     // for determining whether MediaPropertyChanged has no changes
     private string previousMediaProperty = "";
+    private string previousMediaPropertyThumbnail = "";
     private void MediaManager_OnAnyMediaPropertyChanged(MediaSession mediaSession, GlobalSystemMediaTransportControlsSessionMediaProperties mediaProperties)
     {
 #if DEBUG
@@ -434,11 +435,18 @@ public partial class MainWindow : MicaWindow
         var songInfo = mediaSession.ControlSession.TryGetMediaPropertiesAsync().GetAwaiter().GetResult();
         var playbackInfo = mediaSession.ControlSession.GetPlaybackInfo();
 
-        string check = songInfo.Title + songInfo.Artist + playbackInfo.PlaybackStatus + songInfo.Thumbnail;
+        string check = songInfo.Title + songInfo.Artist + playbackInfo.PlaybackStatus;
+        string checkThumbnail = songInfo.Thumbnail?.GetHashCode().ToString() ?? "Null";
+        bool onlyThumbnailChanged = false;
         if (previousMediaProperty == check)
+        {
+            onlyThumbnailChanged = true;
+            if (previousMediaPropertyThumbnail == checkThumbnail)
             return; // prevent multiple calls for the same song info
+        }
 
         previousMediaProperty = check;
+        previousMediaPropertyThumbnail = checkThumbnail;
 
         taskbarWindow?.UpdateUi(songInfo.Title, songInfo.Artist, Helper.GetThumbnail(songInfo.Thumbnail), playbackInfo.PlaybackStatus, playbackInfo.Controls);
 
@@ -446,7 +454,7 @@ public partial class MainWindow : MicaWindow
 
         if (SettingsManager.Current.NextUpEnabled && !FullscreenDetector.IsFullscreenApplicationRunning()) // show NextUpWindow if enabled in settings
         {
-            if (nextUpWindow == null && IsVisible == false && songInfo.Thumbnail != null && currentTitle != songInfo.Title)
+            void createNewNextUpWindow()
             {
                 Dispatcher.Invoke(() =>
                 {
@@ -456,6 +464,26 @@ public partial class MainWindow : MicaWindow
                         currentTitle = songInfo.Title;
                         nextUpWindow.Closed += (s, e) => nextUpWindow = null; // set nextUpWindow to null when closed
                     }
+                });
+            }
+
+            if (nextUpWindow == null && IsVisible == false && songInfo.Thumbnail != null && currentTitle != songInfo.Title)
+            {
+                createNewNextUpWindow();
+            }
+            else if (nextUpWindow != null && !onlyThumbnailChanged)
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    nextUpWindow?.Close(); // must be cleared by the Closed event
+                });
+                createNewNextUpWindow();
+            }
+            else if (nextUpWindow != null && songInfo.Thumbnail != null)
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    nextUpWindow?.UpdateThumbnail(Helper.GetThumbnail(songInfo.Thumbnail));
                 });
             }
         }
@@ -529,7 +557,7 @@ public partial class MainWindow : MicaWindow
 
                 // debounce to prevent hangs with rapid key presses
                 if ((currentTime - _lastFlyoutTime) < 500) // 500ms debounce time
-                { 
+                {
                     return CallNextHookEx(_hookId, nCode, wParam, lParam);
                 }
 
@@ -738,7 +766,7 @@ public partial class MainWindow : MicaWindow
                 BackgroundImageStyle3.Visibility = SettingsManager.Current.MediaFlyoutBackgroundBlur == 3 ? Visibility.Visible : Visibility.Collapsed;
 
                 // acrylic effect setting
-                if (SettingsManager.Current.MediaFlyoutAcrylicWindowEnabled != _acrylicEnabled 
+                if (SettingsManager.Current.MediaFlyoutAcrylicWindowEnabled != _acrylicEnabled
                 || SettingsManager.Current.AppTheme != _themeOption) // if theme changes, reapply acrylic for updated background color
                 {
                     _acrylicEnabled = SettingsManager.Current.MediaFlyoutAcrylicWindowEnabled;

--- a/FluentFlyoutWPF/Windows/NextUpWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/NextUpWindow.xaml.cs
@@ -43,9 +43,7 @@ public partial class NextUpWindow : MicaWindow
         if (Width > 400) Width = 400; // max width to prevent window from being too wide
         SongTitle.Text = title;
         SongArtist.Text = artist;
-        SongImage.ImageSource = thumbnail;
-        if (SongImage.ImageSource == null) SongImagePlaceholder.Visibility = Visibility.Visible;
-        else SongImagePlaceholder.Visibility = Visibility.Collapsed;
+        UpdateThumbnail(thumbnail);
         Show();
 
         mainWindow.OpenAnimation(this);
@@ -59,5 +57,12 @@ public partial class NextUpWindow : MicaWindow
         }
 
         wait();
+    }
+
+    public void UpdateThumbnail(BitmapImage thumbnail)
+    {
+        SongImage.ImageSource = thumbnail;
+        if (SongImage.ImageSource == null) SongImagePlaceholder.Visibility = Visibility.Visible;
+        else SongImagePlaceholder.Visibility = Visibility.Collapsed;
     }
 }


### PR DESCRIPTION
closes #182

If the player (in my case, the `Yandex Music` or `Youtube Music` web applications) did not cache the thumbnail image, then the standard browser icon is displayed instead. In fact, Chromium repeats the `OnAnyMediaPropertyChanged` event call several times (1-4 for me), but only the thumbnail changes in it, so due to current checks, the update does not occur.

I've added a few additional conditions to update the interface if the icon has been changed. This will cause extra window updates to happen, but it usually happened from 1 to 4 times for me and this should not significantly harm performance.

With this patch, `NextUpWindow` will be instantly replaced with the new one if the previous one has not closed yet, but the `Title` has already changed.

Also, all windows will update the interface if the thumbnail is updated while these windows are being displayed.

#### Old:

https://github.com/user-attachments/assets/82f25d5f-2071-4224-b433-854f1500d10f

#### New:

https://github.com/user-attachments/assets/8f4d3141-d41d-4e67-a3f8-18bfeaed0435

<sub>(here, the icon failed to load once, but this was most likely due to high load on the UI thread caused by recording or it only breaks like that when switching to the previous track. )</sub>

In fact, the old behavior didn't work so badly, but it very often displayed the standard icon (usually if the track has not been played yet). The same behavior can be achieved if you open the console on the player's page (<kbd>F12</kbd> or <kbd>Shift + Ctrl + I</kbd>) and turn off the cache.

<img width="571" height="93" alt="browser_pbVoU6WFxP" src="https://github.com/user-attachments/assets/e23d9aa0-b7cb-4ade-9a70-c0a1f9f971eb" />

