### PR TITLE
Variable Lock Flyout size for non English languages

### DIFF
--- a/FluentFlyoutWPF/Classes/LocalizationManager.cs
+++ b/FluentFlyoutWPF/Classes/LocalizationManager.cs
@@ -39,7 +39,7 @@ public static class LocalizationManager
     }
 
     public static LocalizationState Instance { get; } = new();
-    public static double maxLenght = 0;
+    public static double maxLength = 0;
 
     // current language code (first two letters) for easy access
     public static string LanguageCode { get; set; } = string.Empty;
@@ -152,7 +152,7 @@ public static class LocalizationManager
         Lengths.Add(StringWidth.GetStringWidth(OnOffMax + Application.Current.Resources["LockWindow_NumLock"].ToString()));
         Lengths.Add(StringWidth.GetStringWidth(OnOffMax + Application.Current.Resources["LockWindow_ScrollLock"].ToString()));
 
-        maxLenght = Lengths.Max();
+        maxLength = Lengths.Max();
     }
 
     private static void ApplyFlowDirection(string languageCode)

--- a/FluentFlyoutWPF/Windows/LockWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/LockWindow.xaml.cs
@@ -78,7 +78,7 @@ public partial class LockWindow : MicaWindow
         // lengthen the window width to fit longer translated texts
         if (LocalizationManager.LanguageCode != "en")
         {
-            Width = LocalizationManager.maxLenght + 45.0; //Max length of the text + extra space for the icon and padding
+            Width = LocalizationManager.maxLength + 45.0; //Max length of the text + extra space for the icon and padding
         }
         else
         {


### PR DESCRIPTION
This PR is related to the issue https://github.com/unchihugo/FluentFlyout/issues/175, which was fixed in  https://github.com/unchihugo/FluentFlyout/pull/188.

The fix that was made gave too much padding to the Spanish language and didn't account for other languages, the French text for example is even longer than the Spanish text and it's still wrong.

<img width="319" height="102" alt="imagen" src="https://github.com/user-attachments/assets/193e68a0-7767-4d16-bd92-5d899937bfad" />


I have added a new size variable to the Localization manager that is recalculated each time a non English language is set to automatically change the width of the flyout. Which means there won't be any changes needed even if new languages are added.

<img width="457" height="94" alt="imagen" src="https://github.com/user-attachments/assets/6828ea43-c361-49c4-b087-41944ca2e1f0" />