### PR TITLE
Separate setting titles and premium perk descriptions

### DIFF
--- a/FluentFlyoutWPF/Pages/HomePage.xaml
+++ b/FluentFlyoutWPF/Pages/HomePage.xaml
@@ -286,11 +286,11 @@
                             <ui:TextBlock FontSize="14" Margin="0,0,0,8" TextWrapping="WrapWithOverflow"
                                   Text="{DynamicResource UnlockFullExperienceText}" />
                             <ui:TextBlock FontSize="14" Margin="12,0,12,4" Opacity="0.75" TextWrapping="WrapWithOverflow"
-                                  Text="{Binding Source={StaticResource TaskbarWidgetCustomizationTitle}, StringFormat='•  {0}'}" />
+                                  Text="{Binding Source={StaticResource TaskbarWidgetCustomizationPerk}, StringFormat='•  {0}'}" />
                             <ui:TextBlock FontSize="14" Margin="12,0,12,4" Opacity="0.75" TextWrapping="WrapWithOverflow"
-                                  Text="{Binding Source={StaticResource AcrylicBlurOpacityTitle}, StringFormat='•  {0}'}" />
+                                  Text="{Binding Source={StaticResource AcrylicBlurOpacityPerk}, StringFormat='•  {0}'}" />
                             <ui:TextBlock FontSize="14" Margin="12,0,12,4" Opacity="0.75" TextWrapping="WrapWithOverflow"
-                                  Text="{Binding Source={StaticResource HideTrayIconTitle}, StringFormat='•  {0}'}" />
+                                  Text="{Binding Source={StaticResource HideTrayIconPerk}, StringFormat='•  {0}'}" />
                             <ui:TextBlock FontSize="14" Margin="12,0,12,0" Opacity="0.75" TextWrapping="WrapWithOverflow"
                                   Text="{Binding Source={StaticResource AllFuturePremiumFeatures}, StringFormat='•  {0}'}" />
                         </StackPanel>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -93,6 +93,9 @@ Note: As an open-source project, these features are also available for free via 
     <System:String x:Key="PremiumPurchaseFailed">Purchase failed. Please try again.</System:String>
     <System:String x:Key="PremiumPurchaseCancelled">Purchase cancelled.</System:String>
     <System:String x:Key="UnlockFullExperienceText">Unlock the full FluentFlyout experience:</System:String>
+    <System:String x:Key="TaskbarWidgetCustomizationPerk">Taskbar Widget</System:String>
+    <System:String x:Key="AcrylicBlurOpacityPerk">Acrylic Blur Opacity</System:String>
+    <System:String x:Key="HideTrayIconPerk">Hide Tray Icon</System:String>
     <System:String x:Key="AllFuturePremiumFeatures">All future Premium features</System:String>
     <System:String x:Key="NextUpCustomizationTitle">Next Up Flyout</System:String>
     <System:String x:Key="NextUpDescription" xml:space="preserve">A flyout shows what's next when a song/video ends. Only appears if the next item plays automatically, if next/previous is pressed manually, the main flyout appears instead.</System:String>


### PR DESCRIPTION
Separate so as not to have partial and awkward translations. Fixes #344.