### PR TITLE
Reintroduces the option to hide the Media Flyout when clicking on the…

### DIFF
--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
@@ -103,7 +103,7 @@ public partial class TaskbarWidgetControl : UserControl
 
     private void Grid_MouseEnter(object sender, MouseEventArgs e)
     {
-        if (string.IsNullOrEmpty(SongTitle.Text + SongArtist.Text)) return;
+        if (!SettingsManager.Current.TaskbarWidgetClickable || (string.IsNullOrEmpty(SongTitle.Text) && string.IsNullOrEmpty(SongArtist.Text))) return;
 
         SolidColorBrush targetBackgroundBrush;
         // hover effects with animations, hard-coded colors because I can't find the resource brushes
@@ -146,7 +146,7 @@ public partial class TaskbarWidgetControl : UserControl
 
     private void Grid_MouseLeave(object sender, MouseEventArgs e)
     {
-        if (string.IsNullOrEmpty(SongTitle.Text + SongArtist.Text)) return;
+        if (!SettingsManager.Current.TaskbarWidgetClickable || (string.IsNullOrEmpty(SongTitle.Text) && string.IsNullOrEmpty(SongArtist.Text))) return;
 
         // Animate back to transparent
         var backgroundAnimation = new ColorAnimation
@@ -171,7 +171,7 @@ public partial class TaskbarWidgetControl : UserControl
 
     private void Grid_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
     {
-        if (_mainWindow == null) return;
+        if (!SettingsManager.Current.TaskbarWidgetClickable || _mainWindow == null) return;
 
         // toggle main flyout when clicked
         _mainWindow.ShowMediaFlyout(toggleMode: true, forceShow: true);

--- a/FluentFlyoutWPF/Pages/MediaFlyoutPage.xaml
+++ b/FluentFlyoutWPF/Pages/MediaFlyoutPage.xaml
@@ -33,6 +33,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,24">
                 <Border CornerRadius="10" ClipToBounds="True" Width="164" Height="98">
@@ -42,7 +43,7 @@
                 </Border>
                 <TextBlock Text="{DynamicResource MediaFlyoutDescription}" FontSize="14" FontWeight="Regular" HorizontalAlignment="Stretch" Opacity="0.75" Margin="12,0,0,0" MaxWidth="450" TextWrapping="WrapWithOverflow" />
             </StackPanel>
-            <ui:CardControl Grid.Row="1" Icon="{ui:SymbolIcon VideoPlayPause24}" Margin="0,0,0,24">
+            <ui:CardControl Grid.Row="1" Icon="{ui:SymbolIcon VideoPlayPause24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TextBlockText1}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -51,7 +52,16 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="MediaFlyoutEnabledSwitch" IsChecked="{Binding MediaFlyoutEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="2" Icon="{ui:SymbolIcon ColorBackground24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="2" Icon="{ui:SymbolIcon ExpandUpRight24}" Margin="0,0,0,24">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource TaskbarWidgetClickableTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource TaskbarWidgetClickableDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetClickable, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
+            </ui:CardControl>
+            <ui:CardControl Grid.Row="3" Icon="{ui:SymbolIcon ColorBackground24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource BackgroundBlurTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -65,7 +75,7 @@
                     <ComboBoxItem Content="{DynamicResource BackgroundBlurOption4}" />
                 </ComboBox>
             </ui:CardControl>
-            <ui:CardControl Grid.Row="3" Icon="{ui:SymbolIcon Blur24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="4" Icon="{ui:SymbolIcon Blur24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource AcrylicWindowTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -74,7 +84,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="AcrylicWindowSwitch" IsChecked="{Binding MediaFlyoutAcrylicWindowEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="4" Icon="{ui:SymbolIcon ArrowAutofitWidth24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="5" Icon="{ui:SymbolIcon ArrowAutofitWidth24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource CompactLayoutTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -83,7 +93,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="LayoutSwitch" IsChecked="{Binding CompactLayout, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="5" Icon="{ui:SymbolIcon ArrowMove24}" Margin="0,0,0,12">
+            <ui:CardControl Grid.Row="6" Icon="{ui:SymbolIcon ArrowMove24}" Margin="0,0,0,12">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource FlyoutPositionTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -98,7 +108,7 @@
                     <ComboBoxItem Content="{DynamicResource PositionTopRight}" />
                 </ComboBox>
             </ui:CardControl>
-            <ui:CardControl Grid.Row="6" Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="7" Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource FlyoutStayDurationTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -110,7 +120,7 @@
                     <TextBlock Text="{DynamicResource MillisecondsUnit}" FontSize="14" FontWeight="Regular" Margin="10,0,0,0" VerticalAlignment="Center" />
                 </StackPanel>
             </ui:CardControl>
-            <ui:CardControl Grid.Row="7" Icon="{ui:SymbolIcon TimerOff24}" Margin="0,0,0,12">
+            <ui:CardControl Grid.Row="8" Icon="{ui:SymbolIcon TimerOff24}" Margin="0,0,0,12">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource MediaFlyoutAlwaysDisplay}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -121,7 +131,7 @@
                     <controls:ToggleSwitch IsChecked="{Binding MediaFlyoutAlwaysDisplay, Mode=TwoWay}" />
                 </StackPanel>
             </ui:CardControl>
-            <ui:CardControl Grid.Row="8" Icon="{ui:SymbolIcon AlignLeft24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="9" Icon="{ui:SymbolIcon AlignLeft24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource CenterTitleArtistTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -130,7 +140,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="CenterTitleArtistSwitch" IsChecked="{Binding CenterTitleArtist, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="9" Icon="{ui:SymbolIcon Subtitles24}" Margin="0,0,0,12">
+            <ui:CardControl Grid.Row="10" Icon="{ui:SymbolIcon Subtitles24}" Margin="0,0,0,12">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource ShowMediaPlayerNameTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -138,7 +148,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="PlayerInfoSwitch" IsChecked="{Binding PlayerInfoEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="10" Icon="{ui:SymbolIcon ArrowRepeatAll24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="11" Icon="{ui:SymbolIcon ArrowRepeatAll24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource RepeatButtonTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -147,7 +157,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="RepeatSwitch" IsChecked="{Binding RepeatEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="11" Icon="{ui:SymbolIcon ArrowShuffle24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="12" Icon="{ui:SymbolIcon ArrowShuffle24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource ShuffleButtonTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -156,7 +166,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="ShuffleSwitch" IsChecked="{Binding ShuffleEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="12" Icon="{ui:SymbolIcon SlideArrowRight24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="13" Icon="{ui:SymbolIcon SlideArrowRight24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource ShowSeekbarTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -165,8 +175,8 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="SeekbarSwitch" IsChecked="{Binding SeekbarEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:InfoBar Grid.Row="13" Title="{DynamicResource UnsupportedControlsWarning}" IsOpen="True" Severity="Warning" IsClosable="False" Margin="0,0,0,12" />
-            <ui:CardControl Grid.Row="14" Icon="{ui:SymbolIcon Pause24}" Margin="0,0,0,3">
+            <ui:InfoBar Grid.Row="14" Title="{DynamicResource UnsupportedControlsWarning}" IsOpen="True" Severity="Warning" IsClosable="False" Margin="0,0,0,12" />
+            <ui:CardControl Grid.Row="15" Icon="{ui:SymbolIcon Pause24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource PauseOtherMediaTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -175,7 +185,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="PauseOtherSessionsEnabledSwitch" IsChecked="{Binding PauseOtherSessionsEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="15" Icon="{ui:SymbolIcon SpeakerOff24}" Margin="0,0,0,76">
+            <ui:CardControl Grid.Row="16" Icon="{ui:SymbolIcon SpeakerOff24}" Margin="0,0,0,76">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource MediaFlyoutExcludeVolumeTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />

--- a/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
@@ -31,7 +31,6 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <StackPanel Orientation="Horizontal" Margin="0,0,0,24">
                 <Border CornerRadius="10" ClipToBounds="True" Width="164" Height="98">
@@ -189,7 +188,7 @@
                 </StackPanel>
             </ui:CardExpander>
 
-            <ui:CardControl Grid.Row="9" Icon="{ui:SymbolIcon ColorBackground24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="7" Icon="{ui:SymbolIcon ColorBackground24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TaskbarWidgetBackgroundBlurTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -198,7 +197,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetBackgroundBlur, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="10" Icon="{ui:SymbolIcon EyeOff24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="8" Icon="{ui:SymbolIcon EyeOff24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TaskbarWidgetHideCompletelyTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -207,7 +206,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetHideCompletely, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="11" Icon="{ui:SymbolIcon EyeLines24}" Margin="0,0,0,12">
+            <ui:CardControl Grid.Row="9" Icon="{ui:SymbolIcon EyeLines24}" Margin="0,0,0,12">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TaskbarWidgetAutoHideTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -216,7 +215,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetAutoHide, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="12" Icon="{ui:SymbolIcon VideoPlayPause24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="10" Icon="{ui:SymbolIcon VideoPlayPause24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TaskbarWidgetControlsTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -225,7 +224,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetControlsEnabled, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="13" Icon="{ui:SymbolIcon ArrowMove24}" Margin="0,0,0,12">
+            <ui:CardControl Grid.Row="11" Icon="{ui:SymbolIcon ArrowMove24}" Margin="0,0,0,12">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TaskbarWidgetControlsPositionTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -237,7 +236,7 @@
                     <ComboBoxItem Content="{DynamicResource PositionRight}" />
                 </ComboBox>
             </ui:CardControl>
-            <ui:CardControl Grid.Row="14" Icon="{ui:SymbolIcon Wand24}" Margin="0,0,0,76">
+            <ui:CardControl Grid.Row="12" Icon="{ui:SymbolIcon Wand24}" Margin="0,0,0,76">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TaskbarWidgetAnimatedTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -5,7 +5,7 @@
     <System:String x:Key="Disabled">Disabled</System:String>
     <System:String x:Key="MediaFlyoutTitle">Media Flyout</System:String>
     <System:String x:Key="MediaFlyoutDescription">When listening to media, press any media or volume key (play/pause, volume up/down, etc.) on your keyboard to display the flyout. Displays media info, along with playback controls and more.</System:String>
-    <System:String x:Key="TextBlockText1">Enable Media Flyout</System:String>
+    <System:String x:Key="TextBlockText1">Enable Media Flyout on Media Key</System:String>
     <System:String x:Key="TextBlockText3">Display a flyout when you press a media key</System:String>
     <System:String x:Key="MediaFlyoutExcludeVolumeTitle">Exclude Volume Keys</System:String>
     <System:String x:Key="MediaFlyoutExcludeVolumeDescription">Do not display the flyout when pressing volume up/down/mute</System:String>
@@ -58,6 +58,8 @@ hides repeat, shuffle and player info</System:String>
     <System:String x:Key="TaskbarWidgetPaddingDescription">Turn this feature on if you have Windows Widgets enabled</System:String>
     <System:String x:Key="TaskbarWidgetManualPaddingTitle">Custom Padding</System:String>
     <System:String x:Key="TaskbarWidgetManualPaddingDescription">Add extra padding (default: 0px)</System:String>
+    <System:String x:Key="TaskbarWidgetClickableTitle">Enable Media Flyout on Taskbar Widget</System:String>
+    <System:String x:Key="TaskbarWidgetClickableDescription">Display a flyout when you press the taskbar widget and media is Present</System:String>
     <System:String x:Key="TaskbarWidgetBackgroundBlurTitle">Background Blur</System:String>
     <System:String x:Key="TaskbarWidgetBackgroundBlurDescription">Add background blur effect to the taskbar widget</System:String>
     <System:String x:Key="TaskbarWidgetHideCompletelyTitle">Hide Completely When No Media Is Present</System:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -391,6 +391,12 @@ public partial class UserSettings : ObservableObject
     }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the taskbar widget is clickable
+    /// </summary>
+    [ObservableProperty]
+    public partial bool TaskbarWidgetClickable { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indication whether the taskbar widget background should have a blur effect
     /// </summary>
     [ObservableProperty]
@@ -573,6 +579,7 @@ public partial class UserSettings : ObservableObject
         TaskbarWidgetPosition = 0;
         TaskbarWidgetPadding = true;
         TaskbarWidgetManualPadding = 0;
+        TaskbarWidgetClickable = true;
         TaskbarWidgetBackgroundBlur = false;
         TaskbarWidgetHideCompletely = false;
         TaskbarWidgetControlsEnabled = false;
@@ -658,6 +665,12 @@ public partial class UserSettings : ObservableObject
     }
 
     partial void OnTaskbarWidgetManualPaddingChanged(int oldValue, int newValue)
+    {
+        if (oldValue == newValue || _initializing) return;
+        UpdateTaskbar();
+    }
+
+    partial void OnTaskbarWidgetClickableChanged(bool oldValue, bool newValue)
     {
         if (oldValue == newValue || _initializing) return;
         UpdateTaskbar();


### PR DESCRIPTION
## Summary

Reintroduces the option to hide the Media Flyout when clicking on the Taskbar Widget, moves it to the Media Flyout settings and implements recommendations from original code review.

## Motivation

https://github.com/unchihugo/FluentFlyout/issues/668

Closes 668

## Type of Change

- [X] Feature
- [ ] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

- This partially reverts commit 37c10978f3de47f3a878dc12bb0aec361a263d22 ("Removed Taskbar Widget Clickable and Closeable in settings").
- This implements the code review https://github.com/unchihugo/FluentFlyout/pull/556/changes/37c10978f3de47f3a878dc12bb0aec361a263d22#r2969772139 . 
- This moves the TaskbarWidgetClickable option form TaskbarWidgetPage to MediaFlyoutPage and corrects grid row index.

## Additional Information

<img width="897" height="697" alt="image" src="https://github.com/user-attachments/assets/ef25a057-aca4-4be1-bebb-4fad86875927" />

## Checklist
- [X] Code changes are manually tested and working.
- [X] Formatting and naming are consistent with the project.
- [X] Self-review of changes is done.
<!-- AI usage -->
- [X] AI tools were used (if yes, I reviewed and fully understand the changes myself).