### PR TITLE
Fix settings autosave and publish icon configuration

### DIFF
--- a/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
+++ b/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
@@ -53,6 +53,11 @@ public class SettingsManager
         set => _current = value;
     }
 
+    internal static bool IsCurrentSettings(UserSettings settings)
+    {
+        return ReferenceEquals(_current, settings);
+    }
+
     /// <summary>
     /// Restores the settings `SettingsManager.Current` from the settings file.
     /// </summary>

--- a/FluentFlyoutWPF/FluentFlyout.csproj
+++ b/FluentFlyoutWPF/FluentFlyout.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows10.0.22000.0</TargetFramework>
+    <ApplicationIcon>Resources\FluentFlyout2.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
@@ -52,6 +53,7 @@
     </Content>
     <Content Include="Resources\FluentFlyout2.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
     <Content Include="Resources\FluentFlyoutDemo9.1.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -9,6 +9,7 @@ using FluentFlyout.Controls;
 using FluentFlyoutWPF.Classes;
 using FluentFlyoutWPF.Models;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Windows;
 using System.Xml.Serialization;
 
@@ -528,6 +529,15 @@ public partial class UserSettings : ObservableObject
     public partial bool LegacyTaskbarWidthEnabled { get; set; }
 
     [XmlIgnore]
+    private static readonly Dictionary<string, bool> PersistedPropertyLookup = typeof(UserSettings)
+        .GetProperties()
+        .ToDictionary(
+            static property => property.Name,
+            static property => !Attribute.IsDefined(property, typeof(XmlIgnoreAttribute)),
+            StringComparer.Ordinal
+        );
+
+    [XmlIgnore]
     private bool _initializing = true;
 
     public UserSettings()
@@ -606,6 +616,23 @@ public partial class UserSettings : ObservableObject
     internal void CompleteInitialization()
     {
         _initializing = false;
+    }
+
+    protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+    {
+        base.OnPropertyChanged(e);
+
+        if (_initializing || !SettingsManager.IsCurrentSettings(this) || string.IsNullOrWhiteSpace(e.PropertyName))
+        {
+            return;
+        }
+
+        if (!PersistedPropertyLookup.TryGetValue(e.PropertyName, out bool shouldPersist) || !shouldPersist)
+        {
+            return;
+        }
+
+        SettingsManager.SaveSettings();
     }
 
     partial void OnAppLanguageChanged(string oldValue, string newValue)


### PR DESCRIPTION
This PR addresses two user-facing reliability issues observed in FluentFlyoutWPF:

Settings changes not always persisting across sessions.

Startup failures in published builds caused by a missing icon asset.

🛠️ Settings Persistence Hardening
Centralized persistence: Integrated save operations directly into property change notifications within the settings model.

Initialization Safeguards: Added logic to ensure autosave only triggers when:

The application initialization has fully completed.

The modified instance is the active settings instance.

The changed property is intended for persistence (ignoring runtime-only or XmlIgnore properties).

This refactoring eliminates the need for manual save calls throughout the codebase and ensures deterministic persistence behavior.

🚀 Publish/Runtime Reliability
Icon Declaration: Explicitly declared the application icon in the project properties.

Asset Management: Enforced the icon asset copy to the publish output directory using PreserveNewest.

This fix prevents XamlParseException and resource resolution failures in standalone builds, ensuring the icon is correctly bundled during the publish process.

⚖️ Scope and Risk
Changes are minimal and isolated to the settings persistence flow and project asset configuration.

There is no functional redesign of UI or core runtime behavior, focusing strictly on making persistence reliable and the publish output complete.

✅ Validation Performed
Build/Publish: Successfully completed a Release publish for win-x64.

Asset Verification: Confirmed the required icon asset is present in the published output folder.

Runtime Test: Verified the published executable starts correctly, persists settings immediately upon change, and survives process termination/restarts.

Log Audit: Confirmed that startup logs are clean of ERROR or WARN entries regarding resource resolution.

💡 Potential Follow-up
Consider implementing a debounce or throttle strategy for the autosave mechanism if high-frequency property changes lead to excessive disk I/O in future versions.