### PR TITLE
Add font family prioritization when changing language and remove legacy font properties

### DIFF
--- a/FluentFlyoutWPF/Classes/LocalizationManager.cs
+++ b/FluentFlyoutWPF/Classes/LocalizationManager.cs
@@ -46,6 +46,16 @@ public static class LocalizationManager
         { "Tiếng Việt", "vi" },
     };
 
+    // dictionary of font families for specific languages, priorities are switched around
+    private static readonly Dictionary<string, string> _languageFontFamilies = new()
+    {
+        { "default", "Segoe UI Variable, Microsoft YaHei UI, Yu Gothic UI, Malgun Gothic" }, // default support for multiple languages
+        //{ "zh-CN", "Segoe UI Variable, Microsoft YaHei UI, Yu Gothic UI, Malgun Gothic" }, // same as default
+        { "zh-TW", "Segoe UI Variable, Microsoft JhengHei UI, Yu Gothic UI, Malgun Gothic" },
+        { "ja", "Segoe UI Variable, Yu Gothic UI, Microsoft YaHei UI, Malgun Gothic" },
+        { "ko", "Segoe UI Variable, Malgun Gothic, Microsoft YaHei UI, Yu Gothic UI" },
+    };
+
     // right-to-left languages
     private static readonly HashSet<string> _rtlLanguages = ["ar", "he"];
 
@@ -86,6 +96,8 @@ public static class LocalizationManager
 
         // change flow direction of all windows
         ApplyFlowDirection(languageCode);
+
+        ApplyFontFamily(culture);
 
         // if English, the default (en-US) is already loaded, so no need to add another dictionary
         if (languageCode == "en") return;
@@ -142,5 +154,25 @@ public static class LocalizationManager
             : FlowDirection.LeftToRight;
 
         Logger.Debug("Applied flow direction: " + SettingsManager.Current.FlowDirection);
+    }
+
+    private static void ApplyFontFamily(string culture)
+    {
+        string fontFamily;
+        if (_languageFontFamilies.TryGetValue(culture, out string? value))
+        {
+            fontFamily = value;
+        }
+        else if (_languageFontFamilies.TryGetValue(LanguageCode, out string? value1))
+        {
+            fontFamily = value1;
+        }
+        else
+        {
+            fontFamily = _languageFontFamilies["default"];
+        }
+        SettingsManager.Current.FontFamily = fontFamily;
+
+        Logger.Debug("Applied font family: " + fontFamily);
     }
 }

--- a/FluentFlyoutWPF/MainWindow.xaml
+++ b/FluentFlyoutWPF/MainWindow.xaml
@@ -11,7 +11,7 @@
     ResizeMode="NoResize" MouseEnter="MicaWindow_MouseEnter"
     ChangeTitleColorWhenInactive="False"
     TextOptions.TextRenderingMode="ClearType" TextOptions.TextFormattingMode="Ideal" 
-    FontFamily="Segoe UI Variable, Microsoft YaHei, Microsoft JhengHei, MS Gothic"
+    FontFamily="{Binding FontFamily}"
     FlowDirection="{Binding FlowDirection}"
     Loaded="MicaWindow_Loaded"
     xmlns:viewModels="clr-namespace:FluentFlyoutWPF.ViewModels"

--- a/FluentFlyoutWPF/Pages/AboutPage.xaml
+++ b/FluentFlyoutWPF/Pages/AboutPage.xaml
@@ -18,11 +18,11 @@
     </Page.Resources>
 
     <StackPanel MaxWidth="1000" Margin="16">
-        <TextBlock Text="{DynamicResource AboutContributorsTitle}" FontSize="20" FontWeight="SemiBold" FontFamily="Segoe UI Variable" Margin="0,0,0,0" />
+        <TextBlock Text="{DynamicResource AboutContributorsTitle}" FontSize="20" FontWeight="SemiBold" Margin="0,0,0,0" />
         <TextBlock Text="{DynamicResource AboutContributorsDescription}" FontSize="14" Margin="4,12,0,0" FontWeight="Regular" HorizontalAlignment="Left" Opacity="0.75" TextWrapping="WrapWithOverflow" />
         <ui:TextBlock Text="{Binding AboutViewModel.ContributorsText}" FontSize="14" Margin="4,8,0,0" FontWeight="Regular" HorizontalAlignment="Left" Opacity="0.5" TextWrapping="WrapWithOverflow" />
 
