### PR TITLE
Update notification strings to be from dictionary

### DIFF
--- a/FluentFlyoutWPF/Classes/Notifications.cs
+++ b/FluentFlyoutWPF/Classes/Notifications.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Toolkit.Uwp.Notifications;
 using NLog;
 using System.Runtime.InteropServices;
+using System.Windows;
 
 namespace FluentFlyout.Classes;
 
@@ -57,9 +58,9 @@ internal static class Notifications
             //return;
         }
 
-        if (currentVersion == "debug" || lastKnownVersion == "debug")
+        if (currentVersion == "debug")
         {
-            // debug build or when switching between debug and release builds
+            // when on debug build
             return;
 
             //new ToastContentBuilder()
@@ -76,10 +77,10 @@ internal static class Notifications
             {
                 // updated app version
                 new ToastContentBuilder()
-                    .AddText("FluentFlyout has been updated!")
-                    .AddText($"You are now on {currentVersion}.")
+                    .AddText(Application.Current.FindResource("UpdateToastTitle").ToString())
+                    .AddText(string.Format(Application.Current.FindResource("UpdateToastMessage").ToString(), currentVersion))
                     .AddButton(new ToastButton()
-                        .SetContent("View Updates")
+                        .SetContent(Application.Current.FindResource("UpdateToastButton").ToString())
                         .AddArgument("action", "viewChanges")
                         .SetBackgroundActivation())
                     .Show();

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -143,4 +143,7 @@ You can help contribute translations on</System:String>
     <System:String x:Key="TrayIcon_ReportBugOption">Report bug</System:String>
     <System:String x:Key="TrayIcon_QuitOption">Quit FluentFlyout</System:String>
     <System:String x:Key="PixelsUnit">px</System:String>
+    <System:String x:Key="UpdateToastTitle">FluentFlyout has been updated!</System:String>
+    <System:String x:Key="UpdateToastMessage">You are now on {0}.</System:String>
+    <System:String x:Key="UpdateToastButton">View Updates</System:String>
 </ResourceDictionary>


### PR DESCRIPTION
Updates strings in Notifications.cs to be from resource dictionary instead of hardcoded English strings. Also changed debug build notification trigger.

Closes #257 