### PR TITLE
Fix log folder path pointing to wrong location on MS store versions

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -26,6 +26,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using Windows.ApplicationModel;
 using Windows.Media.Control;
+using Windows.Storage;
 using Windows.Storage.Streams;
 using static FluentFlyout.Classes.NativeMethods;
 using static WindowsMediaController.MediaManager;
@@ -489,7 +490,11 @@ public partial class MainWindow : MicaWindow
     {
         try
         {
-            string logFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FluentFlyout");
+            // path containerized for store version, regular path for non-store version
+            string logFolderPath = SettingsManager.Current.IsStoreVersion
+                ? Path.Combine(ApplicationData.Current.LocalCacheFolder.Path, "Roaming", "FluentFlyout")
+                : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FluentFlyout");
+
             Process.Start("explorer.exe", logFolderPath);
         }
         catch (Exception ex)


### PR DESCRIPTION
Fixed log folder path pointing to the wrong location because MS store version containerizes the program resulting in a different path when using Process.Start explorer.exe. Explorer doesn't find the path and opens Documents by default.