### PR TITLE
small fix for #543 acrylic not refreshing on theme switch

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1444,10 +1444,14 @@ public partial class MainWindow : MicaWindow
             return 0;
         }
         else if (msg == WM_SETTINGCHANGE) // Windows theme or system settings changed
-        {  
+        {
             try
             {
                 ThemeManager.UpdateTaskbarWidget();
+                if (SettingsManager.Current.MediaFlyoutAcrylicWindowEnabled)
+                {
+                    WindowBlurHelper.EnableBlur(this);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
hey, saw issue #543 and gave it a shot

noticed the acrylic blur doesnt get refreshed when u switch windows themes, so the flyout stays with the old color until u open it again. added a call to re-enable the blur in the wm_settingchange handler, same pattern thats already in thememanager.cs. only runs if the acrylic setting is on so nothing changes for users who have it off.

tested it locally by flipping light/dark a few times and the blur updates right away now

fixes #543