### PR TITLE
Fixed a crash when the player cannot return session data.

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -232,6 +232,19 @@ public partial class MainWindow : MicaWindow
         }
     }
 
+    private static GlobalSystemMediaTransportControlsSessionMediaProperties? TryGetMediaProperties(GlobalSystemMediaTransportControlsSession controlSession)
+    {
+        try
+        {
+            return controlSession.TryGetMediaPropertiesAsync().GetAwaiter().GetResult();
+        }
+        catch (COMException ex)
+        {
+            Logger.Error(ex, "Failed to retrieve data from the player");
+            return null;
+        }
+    }
+
     private void openSettings(object? sender, EventArgs e)
     {
         SettingsWindow.ShowInstance();
@@ -447,7 +460,10 @@ public partial class MainWindow : MicaWindow
             return;
         }
         var focusedSession = mediaManager.GetFocusedSession();
-        var songInfo = focusedSession.ControlSession.TryGetMediaPropertiesAsync().GetAwaiter().GetResult();
+        var songInfo = TryGetMediaProperties(focusedSession.ControlSession);
+        if (songInfo == null)
+            return;
+
         var playbackInfo = focusedSession.ControlSession.GetPlaybackInfo();
         taskbarWindow?.UpdateUi(songInfo.Title, songInfo.Artist, Helper.GetThumbnail(songInfo.Thumbnail), playbackInfo.PlaybackStatus, playbackInfo.Controls);
     }
@@ -508,7 +524,10 @@ public partial class MainWindow : MicaWindow
             return;
         }
 
-        var songInfo = focusedSession.ControlSession.TryGetMediaPropertiesAsync().GetAwaiter().GetResult();
+        var songInfo = TryGetMediaProperties(focusedSession.ControlSession);
+        if (songInfo == null)
+            return;
+
         taskbarWindow?.UpdateUi(songInfo.Title, songInfo.Artist, Helper.GetThumbnail(songInfo.Thumbnail), playbackInfo?.PlaybackStatus, playbackInfo?.Controls);
 
         if (IsVisible)
@@ -536,7 +555,10 @@ public partial class MainWindow : MicaWindow
             return;
         }
 
-        var songInfo = mediaSession.ControlSession.TryGetMediaPropertiesAsync().GetAwaiter().GetResult();
+        var songInfo = TryGetMediaProperties(mediaSession.ControlSession);
+        if (songInfo == null)
+            return;
+
         var playbackInfo = mediaSession.ControlSession.GetPlaybackInfo();
 
         string check = songInfo.Title + songInfo.Artist + playbackInfo.PlaybackStatus;
@@ -635,7 +657,10 @@ public partial class MainWindow : MicaWindow
         }
         else
         {
-            var songInfo = focusedSession.ControlSession.TryGetMediaPropertiesAsync().GetAwaiter().GetResult();
+            var songInfo = TryGetMediaProperties(focusedSession.ControlSession);
+            if (songInfo == null)
+                return;
+
             var playbackInfo = focusedSession.ControlSession.GetPlaybackInfo();
             taskbarWindow?.UpdateUi(songInfo.Title, songInfo.Artist, Helper.GetThumbnail(songInfo.Thumbnail), playbackInfo.PlaybackStatus, playbackInfo.Controls);
         }
@@ -889,7 +914,10 @@ public partial class MainWindow : MicaWindow
                 }
             }
 
-            var songInfo = controlSession.TryGetMediaPropertiesAsync().GetAwaiter().GetResult();
+            var songInfo = TryGetMediaProperties(controlSession);
+            if (songInfo == null)
+                return;
+
             if (songInfo != null)
             {
                 SongTitle.Text = songInfo.Title;


### PR DESCRIPTION
fixes #299

This PR just replaces all `TryGetMediaPropertiesAsync().GetAwaiter().GetResult()` with a call to the `TryGetMediaProperties` method, which catches the exception.

Now, instead of the crash, one error is printed in the logs.
<img width="1486" height="107" alt="image" src="https://github.com/user-attachments/assets/5622eb62-6721-40b3-9bf6-607acd35337e" />
