### PR TITLE
Save settings during cleanup process

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1250,6 +1250,17 @@ public partial class MainWindow : MicaWindow
 
     private void CleanupResources()
     {
+        // try saving settings before exiting if window is still open
+        try
+        {
+            SettingsManager.SaveSettings();
+            Logger.Info("Settings saved successfully on cleanup");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Error while saving settings on cleanup");
+        }
+
         // should be handled automatically on app exit but just in case
         try
         {


### PR DESCRIPTION
Save settings during cleanup process (when quitting app safely through tray or other means). Ending task forcefully could still bypass the cleanup process and skip saving. fixes #485 