### PR TITLE
Taskbar Widget - Song Info toggle

### DIFF
--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
@@ -61,7 +61,7 @@ public partial class TaskbarWidgetControl : UserControl
         }
 
         Background = new SolidColorBrush(Color.FromArgb(1, 0, 0, 0)); ;
-        
+
         // Initialize control order
         ReorderControls();
     }
@@ -179,27 +179,34 @@ public partial class TaskbarWidgetControl : UserControl
 
     public (double logicalWidth, double logicalHeight) CalculateSize(double dpiScale)
     {
-        // calculate widget width - use cached values if text hasn't changed
-        string currentTitle = SongTitle.Text;
-        string currentArtist = SongArtist.Text;
 
-        if (!string.Equals(currentTitle, _cachedTitleText, StringComparison.Ordinal))
+        double logicalWidth = 45;
+
+        if (SettingsManager.Current.TaskbarSongInfoEnabled && SongInfoStackPanel.Visibility == Visibility.Visible)
         {
-            _cachedTitleWidth = StringWidth.GetStringWidth(currentTitle, 400);
-            _cachedTitleText = currentTitle;
-        }
-        if (!string.Equals(currentArtist, _cachedArtistText, StringComparison.Ordinal))
-        {
-            _cachedArtistWidth = StringWidth.GetStringWidth(currentArtist, 400);
-            _cachedArtistText = currentArtist;
-        }
 
-        double logicalWidth = Math.Max(_cachedTitleWidth, _cachedArtistWidth) + 55; // add margin for cover image
-        // maximum width limit, same as Windows native widget
-        logicalWidth = Math.Min(logicalWidth, _nativeWidgetsPadding / _scale);
+            // calculate widget width - use cached values if text hasn't changed
+            string currentTitle = SongTitle.Text;
+            string currentArtist = SongArtist.Text;
 
-        SongTitle.Width = Math.Max(logicalWidth - 58, 0);
-        SongArtist.Width = Math.Max(logicalWidth - 58, 0);
+            if (!string.Equals(currentTitle, _cachedTitleText, StringComparison.Ordinal))
+            {
+                _cachedTitleWidth = StringWidth.GetStringWidth(currentTitle, 400);
+                _cachedTitleText = currentTitle;
+            }
+            if (!string.Equals(currentArtist, _cachedArtistText, StringComparison.Ordinal))
+            {
+                _cachedArtistWidth = StringWidth.GetStringWidth(currentArtist, 400);
+                _cachedArtistText = currentArtist;
+            }
+
+            logicalWidth = Math.Max(_cachedTitleWidth, _cachedArtistWidth) + 55; // add margin for cover image
+                                                                                // maximum width limit, same as Windows native widget
+            logicalWidth = Math.Min(logicalWidth, _nativeWidgetsPadding / _scale);
+
+            SongTitle.Width = Math.Max(logicalWidth - 58, 0);
+            SongArtist.Width = Math.Max(logicalWidth - 58, 0);
+        }
 
         // add space for playback controls if enabled and visible
         if (SettingsManager.Current.TaskbarWidgetControlsEnabled && ControlsStackPanel.Visibility == Visibility.Visible)
@@ -251,6 +258,19 @@ public partial class TaskbarWidgetControl : UserControl
         {
             _isPaused = true;
         }
+
+        // adjust UI based on available controls
+        Dispatcher.Invoke(() =>
+        {
+            if (!SettingsManager.Current.TaskbarSongInfoEnabled)
+            {
+                SongInfoStackPanel.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                SongInfoStackPanel.Visibility = Visibility.Visible;
+            }
+        });
 
         // adjust UI based on available controls
         Dispatcher.Invoke(() =>
@@ -341,6 +361,9 @@ public partial class TaskbarWidgetControl : UserControl
             ControlsStackPanel.Visibility = SettingsManager.Current.TaskbarWidgetControlsEnabled
                 ? Visibility.Visible
                 : Visibility.Collapsed;
+            SongInfoStackPanel.Visibility = SettingsManager.Current.TaskbarSongInfoEnabled
+                ? Visibility.Visible
+                : Visibility.Collapsed;
 
             Visibility = Visibility.Visible;
         });
@@ -369,11 +392,15 @@ public partial class TaskbarWidgetControl : UserControl
                 EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut }
             };
 
-            // Apply animations
-            SongInfoStackPanel.BeginAnimation(OpacityProperty, opacityAnimation);
-            TranslateTransform translateTransform = new();
-            SongInfoStackPanel.RenderTransform = translateTransform;
-            translateTransform.BeginAnimation(TranslateTransform.XProperty, translateAnimation);
+            // don't play SongInfoStackPanel animation if it's not enabled
+            if (SettingsManager.Current.TaskbarSongInfoEnabled)
+            {
+                // Apply animations
+                SongInfoStackPanel.BeginAnimation(OpacityProperty, opacityAnimation);
+                TranslateTransform translateTransform = new();
+                SongInfoStackPanel.RenderTransform = translateTransform;
+                translateTransform.BeginAnimation(TranslateTransform.XProperty, translateAnimation);
+            }
 
             // don't play ControlsStackPanel animation if it's not enabled
             if (!SettingsManager.Current.TaskbarWidgetControlsEnabled)

--- a/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
@@ -32,6 +32,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <StackPanel Orientation="Horizontal" Margin="0,0,0,24">
                 <Border CornerRadius="10" ClipToBounds="True" Width="164" Height="98">