-        <TextBlock Text="{DynamicResource AboutPremiumTitle}" FontSize="20" FontWeight="SemiBold" FontFamily="Segoe UI Variable" Margin="0,24,0,0" />
+        <TextBlock Text="{DynamicResource AboutPremiumTitle}" FontSize="20" FontWeight="SemiBold" Margin="0,24,0,0" />
         <Grid Margin="0,12,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
@@ -79,7 +79,7 @@
             <TextBlock Grid.Row="2" FontSize="14" Margin="4,0,0,0" FontWeight="Regular" HorizontalAlignment="Left" Opacity="0.75" TextWrapping="WrapWithOverflow" Text="{DynamicResource PremiumFeatureDescription}" />
         </Grid>
 
-        <TextBlock Text="{DynamicResource AboutOpenSourceLicensesTitle}" FontSize="20" FontWeight="SemiBold" FontFamily="Segoe UI Variable" Margin="0,36,0,12" />
+        <TextBlock Text="{DynamicResource AboutOpenSourceLicensesTitle}" FontSize="20" FontWeight="SemiBold" Margin="0,36,0,12" />
         <TextBlock Text="{DynamicResource AboutOpenSourceLicensesDescription}" FontSize="14" Margin="4,0,0,0" FontWeight="Regular" HorizontalAlignment="Left" Opacity="0.75" TextWrapping="WrapWithOverflow" />
         
         <ItemsControl ItemsSource="{Binding AboutViewModel.Licenses}" Margin="0,12,0,0">

--- a/FluentFlyoutWPF/Pages/HomePage.xaml
+++ b/FluentFlyoutWPF/Pages/HomePage.xaml
@@ -25,7 +25,7 @@
             <TextBlock x:Name="VersionTextBlock" FontSize="14" FontWeight="Regular" VerticalAlignment="Bottom" Margin="10" Opacity="0.5" />
         </StackPanel>
 
-        <TextBlock Text="{DynamicResource HomeTitle}" FontSize="24" FontWeight="SemiBold" FontFamily="Segoe UI Variable" Margin="0,36,0,12" />
+        <TextBlock Text="{DynamicResource HomeTitle}" FontSize="24" FontWeight="SemiBold" Margin="0,36,0,12" />
         <StackPanel Orientation="Horizontal">
             <ui:Button x:Name="ViewUpdatesButton" Appearance="Transparent" Padding="0,0,16,0" BorderBrush="Transparent" Margin="0,0,16,16" Click="ViewUpdates_Click">
                 <StackPanel Orientation="Horizontal">
@@ -246,7 +246,7 @@
             </ui:Button>
         </StackPanel>
 
-        <TextBlock Text="{DynamicResource AboutPremiumTitle}" FontSize="14" FontWeight="SemiBold" FontFamily="Segoe UI Variable" Margin="0,36,0,0" />
+        <TextBlock Text="{DynamicResource AboutPremiumTitle}" FontSize="14" FontWeight="SemiBold" Margin="0,36,0,0" />
         <Grid Margin="0,12,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />

--- a/FluentFlyoutWPF/Pages/LockKeysPage.xaml
+++ b/FluentFlyoutWPF/Pages/LockKeysPage.xaml
@@ -13,7 +13,7 @@
       Foreground="{DynamicResource TextFillColorPrimaryBrush}">
 
     <StackPanel MaxWidth="1000" Margin="16">
-        <TextBlock Text="{DynamicResource LockKeysCustomizationTitle}" FontSize="24" FontWeight="SemiBold" FontFamily="Segoe UI Variable" Margin="0,0,0,20" />
+        <TextBlock Text="{DynamicResource LockKeysCustomizationTitle}" FontSize="24" FontWeight="SemiBold" Margin="0,0,0,20" />
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />

--- a/FluentFlyoutWPF/Pages/MediaFlyoutPage.xaml
+++ b/FluentFlyoutWPF/Pages/MediaFlyoutPage.xaml
@@ -13,7 +13,7 @@
       Foreground="{DynamicResource TextFillColorPrimaryBrush}">
 
     <StackPanel MaxWidth="1000" Margin="16">
-        <TextBlock Text="{DynamicResource MediaFlyoutTitle}" FontSize="24" FontWeight="SemiBold" FontFamily="Segoe UI Variable" Margin="0,0,0,20" />
+        <TextBlock Text="{DynamicResource MediaFlyoutTitle}" FontSize="24" FontWeight="SemiBold" Margin="0,0,0,20" />
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />

