### PR TITLE
Update tooltip to match Windows 11 styling

### DIFF
--- a/FluentFlyoutWPF/App.xaml
+++ b/FluentFlyoutWPF/App.xaml
@@ -15,6 +15,7 @@
                 <ui:ThemesDictionary Theme="Unknown"/>
                 <mica:ControlsDictionary />
                 <ResourceDictionary Source="Resources/Styles/CustomSlider.xaml"/>
+                <ResourceDictionary Source="Resources/Styles/CustomToolTip.xaml"/>
                 <!-- default language en-US -->
                 <ResourceDictionary Source="Resources/Localization/Dictionary-en-US.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -870,7 +870,7 @@ public partial class MainWindow : MicaWindow
                 // set tooltip
                 SongInfoStackPanel.ToolTip = string.Empty;
                 SongInfoStackPanel.ToolTip += !String.IsNullOrEmpty(songInfo.Title) ? songInfo.Title : string.Empty;
-                SongInfoStackPanel.ToolTip += !String.IsNullOrEmpty(songInfo.Artist) ? "\n" + songInfo.Artist : string.Empty;
+                SongInfoStackPanel.ToolTip += !String.IsNullOrEmpty(songInfo.Artist) ? "\n\n" + songInfo.Artist : string.Empty;
 
                 // background blurred image
                 if (SettingsManager.Current.MediaFlyoutBackgroundBlur != 0)

--- a/FluentFlyoutWPF/Resources/Styles/CustomToolTip.xaml
+++ b/FluentFlyoutWPF/Resources/Styles/CustomToolTip.xaml
@@ -1,0 +1,55 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls;assembly=Wpf.Ui">
+    <!-- copied and modified from WPF-UI for the ToolTip -->
+    <Style TargetType="{x:Type ToolTip}">
+        <Setter Property="TextElement.FontSize" Value="11" />
+        <Setter Property="TextBlock.LineHeight" Value="11" />
+        <Setter Property="MaxWidth" Value="400" />
+
+        <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
+        <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
+
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToolTip">
+                    <controls:EffectThicknessDecorator Thickness="15">
+                        <Border
+                            Name="Border"
+                            Width="{TemplateBinding Width}"
+                            Height="{TemplateBinding Height}"
+                            MaxWidth="{TemplateBinding MaxWidth}"
+                            Padding="4,4"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            SnapsToDevicePixels="True">
+                            <Border.Effect>
+                                <DropShadowEffect
+                                    BlurRadius="10"
+                                    Direction="270"
+                                    Opacity="0.25"
+                                    ShadowDepth="5"
+                                    Color="#202020" />
+                            </Border.Effect>
+                            <ContentPresenter
+                                Margin="4"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top">
+                                <ContentPresenter.Resources>
+                                    <Style TargetType="{x:Type TextBlock}">
+                                        <Setter Property="TextWrapping" Value="WrapWithOverflow" />
+                                    </Style>
+                                </ContentPresenter.Resources>
+                            </ContentPresenter>
+                        </Border>
+                    </controls:EffectThicknessDecorator>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
+</ResourceDictionary>

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml
@@ -50,7 +50,7 @@
                                     ToolTipService.VerticalOffset="-16">
                             <TextBlock Name="SongTitle" Text="" FontWeight="Normal" TextTrimming="CharacterEllipsis" Foreground="{ui:ThemeResource TextFillColorPrimaryBrush}" />
                             <TextBlock Name="SongArtist" Text="" FontWeight="Normal" Opacity="0.5" Margin="0,-1.5,0,0" TextTrimming="CharacterEllipsis" Foreground="{ui:ThemeResource TextFillColorPrimaryBrush}" />
-						</StackPanel>
+                        </StackPanel>
                         <StackPanel Name="ControlsStackPanel" Orientation="Horizontal" VerticalAlignment="Center" Width="Auto" Margin="8,0,0,0">
                             <StackPanel.Style>
                                 <Style TargetType="StackPanel">

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
@@ -705,7 +705,7 @@ public partial class TaskbarWindow : Window
             // Update tooltip with song info
             SongInfoStackPanel.ToolTip = string.Empty;
             SongInfoStackPanel.ToolTip += !String.IsNullOrEmpty(title) ? title : string.Empty;
-            SongInfoStackPanel.ToolTip += !String.IsNullOrEmpty(artist) ? "\n" + artist : string.Empty;
+            SongInfoStackPanel.ToolTip += !String.IsNullOrEmpty(artist) ? "\n\n" + artist : string.Empty;
 
             if (SettingsManager.Current.TaskbarWidgetControlsEnabled)
             {


### PR DESCRIPTION
Update tooltip to match Windows 11 styling by reducing padding and font size, fixing drop shadow, and increasing max width.