### PR TITLE
Fix Acrylic window bg colors not updating from Windows theme change

### DIFF
--- a/FluentFlyoutWPF/Classes/WindowBlurHelper.cs
+++ b/FluentFlyoutWPF/Classes/WindowBlurHelper.cs
@@ -89,8 +89,7 @@ public static class WindowBlurHelper
     /// <param name="newBlurOpacity">New opacity value (0-255)</param>
     public static void AdjustBlurOpacityForAllWindows(uint newBlurOpacity)
     {
-        if (!SettingsManager.Current.IsPremiumUnlocked) return;
-        newBlurOpacity = Math.Clamp(newBlurOpacity, 0, 255);
+        newBlurOpacity = SettingsManager.Current.IsPremiumUnlocked ? Math.Clamp(newBlurOpacity, 0, 255) : 175;
 
         foreach (Window window in Application.Current.Windows)
         {

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1494,15 +1494,28 @@ public partial class MainWindow : MicaWindow
             handled = true;
             return 0;
         }
-        else if (msg == WM_SETTINGCHANGE) // Windows theme or system settings changed
-        {  
+        else if (msg == WM_SETTINGCHANGE) // system settings changed
+        {
+            if (lParam == IntPtr.Zero)
+                return 0;
+
+            // check if the changed setting is related to theme or accent color
+            string? changedSetting = Marshal.PtrToStringUni(lParam);
+            if (changedSetting != "ImmersiveColorSet" && changedSetting != "WindowsThemeElement")
+                return 0;
+
+            Logger.Info($"System setting changed: {changedSetting}, from {msg}");
+
             try
             {
+                // update theme for taskbar widget since it's independent from the main app theme
                 ThemeManager.UpdateTaskbarWidget();
+                // update Acrylic windows background colors
+                WindowBlurHelper.AdjustBlurOpacityForAllWindows(SettingsManager.Current.AcrylicBlurOpacity);
             }
             catch (Exception ex)
             {
-                Logger.Error(ex, "Failed to apply theme changes to taskbar widgets");
+                Logger.Error(ex, "Failed to apply theme changes to taskbar widgets or Acrylic windows");
             }
             return 0;
         }


### PR DESCRIPTION
## Summary

Fix Acrylic window background colors not updating from Windows theme changes by adding method to WndProc, partially made possible with WPF-UI v4.2.1 bump.

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Closes #543 

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other