### PR TITLE
Fix trackpad scrolling speed being too fast

### DIFF
--- a/FluentFlyoutWPF/app.manifest
+++ b/FluentFlyoutWPF/app.manifest
@@ -4,6 +4,8 @@
 		<asmv3:windowsSettings>
 			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
 			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+			<highResolutionScrollingAware xmlns="http://schemas.microsoft.com/SMI/2013/WindowsSettings">true</highResolutionScrollingAware>
+			<ultraHighResolutionScrollingAware xmlns="http://schemas.microsoft.com/SMI/2013/WindowsSettings">false</ultraHighResolutionScrollingAware>
 		</asmv3:windowsSettings>
 	</asmv3:application>
 </assembly>


### PR DESCRIPTION
Fix trackpad scrolling speed being too fast by disabling ultraHighResolutionScrollingAware in `app.manifest`.
Fixes #99 