### PR TITLE
Add FileSystemHelper and centralize log path.

### DIFF
--- a/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
+++ b/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright © 2024-2026 The FluentFlyout Authors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+using FluentFlyoutWPF.Classes.Utils;
 using FluentFlyoutWPF.ViewModels;
 using System.IO;
 using System.Xml.Serialization;
@@ -19,7 +20,7 @@ public class SettingsManager
         "FluentFlyout",
         "settings.xml"
     );
-    string logFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FluentFlyout", "log.txt");
+    string logFilePath = Path.Combine(FileSystemHelper.GetLogsPath(), "FluentFlyout", "log.txt");
     private static UserSettings _current;
 
     /// <summary>

--- a/FluentFlyoutWPF/Classes/Utils/FileSystemHelper.cs
+++ b/FluentFlyoutWPF/Classes/Utils/FileSystemHelper.cs
@@ -1,0 +1,22 @@
+﻿using FluentFlyout.Classes.Settings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage;
+using System.Windows;
+using System.IO;
+
+namespace FluentFlyoutWPF.Classes.Utils
+{
+    internal class FileSystemHelper
+    {
+        public static string GetLogsPath()
+        {
+            return SettingsManager.Current.IsStoreVersion
+                ? Path.Combine(ApplicationData.Current.LocalCacheFolder.Path, "Roaming", "FluentFlyout")
+                : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FluentFlyout");
+        }
+    }
+}

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -490,12 +490,7 @@ public partial class MainWindow : MicaWindow
     {
         try
         {
-            // path containerized for store version, regular path for non-store version
-            string logFolderPath = SettingsManager.Current.IsStoreVersion
-                ? Path.Combine(ApplicationData.Current.LocalCacheFolder.Path, "Roaming", "FluentFlyout")
-                : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FluentFlyout");
-
-            Process.Start("explorer.exe", logFolderPath);
+            Process.Start("explorer.exe", FileSystemHelper.GetLogsPath());
         }
         catch (Exception ex)
         {

--- a/FluentFlyoutWPF/Pages/HomePage.xaml.cs
+++ b/FluentFlyoutWPF/Pages/HomePage.xaml.cs
@@ -3,6 +3,7 @@
 
 using FluentFlyout.Classes;
 using FluentFlyout.Classes.Settings;
+using FluentFlyoutWPF.Classes.Utils;
 using FluentFlyoutWPF.ViewModels;
 using NLog;
 using System.Diagnostics;
@@ -191,8 +192,7 @@ public partial class HomePage : Page
     {
         try
         {
-            string logFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FluentFlyout");
-            Process.Start("explorer.exe", logFolderPath);
+            Process.Start("explorer.exe", FileSystemHelper.GetLogsPath());
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Introduce FileSystemHelper.GetLogsPath to centralize logic for selecting the log folder (store: ApplicationData.Current.LocalCacheFolder\Roaming\FluentFlyout; non-store: %AppData%\FluentFlyout). Replace duplicated inline path construction in SettingsManager, MainWindow, and HomePage to use the helper and add necessary using directives, reducing duplication and ensuring consistent log path handling across packaged and non-packaged builds.

Solves issue #415 