### PR TITLE
Remove settings window view background for consistency

### DIFF
--- a/FluentFlyoutWPF/App.xaml
+++ b/FluentFlyoutWPF/App.xaml
@@ -20,6 +20,10 @@
                 <ResourceDictionary Source="Resources/Localization/Dictionary-en-US.xaml"/>
             </ResourceDictionary.MergedDictionaries>
             <FontFamily x:Key="SegoeFluentIcons">pack://application:,,,/;component/Fonts/#Segoe Fluent Icons</FontFamily>
+            
+            <!-- override default background colors -->
+            <SolidColorBrush x:Key="NavigationViewContentBackground" Color="Transparent" />
+            <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="Transparent" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/FluentFlyoutWPF/SettingsWindow.xaml
+++ b/FluentFlyoutWPF/SettingsWindow.xaml
@@ -8,7 +8,7 @@
     xmlns:pages="clr-namespace:FluentFlyoutWPF.Pages"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     mc:Ignorable="d"
-    Height="700" MinHeight="300" MinWidth="750" Width="800"
+    Height="700" MinHeight="300" MinWidth="750" Width="900"
     Title="FluentFlyout" Icon="/Resources/FluentFlyout2.ico"
     TextOptions.TextRenderingMode="ClearType" TextOptions.TextFormattingMode="Ideal"
     FontFamily="{Binding FontFamily}"
@@ -28,6 +28,7 @@
                            TransitionDuration="300"
                            IsPaneToggleVisible="true"
                            Margin="0, 40, 0, 0"
+						   FrameMargin="0, 0, 0, 0"
                            OpenPaneLength="250"
                            IsTopSeparatorVisible="false"
                            IsFooterSeparatorVisible="false">


### PR DESCRIPTION
Remove settings window view pane background and border to match Windows 11 Fluent 2 apps more closely, also increase default width of settings window from 800 to 900