--- a/FluentFlyoutWPF/Pages/NextUpPage.xaml
+++ b/FluentFlyoutWPF/Pages/NextUpPage.xaml
@@ -13,7 +13,7 @@
       Foreground="{DynamicResource TextFillColorPrimaryBrush}">
 
     <StackPanel MaxWidth="1000" Margin="16">
-        <TextBlock Text="{DynamicResource NextUpCustomizationTitle}" FontSize="24" FontWeight="SemiBold" FontFamily="Segoe UI Variable" Margin="0,0,0,20" />
+        <TextBlock Text="{DynamicResource NextUpCustomizationTitle}" FontSize="24" FontWeight="SemiBold" Margin="0,0,0,20" />
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />

--- a/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
@@ -20,7 +20,7 @@
     </Page.Resources>
 
     <StackPanel MaxWidth="1000" Margin="16">
-        <TextBlock Text="{DynamicResource TaskbarWidgetCustomizationTitle}" FontSize="24" FontWeight="SemiBold" FontFamily="Segoe UI Variable" Margin="0,0,0,20" />
+        <TextBlock Text="{DynamicResource TaskbarWidgetCustomizationTitle}" FontSize="24" FontWeight="SemiBold" Margin="0,0,0,20" />
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />

--- a/FluentFlyoutWPF/SettingsWindow.xaml
+++ b/FluentFlyoutWPF/SettingsWindow.xaml
@@ -11,7 +11,7 @@
     Height="700" MinHeight="300" MinWidth="750" Width="800"
     Title="FluentFlyout" Icon="/Resources/FluentFlyout2.ico"
     TextOptions.TextRenderingMode="ClearType" TextOptions.TextFormattingMode="Ideal"
-    FontFamily="Segoe UI Variable, Microsoft YaHei, Microsoft JhengHei, MS Gothic"
+    FontFamily="{Binding FontFamily}"
 	FlowDirection="{Binding FlowDirection}"
     Closing="SettingsWindow_Closing"
     xmlns:viewModels="clr-namespace:FluentFlyoutWPF.ViewModels"

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -301,6 +301,10 @@ public partial class UserSettings : ObservableObject
     [ObservableProperty]
     public partial FlowDirection FlowDirection { get; set; }
 
+    [XmlIgnore]
+    [ObservableProperty]
+    public partial string FontFamily { get; set; }
+
     /// <summary>
     /// Gets or sets a value indicating whether the taskbar widget is enabled
     /// </summary>
@@ -453,6 +457,7 @@ public partial class UserSettings : ObservableObject
         MediaFlyoutAcrylicWindowEnabled = true;
         AppLanguage = "system";
         FlowDirection = FlowDirection.LeftToRight;
+        FontFamily = "Segoe UI Variable, Microsoft YaHei UI, Yu Gothic UI";
         NextUpAcrylicWindowEnabled = true;
         LockKeysAcrylicWindowEnabled = true;
         TaskbarWidgetEnabled = false;

--- a/FluentFlyoutWPF/Windows/LockWindow.xaml
+++ b/FluentFlyoutWPF/Windows/LockWindow.xaml
@@ -13,7 +13,7 @@
     WindowStyle="None" ShowInTaskbar="False"
     ChangeTitleColorWhenInactive="False" Visibility="Visible"
     TextOptions.TextRenderingMode="ClearType" TextOptions.TextFormattingMode="Ideal"
-    FontFamily="Segoe UI Variable, Microsoft YaHei, Microsoft JhengHei, MS Gothic"
+    FontFamily="{Binding FontFamily}"
     FlowDirection="{Binding FlowDirection}"
     d:DataContext="{d:DesignInstance viewModels:UserSettings}"
     >
@@ -41,7 +41,7 @@
     <Grid Margin="12,6,12,6">
         <ui:SymbolIcon Name="LockSymbol" HorizontalAlignment="Left" Symbol="LockClosed24" Filled="false" Width="22" Height="22" FontSize="22" VerticalAlignment="Center" Margin="0,0,2,1"/>
         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="20,0,0,4">
