### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/FluentFlyoutMSIX/FluentFlyoutMSIX.wapproj
+++ b/FluentFlyoutMSIX/FluentFlyoutMSIX.wapproj
@@ -145,7 +145,7 @@
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentFlyoutWPF\FluentFlyout.csproj" />

--- a/FluentFlyoutWPF/FluentFlyout.csproj
+++ b/FluentFlyoutWPF/FluentFlyout.csproj
@@ -41,11 +41,11 @@
     <PackageReference Include="Dubya.WindowsMediaController" Version="2.5.6" />
     <PackageReference Include="MicaWPF" Version="6.3.2" />
 	<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-	<PackageReference Include="NAudio" Version="2.2.1" />
-    <PackageReference Include="NLog" Version="6.0.6" />
-    <PackageReference Include="WPF-UI" Version="4.2.0" />
-    <PackageReference Include="WPF-UI.Tray" Version="4.2.0" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+	<PackageReference Include="NAudio" Version="2.3.0" />
+    <PackageReference Include="NLog" Version="6.1.2" />
+    <PackageReference Include="WPF-UI" Version="4.2.1" />
+    <PackageReference Include="WPF-UI.Tray" Version="4.2.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="NLog.config">


### PR DESCRIPTION
## Summary

Update NuGet packages to latest versions

## Motivation

WPF-UI 4.2.1 introduces:
- `fix: Update SystemThemeWatcher WndProc to listen to Windows theme changes`, which will be useful for fixing issues related to theme switching via Windows but the Acrylic window backgrounds not updating with it.
- memory leak issues related to disposing windows.

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [ ] Bug fix
- [x] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other