@@ -225,7 +226,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetControlsEnabled, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="13" Icon="{ui:SymbolIcon ArrowMove24}" Margin="0,0,0,12">
+            <ui:CardControl Grid.Row="13" Icon="{ui:SymbolIcon ArrowMove24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TaskbarWidgetControlsPositionTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -237,7 +238,16 @@
                     <ComboBoxItem Content="{DynamicResource PositionRight}" />
                 </ComboBox>
             </ui:CardControl>
-            <ui:CardControl Grid.Row="14" Icon="{ui:SymbolIcon Wand24}" Margin="0,0,0,76">
+            <ui:CardControl Grid.Row="14" Icon="{ui:SymbolIcon Info24}" Margin="0,0,0,12">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource TaskbarWidgetSongInfoTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource TaskbarWidgetSongInfoDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <controls:ToggleSwitch IsChecked="{Binding TaskbarSongInfoEnabled, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
+            </ui:CardControl>
+            <ui:CardControl Grid.Row="15" Icon="{ui:SymbolIcon Wand24}" Margin="0,0,0,76">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TaskbarWidgetAnimatedTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -66,6 +66,8 @@ hides repeat, shuffle and player info</System:String>
     <System:String x:Key="TaskbarWidgetAutoHideDescription">Hides the widget automatically when media is paused</System:String>
     <System:String x:Key="TaskbarWidgetControlsTitle">Widget Media Controls</System:String>
     <System:String x:Key="TaskbarWidgetControlsDescription">Show media control buttons on the widget</System:String>
+    <System:String x:Key="TaskbarWidgetSongInfoTitle">Widget Media Song Info</System:String>
+    <System:String x:Key="TaskbarWidgetSongInfoDescription">Show song info on the widget, as opposed to just the icon</System:String>
     <System:String x:Key="TaskbarWidgetControlsPositionTitle">Media Controls Position</System:String>
     <System:String x:Key="TaskbarWidgetControlsPositionDescription">Choose where to display the media control buttons</System:String>
     <System:String x:Key="PositionLeft">Left</System:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -249,7 +249,7 @@ public partial class UserSettings : ObservableObject
     /// 0 = Default behavior, 1 = Monitor containing the focused window, 2 = Monitor containing the cursor.
     [ObservableProperty]
     public partial int LockKeysMonitorPreference { get; set; }
-    
+
     /// <summary>
     /// Determines if the user has updated to a new version
     /// </summary>
@@ -339,7 +339,7 @@ public partial class UserSettings : ObservableObject
     /// </summary>
     [ObservableProperty]
     public partial int TaskbarWidgetSelectedMonitor { get; set; }
-    
+
     /// <summary>
     /// Autohide Widget after a few milliseconds after pause 
     /// </summary>
@@ -413,6 +413,12 @@ public partial class UserSettings : ObservableObject
     /// </summary>
     [ObservableProperty]
     public partial int TaskbarWidgetControlsPosition { get; set; }
+
+    /// <summary>
+    /// Whether or not to show the song info in the taskbar widget
+    /// </summary>
+    [ObservableProperty]
+    public partial bool TaskbarSongInfoEnabled { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the taskbar widget should play animations.
@@ -577,6 +583,7 @@ public partial class UserSettings : ObservableObject
         TaskbarWidgetHideCompletely = false;
         TaskbarWidgetControlsEnabled = false;
         TaskbarWidgetControlsPosition = 1;
+        TaskbarSongInfoEnabled = true;
         TaskbarWidgetAnimated = true;
         TaskbarVisualizerEnabled = false;
         TaskbarVisualizerPosition = 1;
@@ -684,9 +691,15 @@ public partial class UserSettings : ObservableObject
     partial void OnTaskbarWidgetControlsPositionChanged(int oldValue, int newValue)
     {
         if (oldValue == newValue || _initializing) return;
-        
+
         MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
         mainWindow.taskbarWindow?.Widget?.ReorderControls();
+    }
+
+    partial void OnTaskbarSongInfoEnabledChanged(bool oldValue, bool newValue)
+    {
+        if (oldValue == newValue || _initializing) return;
+        UpdateTaskbar();
     }
 
     partial void OnTaskbarVisualizerPositionChanged(int oldValue, int newValue)


### PR DESCRIPTION
## Summary

Added the ability to toggle artist info in the taskbar widget, akin to the taskbar control setting.

## Motivation

This goal originally came from personal experience, using Windhawk with a narrower taskbar or also playing songs with longer names. I realised that the amount of space the widget could take could not really be anticipated, and would thus sometimes end up covering half my taskbar. This led me to realise that the ability to have a small widget with just the icon with or without the controls - aka a constant size - would be a nice, sleek addendum. Never developed or contributed to a .NET/Windows App, but took me about 20 minutes to get the reins, so sorry if it seems rusty/primitive!

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

* Toggle added to show/hide song and artist info
* Relevant entry put into the `en-US` localisation (I will add more in languages I know when/if we confirm the next steps or whether this will be dropped)
* Option in the Taskbar Widget added, as well as the relevant behaviour and settings.

## Additional Information

Another method I considered implementing was consolidating the media controls and song info toggles into one "Taskbar widget display" (or similarly named) drop-down, with options like "Full (Song Info and Controls)", "Concise (Icon and Controls only)", etc.
However, I felt like this addition of a toggle was a simple solution. Which do you think would be a more appropriate implementation given your vision for FF?

Also, tackling the same size point, I also wonder if adding a "constant/max-size" option for when song info is shown would be a good target to implement next - let me know!

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
<!-- AI usage -->
- [ ] AI tools were used (if yes, I reviewed and fully understand the changes myself).