### PR TITLE
Change Acrylic window background opacity

### DIFF
--- a/FluentFlyoutWPF/Classes/Utils/StringWidth.cs
+++ b/FluentFlyoutWPF/Classes/Utils/StringWidth.cs
@@ -14,6 +14,7 @@ namespace FluentFlyout.Classes.Utils
         /// </summary>
         /// <param name="text">Text to measure</param>
         /// <param name="fontWeight">Weight of the font. Defaults to 500 (Medium)</param>
+        /// <param name="fontSize">Size of the font in device-independent units (pixels). Defaults to 14.</param>
         /// <returns>The width of the specified text, in device-independent units (pixels), including a small padding.</returns>
         public static double GetStringWidth(string text, int fontWeight = 500, int fontSize = 14)
         {

--- a/FluentFlyoutWPF/Classes/WindowBlurHelper.cs
+++ b/FluentFlyoutWPF/Classes/WindowBlurHelper.cs
@@ -47,7 +47,7 @@ public static class WindowBlurHelper
     /// </summary>
     /// <param name="window">The window to apply blur to</param>
     /// <param name="blurOpacity">Opacity of the blur (0-255)</param>
-    /// <param name="blurBackgroundColor">Background color in BGR format (default: 0x990000)</param>
+    /// <param name="blurBackgroundColor">Background color in BGR format (default: 0x000000)</param>
     public static void EnableBlur(Window window, uint blurOpacity = 175, uint blurBackgroundColor = 0x000000)
     {
         var windowHelper = new WindowInteropHelper(window);


### PR DESCRIPTION
Change Acrylic windows background opacity from 150 to 175 for a closer Windows 11-like look and add optional fontSize parameter into GetStringWidth function.