### PR TITLE
Improve UI handling for non-premium versions

### DIFF
--- a/FluentFlyoutWPF/Classes/Utils/BoolToFullHalfOpacityConverter.cs
+++ b/FluentFlyoutWPF/Classes/Utils/BoolToFullHalfOpacityConverter.cs
@@ -1,0 +1,32 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+
+namespace FluentFlyoutWPF.Classes.Utils;
+
+public class BoolToFullHalfOpacityConverter : IValueConverter
+{
+    public double TrueValue { get; set; } = 1;
+    public double FalseValue { get; set; } = 0.5;
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value == null) return FalseValue;
+        if (value is bool boolValue)
+        {
+            return boolValue ? TrueValue : FalseValue;
+        }
+        else
+        {
+            return FalseValue;
+        }
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is double opacity)
+        {
+            return opacity == TrueValue;
+        }
+        return false;
+    }
+}

--- a/FluentFlyoutWPF/Pages/HomePage.xaml
+++ b/FluentFlyoutWPF/Pages/HomePage.xaml
@@ -7,7 +7,7 @@
       xmlns:viewModels="clr-namespace:FluentFlyoutWPF.ViewModels"
       xmlns:utils="clr-namespace:FluentFlyoutWPF.Classes.Utils"
       mc:Ignorable="d"
-      d:DesignHeight="800" d:DesignWidth="600"
+      d:DesignHeight="1000" d:DesignWidth="600"
       Title="HomePage"
       d:DataContext="{d:DesignInstance viewModels:UserSettings}"
       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -16,7 +16,6 @@
     <Page.Resources>
         <utils:BoolToEnabledDisabledConverter x:Key="BoolToEnabledDisabledConverter" />
         <utils:BoolToVisibleCollapsedConverter x:Key="BoolToCollapsedVisibleConverter" TrueValue="Collapsed" FalseValue="Visible" />
-        <utils:BoolToVisibleCollapsedConverter x:Key="BoolToVisibleCollapsedConverter" />
     </Page.Resources>
 
     <StackPanel MaxWidth="1000" Margin="16">
@@ -105,7 +104,10 @@
                     <ui:SymbolIcon Symbol="TextboxAlignBottom24" FontSize="30" Filled="False" />
                 </ui:CardAction.Icon>
                 <StackPanel>
-                    <ui:TextBlock FontWeight="Medium" Text="{DynamicResource TaskbarWidgetCustomizationTitle}" />
+                    <StackPanel Orientation="Horizontal">
+                        <ui:TextBlock FontWeight="Medium" Text="{DynamicResource TaskbarWidgetCustomizationTitle}" />
+                        <ui:InfoBadge Value=" PREMIUM " FontSize="8" FontWeight="Medium" Margin="6,-2,0,-2" Severity="Attention" />
+                    </StackPanel>
                     <ui:TextBlock Appearance="Secondary" Text="{Binding TaskbarWidgetEnabled, Converter={StaticResource BoolToEnabledDisabledConverter}}">
                         <ui:TextBlock.Style>
                             <Style TargetType="ui:TextBlock">
@@ -256,7 +258,7 @@
             <!-- GitHub Version InfoBar -->
             <ui:InfoBar Grid.Row="0" Title="{DynamicResource PremiumGitHubMessage}" IsOpen="True" Severity="Informational" IsClosable="False" Margin="0,0,0,12" Visibility="{Binding IsStoreVersion, Converter={StaticResource BoolToCollapsedVisibleConverter}}" />
 
-            <ui:TextBlock Grid.Row="1" FontSize="14" Margin="4,0,0,0" FontWeight="Regular" HorizontalAlignment="Left" Opacity="0.75" TextWrapping="WrapWithOverflow" Text="{DynamicResource PremiumFeatureDescription}" Visibility="{Binding IsStoreVersion, Converter={StaticResource BoolToVisibleCollapsedConverter}}" />
+            <ui:TextBlock Grid.Row="1" FontSize="14" Margin="4,0,0,0" FontWeight="Regular" HorizontalAlignment="Left" Opacity="0.75" TextWrapping="WrapWithOverflow" Text="{DynamicResource PremiumFeatureDescription}" />
         </Grid>
 
         <DockPanel LastChildFill="False" Margin="0,24,0,12">

