### PR TITLE
Fixed crash when right-clicking on a widget.

### DIFF
--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
@@ -130,6 +130,27 @@ public partial class TaskbarWindow : Window
         Show();
     }
 
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+        HwndSource source = (HwndSource)PresentationSource.FromDependencyObject(this);
+        source.AddHook(WindowProc);
+    }
+
+    private static IntPtr WindowProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        // Some interface mods may collect information from all windows associated with the taskbar,
+        // causing the widget and the entire taskbar to freeze.
+        // For example, Nilesoft Shell and "Click on empty taskbar space" from Windhawk.
+        // Therefore, we are preventing the propagation of this message.
+        //
+        // WM_GETOBJECT (Sent by Microsoft UI Automation to obtain information about an accessible object contained in a server application)
+        if (msg == 0x003D)
+            handled = true;
+
+        return IntPtr.Zero;
+    }
+    
     private void Window_Loaded(object sender, RoutedEventArgs e)
     {
         SetupWindow();


### PR DESCRIPTION
fixes #203

Fixes deadlock (or something else?) when right-clicking on the widget.

At first, I thought the problem was specifically with right-clicking, so I used a different method of processing messages, and that helped with the freezing caused by `Click on empty taskbar space` from `Windhawk`. Old behavior: https://github.com/unchihugo/FluentFlyout/issues/203#issuecomment-3680876153
But `Nilesoft Shell` continued to cause freezes.

The solution turned out to be extremely simple to implement! but very difficult to trace the cause.
It seems that both of these mods also use `UI Automation` for their work, which leads to freezing. `UI Automation` sends message `0x003D`, without which it cannot function. Therefore, we can just prevent this message from propagating!

#### New behavior:

https://github.com/user-attachments/assets/b9680898-d9cf-488b-8fc4-9887dfd36b33
