### PR TITLE
Revert save settings on close because it caused too many issues

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1254,15 +1254,16 @@ public partial class MainWindow : MicaWindow
     private void CleanupResources()
     {
         // try saving settings before exiting if window is still open
-        try
-        {
-            SettingsManager.SaveSettings();
-            Logger.Info("Settings saved successfully on cleanup");
-        }
-        catch (Exception ex)
-        {
-            Logger.Error(ex, "Error while saving settings on cleanup");
-        }
+        // disabled because it caused too many issues (race conditions, shutdown exceptions), could look into another time
+        //try
+        //{
+        //    SettingsManager.SaveSettings();
+        //    Logger.Info("Settings saved successfully on cleanup");
+        //}
+        //catch (Exception ex)
+        //{
+        //    Logger.Error(ex, "Error while saving settings on cleanup");
+        //}
 
         // should be handled automatically on app exit but just in case
         try


### PR DESCRIPTION
## Summary

Comments out the save settings on close code because it caused too many issues.

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

A lot of users have reported issues with settings like race conditions, shutdown exceptions and premium state issues, most likely caused by the introduction of this feature.

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other