### PR TITLE
Add two plain text on TaskbarVisualizerPage to en-us dictionary

### DIFF
--- a/FluentFlyoutWPF/Pages/TaskbarVisualizerPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarVisualizerPage.xaml
@@ -173,11 +173,11 @@
                         <TextBlock FontSize="14" FontWeight="Regular" VerticalAlignment="Center">
                             <Hyperlink x:Name="StartupHyperlink" NavigateUri="ms-settings:apps-volume" BaselineAlignment="Center"
                                    RequestNavigate="StartupHyperlink_RequestNavigate" TextDecorations="None" Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}" >
-                                <Run Text="Output Device" />
+                                <Run Text="{DynamicResource TaskbarVisualizerOutputDeviceTitle}" />
                                 <ui:SymbolIcon VerticalAlignment="Center" FontSize="14" Symbol="ArrowUpRight24" />
                             </Hyperlink>
                         </TextBlock>
-                        <TextBlock Text="Change what the visualizer listens to by switching FluentFlyout's output device." FontSize="12" Opacity="0.5" />
+                        <TextBlock Text="{DynamicResource TaskbarVisualizerOutputDeviceDescription}" FontSize="12" Opacity="0.5" />
                     </StackPanel>
                 </ui:CardControl.Header>
                 

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -81,6 +81,8 @@ hides repeat, shuffle and player info</System:String>
     <System:String x:Key="TaskbarVisualizerBaselineDescription">Displays a thin line when audio levels are at zero</System:String>
     <System:String x:Key="TaskbarVisualizerAudioSensitivityTitle">Audio Sensitivity</System:String>
     <System:String x:Key="TaskbarVisualizerAudioSensitivityDescription">How strongly the bars respond to audio loudness</System:String>
+    <System:String x:Key="TaskbarVisualizerOutputDeviceTitle">Output Device</System:String>
+    <System:String x:Key="TaskbarVisualizerOutputDeviceDescription">Change what the visualizer listens to by switching FluentFlyout's output device.</System:String>
     <System:String x:Key="PremiumFeatureTitle">Premium Feature</System:String>
     <System:String x:Key="PremiumFeatureDescription" xml:space="preserve">Your one-time contribution helps me keep FluentFlyout alive and updated. It instantly unlocks all premium customization features, forever.
         


### PR DESCRIPTION
Converts the two plain strings from TaskbarVisualizerPage to DynamicResources and adds them to the en-us dictionary.
This should solve issue #400 ✌️