### PR TITLE
Limiting the visible area of a widget using regions to avoid blocking system messages.

### DIFF
--- a/FluentFlyoutWPF/Classes/NativeMethods.cs
+++ b/FluentFlyoutWPF/Classes/NativeMethods.cs
@@ -193,6 +193,9 @@ public static class NativeMethods
     [DllImport("user32.dll", SetLastError = true)]
     internal static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
 
+    [DllImport("user32.dll")]
+    internal static extern int SetWindowRgn(IntPtr hWnd, IntPtr hRgn, bool bRedraw);
+
     [DllImport("user32.dll", SetLastError = true)]
     internal static extern uint GetWindowThreadProcessId(IntPtr hWnd, IntPtr lpdwProcessId);
 
@@ -241,6 +244,19 @@ public static class NativeMethods
 
     [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     internal static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+
+    #endregion
+
+    #region gdi32.dll
+
+    [DllImport("gdi32.dll")]
+    internal static extern IntPtr CreateRectRgn(int left, int top, int right, int bottom);
+
+    [DllImport("gdi32.dll")]
+    internal static extern int CombineRgn(IntPtr dest, IntPtr src1, IntPtr src2, int mode);
+
+    [DllImport("gdi32.dll")]
+    internal static extern bool DeleteObject(IntPtr hObject);
 
     #endregion
 

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024-2026 The FluentFlyout Authors
+// Copyright Â© 2024-2026 The FluentFlyout Authors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using FluentFlyout.Classes.Settings;
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows;
 using System.Windows.Automation;
+using System.Windows.Controls;
 using System.Windows.Interop;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
@@ -212,6 +213,56 @@ public partial class TaskbarWindow : Window
         }
     }
 
+    private void UpdateWindowRegion(IntPtr windowHandle, params Rect[] rects)
+    {
+        IntPtr rgn = CreateRectRgn(0, 0, 0, 0);
+        foreach (var r in rects)
+        {
+            IntPtr newRgn = CreateRectRgn((int)r.Left, (int)r.Top, (int)r.Right, (int)r.Bottom);
+            if (newRgn == IntPtr.Zero)
+            {
+                Logger.Error($"Taskbar Widget error during CreateRectRgn({(int)r.Left}, {(int)r.Top}, {(int)r.Right}, {(int)r.Bottom}).");
+                goto on_error;
+            }
+
+            if (CombineRgn(rgn, rgn, newRgn, 2 /*RGN_OR*/) == 0)
+            {
+                Logger.Error($"Taskbar Widget error during CombineRgn. Combined regions: {string.Join(", ", rects.Select(i => $"RECT({(int)i.Left}, {(int)i.Top}, {(int)i.Right}, {(int)i.Bottom})"))}");
+                DeleteObject(newRgn);
+                goto on_error;
+            }
+
+            DeleteObject(newRgn);
+        }
+
+        if (SetWindowRgn(windowHandle, rgn, true) == 0)
+        {
+            Logger.Error($"Taskbar Widget error during SetWindowRgn.");
+            goto on_error;
+        }
+
+        // Simple debugging to display the window region:
+#if false
+        var whiteRect = WidgetCanvas.Children.Cast<FrameworkElement>().FirstOrDefault(e => e.Name == "test_border");
+        if (whiteRect == null)
+        {
+            whiteRect = new System.Windows.Shapes.Rectangle() { Name = "test_border", Width = 20000, Height = 20000, Fill = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Colors.Black) };
+            WidgetCanvas.Children.Add(whiteRect);
+            Canvas.SetLeft(whiteRect, -10000);
+            Canvas.SetTop(whiteRect, -10000);
+        }
+#endif
+
+        return;
+
+    on_error:
+
+        // All regions that were not sent without errors to SetWindowRgn must be destroyed manually
+        DeleteObject(rgn);
+        if (SetWindowRgn(windowHandle, IntPtr.Zero, true) == 0)
+            Logger.Error("Taskbar Widget error during window region reset.");
+    }
+
     private void UpdatePosition()
     {
         if (MainWindow.ExplorerRestarting)
@@ -330,9 +381,10 @@ public partial class TaskbarWindow : Window
                      containerWidth, containerHeight,
                      SWP_NOZORDER | SWP_NOACTIVATE | SWP_ASYNCWINDOWPOS | SWP_SHOWWINDOW);
 
-            PositionWidget(taskbarHandle, taskbarRect, dpiScale, isMainTaskbarSelected);
+            var wRect = PositionWidget(taskbarHandle, taskbarRect, dpiScale, isMainTaskbarSelected);
+            var vRect = PositionVisualizer(taskbarHandle, taskbarRect, dpiScale, isMainTaskbarSelected);
 
