### PR TITLE
Implement audio visualizer peak threshold option

### DIFF
--- a/FluentFlyoutWPF/Classes/Visualizer.cs
+++ b/FluentFlyoutWPF/Classes/Visualizer.cs
@@ -183,8 +183,8 @@ namespace FluentFlyoutWPF.Classes
             double maxFreq = 8000; // Hz
             //double minFreq = 40;  // Hz // could be a setting to be bass only
             //double maxFreq = 120; // Hz
-            float minDb = (SettingsManager.Current.TaskbarVisualizerAudioSensitivity * -10f) + -30f;
-            float maxDb = -10f;
+            float minDb = (SettingsManager.Current.TaskbarVisualizerAudioSensitivity * -10f) - 30f;
+            float maxDb = (SettingsManager.Current.TaskbarVisualizerAudioPeakLevel * 10f) - 30f;
 
             float[] currentBars = new float[BarCount];
 

--- a/FluentFlyoutWPF/Pages/TaskbarVisualizerPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarVisualizerPage.xaml
@@ -8,7 +8,7 @@
       xmlns:viewModels="clr-namespace:FluentFlyoutWPF.ViewModels"
       xmlns:utils="clr-namespace:FluentFlyoutWPF.Classes.Utils"
       mc:Ignorable="d"
-      d:DesignHeight="800" d:DesignWidth="800"
+      d:DesignHeight="1000" d:DesignWidth="800"
       Title="TaskbarWidgetPage"
       d:DataContext="{d:DesignInstance viewModels:UserSettings}"
       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -163,6 +163,20 @@
                 <StackPanel Orientation="Horizontal" Opacity="{Binding IsPremiumUnlocked, Converter={StaticResource BoolToFullHalfOpacityConverter}}" >
                     <ui:SymbolIcon Symbol="Subtract24" Width="24" HorizontalAlignment="Center" VerticalAlignment="Center" />
                     <Slider Minimum="1" Maximum="3" Value="{Binding TaskbarVisualizerAudioSensitivity, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" TickFrequency="1" TickPlacement="Both" IsSnapToTickEnabled="True" Width="150" Margin="12,0,12,0" />
+                    <ui:SymbolIcon Symbol="Add24" Width="24" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                </StackPanel>
+            </ui:CardControl>
+
+            <ui:CardControl Icon="{ui:SymbolIcon ArrowAutofitUp24, Filled=False}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource TaskbarVisualizerAudioPeakLevelTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource TaskbarVisualizerAudioPeakLevelDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <StackPanel Orientation="Horizontal" Opacity="{Binding IsPremiumUnlocked, Converter={StaticResource BoolToFullHalfOpacityConverter}}" >
+                    <ui:SymbolIcon Symbol="Subtract24" Width="24" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    <Slider Minimum="1" Maximum="3" Value="{Binding TaskbarVisualizerAudioPeakLevel, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" TickFrequency="1" TickPlacement="Both" IsSnapToTickEnabled="True" Width="150" Margin="12,0,12,0" />
                     <ui:SymbolIcon Symbol="Add24" Width="24" HorizontalAlignment="Center" VerticalAlignment="Center" />
                 </StackPanel>
             </ui:CardControl>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -80,7 +80,9 @@ hides repeat, shuffle and player info</System:String>
     <System:String x:Key="TaskbarVisualizerBaselineTitle">Show Baseline</System:String>
     <System:String x:Key="TaskbarVisualizerBaselineDescription">Displays a thin line when audio levels are at zero</System:String>
     <System:String x:Key="TaskbarVisualizerAudioSensitivityTitle">Audio Sensitivity</System:String>
-    <System:String x:Key="TaskbarVisualizerAudioSensitivityDescription">How strongly the bars respond to audio loudness</System:String>
+    <System:String x:Key="TaskbarVisualizerAudioSensitivityDescription">How loud audio must be before the bars start moving</System:String>
+    <System:String x:Key="TaskbarVisualizerAudioPeakLevelTitle">Audio Peak Threshold</System:String>
+    <System:String x:Key="TaskbarVisualizerAudioPeakLevelDescription">How loud audio must be for the bars to reach their maximum height</System:String>
     <System:String x:Key="TaskbarVisualizerOutputDeviceTitle">Output Device</System:String>
     <System:String x:Key="TaskbarVisualizerOutputDeviceDescription">Change what the visualizer listens to by switching FluentFlyout's output device.</System:String>
     <System:String x:Key="PremiumFeatureTitle">Premium Feature</System:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -440,6 +440,13 @@ public partial class UserSettings : ObservableObject
     public partial int TaskbarVisualizerAudioSensitivity { get; set; }
 
     /// <summary>
+    /// The audio peak level for the taskbar visualizer from 1 to 3.
+    /// This is used to calibrate the visualizer bar height to the audio output.
+    /// </summary>
+    [ObservableProperty]
+    public partial int TaskbarVisualizerAudioPeakLevel { get; set; }
+
+    /// <summary>
     /// Gets whether premium features are unlocked (runtime only, not persisted)
     /// </summary>
     [XmlIgnore]
@@ -535,6 +542,7 @@ public partial class UserSettings : ObservableObject
         TaskbarVisualizerCenteredBars = false;
         TaskbarVisualizerBaseline = false;
         TaskbarVisualizerAudioSensitivity = 2;
+        TaskbarVisualizerAudioPeakLevel = 2;
         AcrylicBlurOpacity = 175;
         LastUpdateNotificationUnixSeconds = 0;
         ShowUpdateNotifications = true;


### PR DESCRIPTION
Add audio visualizer peak threshold option for adjusting how loud audio must be for the bars to reach their maximum height. Also adjust description for Audio Sensitivity option.