### PR TITLE
Revert SetWindowPos import and add error logging

### DIFF
--- a/FluentFlyoutMSIX/Package.appxmanifest
+++ b/FluentFlyoutMSIX/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="unchihugo.FluentFlyout"
     Publisher="CN=unchihugo"
-    Version="2.9.0.0" />
+    Version="2.9.2.0" />
 
   <Properties>
     <DisplayName>FluentFlyout</DisplayName>

--- a/FluentFlyoutWPF/Classes/NativeMethods.cs
+++ b/FluentFlyoutWPF/Classes/NativeMethods.cs
@@ -256,9 +256,10 @@ public static partial class NativeMethods
     [LibraryImport("user32.dll")]
     internal static partial uint GetDpiForWindow(IntPtr hMonitor);
 
-    [LibraryImport("user32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    internal static partial bool SetWindowPos(IntPtr hWnd, int hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
+    // DllImport instead of LibraryImport for SetWindowPos because for some reason it functions differently when using LibraryImport,
+    // causing windows to not be topmost and it to be hidden unless you focus on the taskbar.
+    [DllImport("user32.dll", SetLastError = true)]
+    internal static extern bool SetWindowPos(IntPtr hWnd, int hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
 
     [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/FluentFlyoutWPF/Classes/WindowHelper.cs
+++ b/FluentFlyoutWPF/Classes/WindowHelper.cs
@@ -11,6 +11,8 @@ namespace FluentFlyoutWPF.Classes;
 
 public static class WindowHelper
 {
+    private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+
     [StructLayout(LayoutKind.Sequential)]
     public struct RECT
     {
@@ -52,7 +54,14 @@ public static class WindowHelper
     public static void SetPosition(Window window, double x, double y, bool async = false) // set the position of the window, ignoring WPF
     {
         var handle = new WindowInteropHelper(window).Handle;
-        SetWindowPos(handle, 0, (int)x, (int)y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | (async ? SWP_ASYNCWINDOWPOS : (uint)0));
+        uint flags = SWP_NOSIZE | SWP_NOZORDER | (async ? SWP_ASYNCWINDOWPOS : (uint)0);
+        bool result = SetWindowPos(handle, 0, (int)x, (int)y, 0, 0, flags);
+
+        if (!result)
+        {
+            int error = Marshal.GetLastWin32Error();
+            Logger.Warn($"SetPosition failed for '{window.GetType().Name}' (HWND=0x{handle.ToInt64():X}, X={x}, Y={y}, Flags=0x{flags:X}), Win32Error={error}");
+        }
 
         return;
     }


### PR DESCRIPTION
Revert SetWindowPos() function to import with DllImport instead of LibraryImport because for some reason it functions differently when using LibraryImport, causing windows to not be topmost and it to be hidden unless you focus on the taskbar. fixes #505, fixes #514 

Also bump version to 2.9.2 and add logging