-            <TextBlock Name="LockTextBlock" Text="Loading..." FontSize="14" FontFamily="Segoe UI Variable" FontWeight="Medium" TextTrimming="CharacterEllipsis"/>
+            <TextBlock Name="LockTextBlock" Text="Loading..." FontSize="14" FontWeight="Medium" TextTrimming="CharacterEllipsis"/>
         </StackPanel>
         <Rectangle Name="LockIndicatorRectangle" Fill="{DynamicResource MicaWPF.Brushes.AccentFillColorDefault}" Height="4" RadiusX="2" RadiusY="2" Width="60" VerticalAlignment="Bottom"/>
     </Grid>

--- a/FluentFlyoutWPF/Windows/NextUpWindow.xaml
+++ b/FluentFlyoutWPF/Windows/NextUpWindow.xaml
@@ -13,7 +13,7 @@
       WindowStyle="None" ShowInTaskbar="False"
       SystemBackdropType="Mica" ChangeTitleColorWhenInactive="False"
       TextOptions.TextRenderingMode="ClearType" TextOptions.TextFormattingMode="Ideal"
-      FontFamily="Segoe UI Variable, Microsoft YaHei, Microsoft JhengHei, MS Gothic"
+      FontFamily="{Binding FontFamily}"
       FlowDirection="{Binding FlowDirection}"
       d:DataContext="{d:DesignInstance viewModels:UserSettings}"
       >
@@ -46,7 +46,7 @@
         </Grid.ColumnDefinitions>
         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
             <ui:SymbolIcon Symbol="MusicNote120" Filled="True" Width="14" Height="14" FontSize="14" VerticalAlignment="Center" Margin="0,0,2,0"/>
-            <TextBlock x:Name="UpNextTextBlock" Text="{DynamicResource NextUpWindow_UpNextText}" FontSize="12" VerticalAlignment="Center" FontFamily="Segoe UI Variable" FontWeight="Medium"/>
+            <TextBlock x:Name="UpNextTextBlock" Text="{DynamicResource NextUpWindow_UpNextText}" FontSize="12" VerticalAlignment="Center" FontWeight="Medium"/>
         </StackPanel>
         <Border Grid.Column="1" Name="SongImageBorder" CornerRadius="6" Margin="12,1,0,0" ClipToBounds="True" Width="38" Height="38">
             <ui:SymbolIcon Name="SongImagePlaceholder" Symbol="MusicNote220" FontSize="40" Filled="True" Foreground="{DynamicResource MicaWPF.Brushes.SystemAccentColorLight2}" Visibility="Collapsed" />
@@ -55,8 +55,8 @@
             </Border.Background>
         </Border>
         <StackPanel Grid.Column="2" Name="SongInfoStackPanel" Margin="6,0,0,0" Orientation="Vertical" VerticalAlignment="Center">
-            <TextBlock Name="SongTitle" Text="Song Title" FontSize="14" FontFamily="Segoe UI Variable" FontWeight="Medium" TextTrimming="CharacterEllipsis"/>
-            <TextBlock Name="SongArtist" Text="Artist Name" FontSize="14" FontFamily="Segoe UI Variable" FontWeight="Medium" Opacity="0.5" TextTrimming="CharacterEllipsis"/>
+            <TextBlock Name="SongTitle" Text="Song Title" FontSize="14" FontWeight="Medium" TextTrimming="CharacterEllipsis"/>
+            <TextBlock Name="SongArtist" Text="Artist Name" FontSize="14" FontWeight="Medium" Opacity="0.5" TextTrimming="CharacterEllipsis"/>
         </StackPanel>
     </Grid>
 </controls:MicaWindow>

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml
@@ -13,7 +13,7 @@
         AllowsTransparency="True"
         Background="Transparent"
         TextOptions.TextRenderingMode="ClearType" TextOptions.TextFormattingMode="Ideal"
-        FontFamily="Segoe UI Variable, Microsoft YaHei, Microsoft JhengHei, MS Gothic"
+        FontFamily="{Binding FontFamily}"
         FlowDirection="{Binding FlowDirection}"
         Loaded="Window_Loaded" Visibility="Collapsed"
         xmlns:viewModels="clr-namespace:FluentFlyoutWPF.ViewModels"


### PR DESCRIPTION
Fixes issue in other languages where font families were incorrectly prioritized over others (like YaHei prioritized over JhengHei in Traditional Chinese) and cleaned elements from using custom font properties (this forced some elements to use Segoe UI instead of localized font families).

Fixes #308, fixes #315 

