### PR TITLE
Attempt to fix and recover after taskbar widget crash and update manifest version

### DIFF
--- a/FluentFlyoutMSIX/Package.appxmanifest
+++ b/FluentFlyoutMSIX/Package.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="unchihugo.FluentFlyout"
     Publisher="CN=49793F74-1457-4B66-A672-4ED3A640FC76"
-    Version="2.3.6.0" />
+    Version="2.4.0.0" />
 
   <Properties>
     <DisplayName>FluentFlyout</DisplayName>

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1204,6 +1204,34 @@ public partial class MainWindow : MicaWindow
         UpdateTaskbar();
     }
 
+    public void RecreateTaskbarWindow()
+    {
+        try
+        {
+            Logger.Info("Recreating Taskbar Widget window");
+
+            if (taskbarWindow != null)
+            {
+                try
+                {
+                    taskbarWindow.Close();
+                }
+                catch { }
+
+                taskbarWindow = null;
+            }
+
+            taskbarWindow = new();
+            UpdateTaskbar();
+
+            Logger.Info("Taskbar Widget window recreated successfully");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to recreate Taskbar Widget window");
+        }
+    }
+
     private void nIcon_LeftClick(Wpf.Ui.Tray.Controls.NotifyIcon sender, RoutedEventArgs e) // change the behavior of the tray icon
     {
         if (SettingsManager.Current.NIconLeftClick == 0)


### PR DESCRIPTION
Attempt to fix taskbar widget crashing in edge-cases where the taskbar resets, crashes or disappears. UI automations are now in try-catch blocks, and if the widget crashes, it will try to restart itself.

Fixes #226 