### PR TITLE
Bump version and fix CI action

### DIFF
--- a/.github/build-files/FluentFlyout_Installer.bat
+++ b/.github/build-files/FluentFlyout_Installer.bat
@@ -1,0 +1,33 @@
+@echo off
+TITLE FluentFlyout Installer
+CLS
+
+SET AppNamePattern=*FluentFlyout*
+
+ECHO ===================================================
+ECHO   Installing FluentFlyout...
+ECHO   Please follow the prompts in the blue window.
+ECHO ===================================================
+ECHO.
+
+cd /d "%~dp0SystemFiles"
+
+:: Run the VS generated script
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& './Add-AppDevPackage.ps1' -SkipLoggingTelemetry"
+
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO.
+    ECHO Something went wrong during installation.
+    PAUSE
+    EXIT
+)
+
+ECHO.
+ECHO Installation complete. Launching App...
+
+:: This PowerShell command finds the Package Family Name of the app we just installed
+:: and launches it using the "shell:AppsFolder" protocol.
+PowerShell -Command "& { $pkg = Get-AppxPackage '%AppNamePattern%' | Select-Object -First 1; if ($pkg) { $exe = Join-Path $pkg.InstallLocation 'FluentFlyout\FluentFlyout.exe'; Start-Process $exe } else { Write-Host 'Could not find installed App.' } }"
+
+:: Close this installer window automatically
+EXIT

--- a/.github/build-files/README.txt
+++ b/.github/build-files/README.txt
@@ -1,0 +1,21 @@
+Thank you for downloading FluentFlyout!
+
+
+INSTALLATION:
+Since you've chosen to install via the GitHub method, there are two ways to install:
+
+1. With FluentFlyout_Installer.bat (recommended):
+   this script will try go through the tedious manual installation process by automating most of
+   the tinkering required to install a program without a paid certificate.
+
+2. With SystemFiles\*.msixbundle:
+   this is the manual method. Follow the installation instructions below: 
+   https://github.com/unchihugo/FluentFlyout?tab=readme-ov-file#using-msixbundle-installer
+
+-----------------------------------------------------------------------------------------------------
+
+Note: GitHub releases provide the full feature set without restrictions. The only trade-off is
+that updates must be done manually. If you prefer automatic background updates, consider
+downloading the Microsoft Store version (https://apps.microsoft.com/detail/9N45NSM4TNBP?mode=direct).
+
+The MS Store version has a one-time purchase to unlock the premium features to support development.

--- a/.github/workflows/build-msix.yml
+++ b/.github/workflows/build-msix.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Decode signing certificate
         run: |
@@ -44,12 +44,10 @@ jobs:
             /p:Platform=$env:PLATFORM `
             /p:UapAppxPackageBuildMode=StoreUpload `
             /p:AppxPackageDir="$env:GITHUB_WORKSPACE\AppxPackages\\" `
-            /p:AppxPackageSigningEnabled=true `
-            /p:PackageCertificateKeyFile="$env:RUNNER_TEMP\cert.pfx" `
-            /p:PackageCertificatePassword="${{ secrets.MSIX_CERT_PASSWORD }}"
+            /p:AppxPackageSigningEnabled=false `
 
       - name: Upload MSIX bundle as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MSIX-${{ env.CONFIGURATION == 'GitHub Release' && 'GitHub_Release' || matrix.configuration }}-${{ env.PLATFORM }}
           path: AppxPackages\*\

--- a/.github/workflows/build-msix.yml
+++ b/.github/workflows/build-msix.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Restore NuGet packages
         run: nuget restore $env:SOLUTION_PATH
 
+      - name: Extract app version
+        run: |
+          [xml]$manifest = Get-Content 'FluentFlyoutMSIX\Package.appxmanifest'
+          $fullVersion = $manifest.Package.Identity.Version
+          $version = ($fullVersion -split '\.')[0..2] -join '.'
+          echo "APP_VERSION=$version" >> $env:GITHUB_ENV
+
       - name: Build & Package (MSIX)
         run: |
           msbuild $env:WAP_PROJECT_PATH `
@@ -46,8 +53,18 @@ jobs:
             /p:AppxPackageDir="$env:GITHUB_WORKSPACE\AppxPackages\\" `
             /p:AppxPackageSigningEnabled=false `
 
-      - name: Upload MSIX bundle as artifact
+      - name: Prepare installer structure
+        run: |
+          $outDir = "$env:GITHUB_WORKSPACE\InstallerOutput"
+          New-Item -ItemType Directory -Path $outDir | Out-Null
+          $testFolder = Get-ChildItem "$env:GITHUB_WORKSPACE\AppxPackages" -Directory |
+            Where-Object { $_.Name -like '*_Test' } | Select-Object -First 1
+          Move-Item $testFolder.FullName "$outDir\SystemFiles"
+          Copy-Item ".github\build-files\FluentFlyout_Installer.bat" "$outDir\"
+          Copy-Item ".github\build-files\README.txt" "$outDir\"
+
+      - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: MSIX-${{ env.CONFIGURATION == 'GitHub Release' && 'GitHub_Release' || matrix.configuration }}-${{ env.PLATFORM }}
-          path: AppxPackages\*\
+          name: FluentFlyout_${{ env.APP_VERSION }}_${{ env.PLATFORM }}_${{ matrix.configuration == 'GitHub Release' && 'Installer' || 'Release' }}
+          path: InstallerOutput\

--- a/FluentFlyoutMSIX/Package.appxmanifest
+++ b/FluentFlyoutMSIX/Package.appxmanifest
@@ -10,7 +10,7 @@
 
   <Identity
     Name="unchihugo.FluentFlyout"
-    Publisher="CN=unchihugo"
+    Publisher="CN=49793F74-1457-4B66-A672-4ED3A640FC76"
     Version="2.10.0.0" />
 
   <Properties>

--- a/FluentFlyoutMSIX/Package.appxmanifest
+++ b/FluentFlyoutMSIX/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="unchihugo.FluentFlyout"
     Publisher="CN=49793F74-1457-4B66-A672-4ED3A640FC76"
-    Version="2.10.0.0" />
+    Version="2.10.1.0" />
 
   <Properties>
     <DisplayName>FluentFlyout</DisplayName>


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->

Fixes the CI action so that the MSIX installer correctly detects existing installs. Automatically add build-files into the installer zip (previously I had stored them locally), and bump version to v2.10.1.

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Better CI pipeline in the future, and stronger trust/security because built artifact == release

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other
