### PR TITLE
Add cover image hover tooltip to media flyout and widget

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml
+++ b/FluentFlyoutWPF/MainWindow.xaml
@@ -96,7 +96,10 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <StackPanel Grid.Row="0" Margin="12" Orientation="Horizontal">
-                    <Border Name="SongImageBorder" CornerRadius="6" BorderThickness="1" BorderBrush="#26FFFFFF" Margin="0" ClipToBounds="True" Width="78" Height="78">
+                    <Border Name="SongImageBorder" CornerRadius="6" BorderThickness="1" BorderBrush="#26FFFFFF" Margin="0" ClipToBounds="True" Width="78" Height="78"
+                            ToolTipService.InitialShowDelay="800"
+                            ToolTipService.Placement="RelativePoint"
+                            ToolTipService.VerticalOffset="-16">
                         <ui:SymbolIcon Name="SongImagePlaceholder" Symbol="MusicNote220" FontSize="40" Filled="True" Foreground="{DynamicResource MicaWPF.Brushes.SystemAccentColorLight2}" Visibility="Collapsed" />
                         <Border.Background>
                             <ImageBrush x:Name="SongImage" Stretch="UniformToFill"/>

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -8,13 +8,14 @@ using MicaWPF.Controls;
 using MicaWPF.Core.Extensions;
 using Microsoft.Win32;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
-using System.Windows.Interop;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
@@ -764,6 +765,7 @@ public partial class MainWindow : MicaWindow
                 ControlBack.IsEnabled = ControlForward.IsEnabled = false;
                 ControlBack.Opacity = ControlForward.Opacity = 0.35;
                 SongInfoStackPanel.ToolTip = string.Empty;
+                SongImageBorder.ToolTip = null;
                 return;
             }
 
@@ -892,8 +894,22 @@ public partial class MainWindow : MicaWindow
                     }
                 }
 
-                if (SongImage.ImageSource == null) SongImagePlaceholder.Visibility = Visibility.Visible;
-                else SongImagePlaceholder.Visibility = Visibility.Collapsed;
+                if (SongImage.ImageSource == null)
+                {
+                    SongImagePlaceholder.Visibility = Visibility.Visible;
+                    SongImageBorder.ToolTip = null;
+                }
+                else
+                {
+                    SongImagePlaceholder.Visibility = Visibility.Collapsed;
+                    SongImageBorder.ToolTip = new System.Windows.Controls.Image
+                    {
+                        Source = image,
+                        MaxWidth = 300,
+                        MaxHeight = 300,
+                        Stretch = Stretch.Uniform
+                    };
+                }
 
                 if (_seekBarEnabled)
                 {
@@ -1213,7 +1229,7 @@ public partial class MainWindow : MicaWindow
     {
         private const int MaxThumbnailSize = 512;
 
-        internal static BitmapImage? GetThumbnail(IRandomAccessStreamReference Thumbnail, bool convertToPng = true)
+        internal static BitmapImage? GetThumbnail(IRandomAccessStreamReference Thumbnail, bool convertToPng = true, int maxThumbnailSize = MaxThumbnailSize)
         {
             if (Thumbnail == null)
                 return null;
@@ -1224,7 +1240,7 @@ public partial class MainWindow : MicaWindow
                 // initialize the BitmapImage
                 image.BeginInit();
                 image.CacheOption = BitmapCacheOption.OnLoad;
-                image.DecodePixelWidth = MaxThumbnailSize;
+                image.DecodePixelWidth = maxThumbnailSize;
                 image.StreamSource = imageStream;
                 image.EndInit();
             }

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml
@@ -38,11 +38,14 @@
 						<ScaleTransform ScaleX="0.9" ScaleY="0.9" />
 					</Grid.RenderTransform>
 					<StackPanel Name="MainStackPanel" Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center" Width="Auto" Margin="4,0,-100,0">
-                        <Border Name="SongImageBorder" CornerRadius="5" Margin="0,0,0,-3" ClipToBounds="True" Width="36" Height="36" Panel.ZIndex="2">
+                        <Border Name="SongImageBorder" CornerRadius="5" Margin="0,0,0,-3" ClipToBounds="True" Width="36" Height="36" Panel.ZIndex="2" 
+                                ToolTipService.InitialShowDelay="800"
+                                ToolTipService.Placement="RelativePoint"
+                                ToolTipService.VerticalOffset="-16">
 							<ui:SymbolIcon Name="SongImagePlaceholder" Symbol="MusicNote220" FontSize="24" Filled="True" Foreground="{ui:ThemeResource AccentTextFillColorPrimaryBrush}" />
 							<Border.Background>
-								<ImageBrush x:Name="SongImage" Stretch="UniformToFill" />
-							</Border.Background>
+                                <ImageBrush x:Name="SongImage" Stretch="UniformToFill" />
+                            </Border.Background>
 						</Border>
                         <StackPanel Name="SongInfoStackPanel" Orientation="Vertical" VerticalAlignment="Center" Width="Auto" Margin="8,0,0,0" 
                                     ToolTipService.InitialShowDelay="800"

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
@@ -665,6 +665,7 @@ public partial class TaskbarWindow : Window
                 SongArtist.Text = string.Empty;
                 SongInfoStackPanel.Visibility = Visibility.Collapsed;
                 SongInfoStackPanel.ToolTip = string.Empty;
+                SongImageBorder.ToolTip = null;
                 SongImagePlaceholder.Symbol = SymbolRegular.MusicNote220;
                 SongImagePlaceholder.Visibility = Visibility.Visible;
                 SongImage.ImageSource = null;
@@ -753,6 +754,14 @@ public partial class TaskbarWindow : Window
                 BackgroundImage.Source = icon;
                 SongImageBorder.Margin = new Thickness(0, 0, 0, -2); // align image better when cover is present
 
+                SongImageBorder.ToolTip = new System.Windows.Controls.Image
+                {
+                    Source = icon,
+                    MaxWidth = 300,
+                    MaxHeight = 300,
+                    Stretch = Stretch.Uniform
+                };
+
                 // start cross-fade if previous task is completed
                 //if (_crossFadeTask.IsCompleted)
                 //{
@@ -765,6 +774,7 @@ public partial class TaskbarWindow : Window
                 SongImagePlaceholder.Visibility = Visibility.Visible;
                 SongImage.ImageSource = null;
                 BackgroundImage.Source = null;
+                SongImageBorder.ToolTip = null;
             }
 
             SongTitle.Visibility = Visibility.Visible;


### PR DESCRIPTION
Add cover image hover tooltip to media flyout and widget using native tooltips. 
TODO: Investigate why tooltip images are blurred.