### PR TITLE
Fix lock keys flyout being draggable and standardize CustomWindowChrome

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -159,8 +159,6 @@ public partial class MainWindow : MicaWindow
         WindowStartupLocation = WindowStartupLocation.Manual;
         Left = -Width - 20; // workaround for window appearing on the screen before the animation starts
         CustomWindowChrome.CaptionHeight = 0; // hide the title bar
-        CustomWindowChrome.UseAeroCaptionButtons = false;
-        CustomWindowChrome.GlassFrameThickness = new Thickness(0);
 
         mediaManager.OnAnyMediaPropertyChanged += MediaManager_OnAnyMediaPropertyChanged;
         mediaManager.OnAnyPlaybackStateChanged += CurrentSession_OnPlaybackStateChanged;

--- a/FluentFlyoutWPF/Windows/LockWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/LockWindow.xaml.cs
@@ -28,6 +28,7 @@ public partial class LockWindow : MicaWindow
         WindowHelper.SetNoActivate(this);
         InitializeComponent();
         WindowHelper.SetTopmost(this);
+        CustomWindowChrome.CaptionHeight = 0;
 
         WindowStartupLocation = WindowStartupLocation.Manual;
         Top = -9999; // start off-screen

--- a/FluentFlyoutWPF/Windows/NextUpWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/NextUpWindow.xaml.cs
@@ -27,8 +27,7 @@ public partial class NextUpWindow : MicaWindow
         InitializeComponent();
         WindowHelper.SetTopmost(this);
         CustomWindowChrome.CaptionHeight = 0;
-        CustomWindowChrome.UseAeroCaptionButtons = false;
-        CustomWindowChrome.GlassFrameThickness = new Thickness(0);
+
         if (SettingsManager.Current.NextUpAcrylicWindowEnabled)
         {
             WindowBlurHelper.EnableBlur(this);


### PR DESCRIPTION
## Summary

Fixes lock keys flyout being draggable by adding CustomWindowChrome.CaptionHeight = 0; (title bar height). Also cleaned up CustomWindowChrome code in other flyouts.

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Closes #641 

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other