### PR TITLE
fix: Set DataContext after restoring settings to fix UI binding issue

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -78,7 +78,6 @@ public partial class MainWindow : MicaWindow
 
     public MainWindow()
     {
-        DataContext = SettingsManager.Current;
         WindowHelper.SetNoActivate(this); // prevents some fullscreen apps from minimizing
         InitializeComponent();
         WindowHelper.SetTopmost(this); // more prevention of fullscreen apps minimizing
@@ -136,6 +135,9 @@ public partial class MainWindow : MicaWindow
             MessageBox.Show($"Failed to restore settings: {ex.Message}");
             Logger.Error(ex, "Failed to restore settings");
         }
+
+        // Set DataContext AFTER restoring settings to ensure it's bound to the correct instance
+        DataContext = SettingsManager.Current;
 
         if (SettingsManager.Current.Startup == true) // add to startup programs if enabled, needs improvement
         {


### PR DESCRIPTION
## Problem

Issue #500: Users report that "everything doesn't appear even when turned on except for lock keys notifications." After force-closing and reopening the app, settings don't work properly.

## Root Cause

In `MainWindow.xaml.cs`, the `DataContext` was being set to `SettingsManager.Current` **before** `RestoreSettings()` was called:

1. `DataContext = SettingsManager.Current` creates a NEW default settings instance (since `_current` is null)
2. `RestoreSettings()` then replaces `_current` with the deserialized instance from the settings file
3. The UI remains bound to the old temporary instance, not the restored one
4. This causes the UI to use default values instead of the user's saved settings

## Fix

Move the `DataContext` assignment to **after** `RestoreSettings()` is called. This ensures the UI is always bound to the correct settings instance.

## Changes

- Moved `DataContext = SettingsManager.Current` from the start of the constructor to after `RestoreSettings()`

Fixes #500