-            PositionVisualizer(taskbarHandle, taskbarRect, dpiScale, isMainTaskbarSelected);
+            UpdateWindowRegion(taskbarWindowHandle, wRect, vRect);
 
             _lastSelectedMonitor = SettingsManager.Current.TaskbarWidgetSelectedMonitor;
         }
@@ -342,10 +394,10 @@ public partial class TaskbarWindow : Window
         }
     }
 
-    private void PositionWidget(IntPtr taskbarHandle, RECT taskbarRect, double dpiScale, bool isMainTaskbarSelected)
+    private Rect PositionWidget(IntPtr taskbarHandle, RECT taskbarRect, double dpiScale, bool isMainTaskbarSelected)
     {
         if (!SettingsManager.Current.TaskbarWidgetEnabled)
-            return;
+            return Rect.Empty;
 
         // Calculate widget size
         var (logicalWidth, logicalHeight) = Widget.CalculateSize(dpiScale);
@@ -479,16 +531,18 @@ public partial class TaskbarWindow : Window
         widgetLeft += SettingsManager.Current.TaskbarWidgetManualPadding;
 
         // Set widget position within canvas
-        System.Windows.Controls.Canvas.SetLeft(Widget, widgetLeft / dpiScale);
-        System.Windows.Controls.Canvas.SetTop(Widget, widgetTop / dpiScale);
+        Canvas.SetLeft(Widget, widgetLeft / dpiScale);
+        Canvas.SetTop(Widget, widgetTop / dpiScale);
         Widget.Width = physicalWidth / dpiScale;
         Widget.Height = physicalHeight / dpiScale;
+
+        return new Rect(Canvas.GetLeft(Widget) * dpiScale, Canvas.GetTop(Widget) * dpiScale, Widget.Width * dpiScale, Widget.Height * dpiScale);
     }
 
-    private void PositionVisualizer(IntPtr taskbarHandle, RECT taskbarRect, double dpiScale, bool isMainTaskbarSelected)
+    private Rect PositionVisualizer(IntPtr taskbarHandle, RECT taskbarRect, double dpiScale, bool isMainTaskbarSelected)
     {
         if (!SettingsManager.Current.TaskbarVisualizerEnabled)
-            return;
+            return Rect.Empty;
 
         int taskbarHeight = taskbarRect.Bottom - taskbarRect.Top;
         int visualizerTop = (taskbarHeight - (int)(TaskbarVisualizer.Height * dpiScale)) / 2;
@@ -497,17 +551,19 @@ public partial class TaskbarWindow : Window
         switch (SettingsManager.Current.TaskbarVisualizerPosition)
         {
             case 0: // left aligned next to widget
-                visualizerLeft = (int)(System.Windows.Controls.Canvas.GetLeft(Widget) * dpiScale) - (int)(TaskbarVisualizer.Width * dpiScale);
+                visualizerLeft = (int)(Canvas.GetLeft(Widget) * dpiScale) - (int)(TaskbarVisualizer.Width * dpiScale);
                 break;
 
             case 1: // right aligned next to widget
-                visualizerLeft = (int)(System.Windows.Controls.Canvas.GetLeft(Widget) * dpiScale) + (int)(Widget.Width * dpiScale);
+                visualizerLeft = (int)(Canvas.GetLeft(Widget) * dpiScale) + (int)(Widget.Width * dpiScale);
                 break;
         }
 
         // Set visualizer position within canvas
-        System.Windows.Controls.Canvas.SetLeft(TaskbarVisualizer, visualizerLeft / dpiScale);
-        System.Windows.Controls.Canvas.SetTop(TaskbarVisualizer, visualizerTop / dpiScale);
+        Canvas.SetLeft(TaskbarVisualizer, visualizerLeft / dpiScale);
+        Canvas.SetTop(TaskbarVisualizer, visualizerTop / dpiScale);
+
+        return new Rect(Canvas.GetLeft(TaskbarVisualizer) * dpiScale, Canvas.GetTop(TaskbarVisualizer) * dpiScale, TaskbarVisualizer.Width * dpiScale, TaskbarVisualizer.Height * dpiScale);
     }
 
     public void UpdateUi(string title, string artist, BitmapImage? icon, GlobalSystemMediaTransportControlsSessionPlaybackStatus? playbackStatus, GlobalSystemMediaTransportControlsSessionPlaybackControls? playbackControls = null)


### PR DESCRIPTION
fixes #391

In this commit, I was based on my previous patch, but now more error checks and logging have been added here.

I also added an `#if`/`#endif` block for debugging the set region.

https://github.com/user-attachments/assets/312c3244-f129-4104-9a9e-01d6aa35dd92

`UpdateWindowRegion` uses `goto` to quickly exit the loop and remove the unmanaged object. I hope this is not a problem.

`return new Rect` uses multiplication by `dpiScale` so that if more complex calculations are used above, they do not have to be repeated, but without `dpiScale`.