--- a/FluentFlyoutWPF/Pages/SystemPage.xaml
+++ b/FluentFlyoutWPF/Pages/SystemPage.xaml
@@ -6,11 +6,17 @@
       xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
       xmlns:controls="clr-namespace:MicaWPF.Controls;assembly=MicaWPF"
       xmlns:viewModels="clr-namespace:FluentFlyoutWPF.ViewModels"
+      xmlns:utils="clr-namespace:FluentFlyoutWPF.Classes.Utils"
       mc:Ignorable="d"
       d:DesignHeight="1600" d:DesignWidth="800"
       Title="SystemPage"
       d:DataContext="{d:DesignInstance viewModels:UserSettings}"
-      Foreground="{DynamicResource TextFillColorPrimaryBrush}">
+      Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+      d:Background="White">
+
+    <Page.Resources>
+        <utils:BoolToFullHalfOpacityConverter x:Key="BoolToFullHalfOpacityConverter" />
+    </Page.Resources>
 
     <StackPanel MaxWidth="1000" Margin="16">
         <TextBlock Text="{DynamicResource SystemSettingsTitle}" FontSize="24" FontWeight="SemiBold" Margin="0,0,0,24" />
@@ -153,7 +159,7 @@
                         <TextBlock Text="{DynamicResource AcrylicBlurOpacityDescription}" FontSize="12" Opacity="0.5" />
                     </StackPanel>
                 </ui:CardControl.Header>
-                <StackPanel Orientation="Horizontal">
+                <StackPanel Orientation="Horizontal" Opacity="{Binding IsPremiumUnlocked, Converter={StaticResource BoolToFullHalfOpacityConverter}}" >
                     <Slider Minimum="0" Maximum="255" Value="{Binding AcrylicBlurOpacity, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" TickFrequency="5" IsSnapToTickEnabled="True" Width="150" />
                     <ui:TextBlock Text="{Binding AcrylicBlurOpacity}" Width="24" TextAlignment="Center" Margin="12,0,0,0" />
                 </StackPanel>

--- a/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
@@ -11,10 +11,12 @@
       d:DesignHeight="1600" d:DesignWidth="800"
       Title="TaskbarWidgetPage"
       d:DataContext="{d:DesignInstance viewModels:UserSettings}"
-      Foreground="{DynamicResource TextFillColorPrimaryBrush}">
+      Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+      d:Background="White">
 
     <Page.Resources>
         <utils:BoolToVisibleCollapsedConverter x:Key="BoolToCollapsedVisibleConverter" TrueValue="Collapsed" FalseValue="Visible" />
+        <utils:BoolToFullHalfOpacityConverter x:Key="BoolToFullHalfOpacityConverter" />
     </Page.Resources>
 
     <StackPanel MaxWidth="1000" Margin="16">
@@ -88,8 +90,10 @@
 
             <!-- GitHub Version InfoBar -->
             <ui:InfoBar Grid.Row="1" Title="{DynamicResource PremiumGitHubMessage}" IsOpen="True" Severity="Informational" IsClosable="True" Margin="0,0,0,3" Visibility="{Binding IsStoreVersion, Converter={StaticResource BoolToCollapsedVisibleConverter}}" />
+        </Grid>
 
-            <ui:CardControl Grid.Row="2" Icon="{ui:SymbolIcon TextboxAlignBottom24}" Margin="0,0,0,24">
+        <StackPanel Opacity="{Binding IsPremiumUnlocked, Converter={StaticResource BoolToFullHalfOpacityConverter}}">
+                <ui:CardControl Grid.Row="2" Icon="{ui:SymbolIcon TextboxAlignBottom24}" Margin="0,0,0,24">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <StackPanel Orientation="Horizontal">
@@ -234,6 +238,6 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetAnimated, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
             </ui:CardControl>
-        </Grid>
+        </StackPanel>
     </StackPanel>
 </Page>


### PR DESCRIPTION
Improve UI handling for non-premium versions by adding an Opacity converter that sets opacity of controls in TaskbarWidgetPage and slider in SystemPage (IsEnabled did not change opacity) to 0.5. Also added Premium badge to Taskbar Widget card in HomePage.