### PR TITLE
Update FileSystemHelper to search multiple log paths and adjust logging level of some logging

### DIFF
--- a/FluentFlyoutWPF/Classes/LocalizationManager.cs
+++ b/FluentFlyoutWPF/Classes/LocalizationManager.cs
@@ -96,7 +96,7 @@ public static class LocalizationManager
             }
         }
 
-        Logger.Debug("Applying localization for language: " + culture);
+        Logger.Info("Applying localization for language: " + culture);
 
         // change flow direction of all windows
         ApplyFlowDirection(languageCode);
@@ -161,7 +161,7 @@ public static class LocalizationManager
             ? FlowDirection.RightToLeft
             : FlowDirection.LeftToRight;
 
-        Logger.Debug("Applied flow direction: " + SettingsManager.Current.FlowDirection);
+        Logger.Info("Applied flow direction: " + SettingsManager.Current.FlowDirection);
     }
 
     private static void ApplyFontFamily(string culture)

--- a/FluentFlyoutWPF/Classes/Utils/FileSystemHelper.cs
+++ b/FluentFlyoutWPF/Classes/Utils/FileSystemHelper.cs
@@ -1,12 +1,6 @@
 ﻿using FluentFlyout.Classes.Settings;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Windows.Storage;
-using System.Windows;
 using System.IO;
+using Windows.Storage;
 
 namespace FluentFlyoutWPF.Classes.Utils
 {
@@ -14,9 +8,48 @@ namespace FluentFlyoutWPF.Classes.Utils
     {
         public static string GetLogsPath()
         {
-            return SettingsManager.Current.IsStoreVersion
-                ? Path.Combine(ApplicationData.Current.LocalCacheFolder.Path, "Roaming", "FluentFlyout")
-                : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FluentFlyout");
+            if (SettingsManager.Current.IsStoreVersion)
+            {
+                return Path.Combine(ApplicationData.Current.LocalCacheFolder.Path, "Roaming", "FluentFlyout");
+            }
+            else
+            {
+                string path;
+
+                // non-store versions work incredibly weirdly (i haven't figured it out), so we're searching multiple possible locations
+                // first, check %appData%\FluentFlyout
+                try
+                {
+                    path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                        "FluentFlyout");
+                    if (Directory.Exists(path))
+                        return path;
+
+                }
+                catch { }
+
+                // if that doesn't exist, check same path as store version
+                try
+                {
+                    path = Path.Combine(ApplicationData.Current.LocalCacheFolder.Path,
+                        "Roaming",
+                        "FluentFlyout");
+                    if (Directory.Exists(path))
+                        return path;
+                }
+                catch { }
+
+                // if neither of those exist, return hardcoded path
+                // %localAppData%\Packages\unchihugo.FluentFlyout_69b7b6qge1ahj\LocalCache\Roaming\FluentFlyout
+                return Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "Packages",
+                    "unchihugo.FluentFlyout_69b7b6qge1ahj",
+                    "LocalCache",
+                    "Roaming",
+                    "FluentFlyout"
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Updates FileSystemHelper to try searching multiple logs paths on non-store versions because for some reason users all have different directories logging is stored into. Also adjusted logging level of localization language & direction for better debugging in the future.

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Users consistently report logs opening the Documents folder (default explorer fallback if directory doesn't exist) on non-store versions. This should make sure that it points to the right directory.

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other