### PR TITLE
Fix widget width calculations when controls enabled and no media playing

### DIFF
--- a/FluentFlyoutMSIX/Package.appxmanifest
+++ b/FluentFlyoutMSIX/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="unchihugo.FluentFlyout"
     Publisher="CN=49793F74-1457-4B66-A672-4ED3A640FC76"
-    Version="2.4.0.0" />
+    Version="2.5.0.0" />
 
   <Properties>
     <DisplayName>FluentFlyout</DisplayName>

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
@@ -470,8 +470,8 @@ public partial class TaskbarWindow : Window
         SongTitle.Width = Math.Max(logicalWidth - 58, 0);
         SongArtist.Width = Math.Max(logicalWidth - 58, 0);
 
-        // add space for playback controls if enabled
-        if (SettingsManager.Current.TaskbarWidgetControlsEnabled)
+        // add space for playback controls if enabled and visible
+        if (SettingsManager.Current.TaskbarWidgetControlsEnabled && ControlsStackPanel.Visibility == Visibility.Visible)
         {
             logicalWidth += (int)(102);
         }


### PR DESCRIPTION
Fix widget width calculations when control buttons are enabled and no media is playing. Previously would leave extra padding to the right visible when aligned to the right of the taskbar. Also bumped version to v2.5.0