### PR TITLE
[Feature] Add taskbar widget overlap prevention feature

### DIFF
--- a/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
@@ -174,6 +174,30 @@
                             </controls:ToggleSwitch.Style>
                         </controls:ToggleSwitch>
                     </ui:CardControl>
+                    <ui:CardControl Icon="{ui:SymbolIcon ArrowFit20}" Margin="0,0,0,3">
+                        <ui:CardControl.Header>
+                            <StackPanel Orientation="Vertical">
+                                <TextBlock Text="{DynamicResource TaskbarWidgetPreventStartOverlapTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                                <TextBlock Text="{DynamicResource TaskbarWidgetPreventStartOverlapDescription}" FontSize="12" Opacity="0.5" />
+                            </StackPanel>
+                        </ui:CardControl.Header>
+                        <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetPreventStartOverlap, Mode=TwoWay}">
+                            <controls:ToggleSwitch.Style>
+                                <Style TargetType="controls:ToggleSwitch" BasedOn="{StaticResource {x:Type controls:ToggleSwitch}}">
+                                    <Setter Property="IsEnabled" Value="False" />
+                                    <Style.Triggers>
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding IsPremiumUnlocked}" Value="True" />
+                                                <Condition Binding="{Binding TaskbarWidgetPosition}" Value="0" />
+                                            </MultiDataTrigger.Conditions>
+                                            <Setter Property="IsEnabled" Value="True" />
+                                        </MultiDataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </controls:ToggleSwitch.Style>
+                        </controls:ToggleSwitch>
+                    </ui:CardControl>
                     <ui:CardControl Icon="{ui:SymbolIcon ArrowFit20}" Margin="0,0,0,0">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -56,6 +56,8 @@ hides repeat, shuffle and player info</System:String>
     <System:String x:Key="TaskbarWidgetPaddingSettingsDescription">Adjust the padding around the widget to fit your taskbar style</System:String>
     <System:String x:Key="TaskbarWidgetPaddingTitle">Automatic Padding for Windows Widgets button</System:String>
     <System:String x:Key="TaskbarWidgetPaddingDescription">Turn this feature on if you have Windows Widgets enabled</System:String>
+    <System:String x:Key="TaskbarWidgetPreventStartOverlapTitle">Prevent overlap with Start button</System:String>
+    <System:String x:Key="TaskbarWidgetPreventStartOverlapDescription">For left alignment, shrink widget width if space before Start is limited</System:String>
     <System:String x:Key="TaskbarWidgetManualPaddingTitle">Custom Padding</System:String>
     <System:String x:Key="TaskbarWidgetManualPaddingDescription">Add extra padding (default: 0px)</System:String>
     <System:String x:Key="TaskbarWidgetBackgroundBlurTitle">Background Blur</System:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -364,6 +364,13 @@ public partial class UserSettings : ObservableObject
     public partial bool TaskbarWidgetPadding { get; set; }
 
     /// <summary>
+    /// Prevent overlap with the Start button by shrinking the taskbar widget width when there is not enough space.
+    /// Applies only when the widget position is set to left.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool TaskbarWidgetPreventStartOverlap { get; set; }
+
+    /// <summary>
     /// Manual padding value in pixels applied to the taskbar widget
     /// </summary>
     [ObservableProperty]
@@ -623,6 +630,7 @@ public partial class UserSettings : ObservableObject
         TaskbarWidgetSelectedMonitor = 0;
         TaskbarWidgetPosition = 0;
         TaskbarWidgetPadding = true;
+        TaskbarWidgetPreventStartOverlap = false;
         TaskbarWidgetManualPadding = 0;
         TaskbarWidgetBackgroundBlur = false;
         TaskbarWidgetHideCompletely = false;
@@ -715,6 +723,12 @@ public partial class UserSettings : ObservableObject
     }
 
     partial void OnTaskbarWidgetManualPaddingChanged(int oldValue, int newValue)
+    {
+        if (oldValue == newValue || _initializing) return;
+        UpdateTaskbar();
+    }
+
+    partial void OnTaskbarWidgetPreventStartOverlapChanged(bool oldValue, bool newValue)
     {
         if (oldValue == newValue || _initializing) return;
         UpdateTaskbar();

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
@@ -33,10 +33,13 @@ public partial class TaskbarWindow : Window
     private AutomationElement? _widgetElement;
     private AutomationElement? _trayElement;
     private AutomationElement? _taskbarFrameElement;
+    private AutomationElement? _startButtonElement;
+    private AutomationElement? _startButtonByNameElement;
     // reference to main window for flyout functions
     private MainWindow? _mainWindow;
     private int _lastSelectedMonitor = -1;
     private bool _positionUpdateInProgress;
+    private bool _startButtonLookupWarningLogged;
     private readonly Dictionary<string, Task> _pendingAutomationTasks = [];
     
     private GlobalSystemMediaTransportControlsSessionPlaybackStatus? _lastPlaybackStatus;
@@ -546,10 +549,44 @@ public partial class TaskbarWindow : Window
 
         widgetLeft += SettingsManager.Current.TaskbarWidgetManualPadding;
 
+        int finalPhysicalWidth = physicalWidth;
+        if (SettingsManager.Current.TaskbarWidgetPosition == 0 && SettingsManager.Current.TaskbarWidgetPreventStartOverlap)
+        {
+            const int startButtonGap = 2;
+            (bool foundStartButton, Rect startButtonRect) = GetStartButtonRect(taskbarHandle);
+            bool hasValidStartBounds = foundStartButton &&
+                startButtonRect.Width > 0 &&
+                startButtonRect.Left > taskbarRect.Left &&
+                startButtonRect.Left < taskbarRect.Right &&
+                startButtonRect.Left < (taskbarRect.Left + taskbarRect.Right) / 2.0;
+
+            if (hasValidStartBounds)
+            {
+                _startButtonLookupWarningLogged = false;
+
+                int startLeftInTaskbar = (int)(startButtonRect.Left - taskbarRect.Left);
+                int noOverlapRightBoundary = startLeftInTaskbar - startButtonGap;
+
+                if (widgetLeft >= noOverlapRightBoundary)
+                    widgetLeft = Math.Max(0, noOverlapRightBoundary - 1);
+
+                int maxWidthToFitGap = noOverlapRightBoundary - widgetLeft;
+                if (maxWidthToFitGap < finalPhysicalWidth)
+                {
+                    finalPhysicalWidth = Math.Max(1, maxWidthToFitGap);
+                }
+            }
+            else if (!_startButtonLookupWarningLogged)
+            {
+                Logger.Warn("Failed to resolve Start button bounds for taskbar overlap prevention. Using existing widget width.");
+                _startButtonLookupWarningLogged = true;
+            }
+        }
+
         // Set widget position within canvas
         Canvas.SetLeft(Widget, widgetLeft / dpiScale);
         Canvas.SetTop(Widget, widgetTop / dpiScale);
-        Widget.Width = physicalWidth / dpiScale;
+        Widget.Width = finalPhysicalWidth / dpiScale;
         Widget.Height = physicalHeight / dpiScale;
 
         return new Rect(Canvas.GetLeft(Widget) * dpiScale, Canvas.GetTop(Widget) * dpiScale, Widget.Width * dpiScale, Widget.Height * dpiScale);
@@ -656,10 +693,13 @@ public partial class TaskbarWindow : Window
         });
     }
 
-    private (bool, Rect) GetTaskbarXamlElementRect(IntPtr taskbarHandle, ref AutomationElement? elementCache, string elementName)
+    private (bool, Rect) GetTaskbarXamlElementRect(IntPtr taskbarHandle, ref AutomationElement? elementCache, string elementName, AutomationProperty? property = null)
     {
         if (taskbarHandle == IntPtr.Zero)
             return (false, Rect.Empty);
+
+        AutomationProperty lookupProperty = property ?? AutomationElement.AutomationIdProperty;
+        string pendingTaskKey = $"{lookupProperty.ProgrammaticName}:{elementName}";
 
         try
         {
@@ -670,7 +710,7 @@ public partial class TaskbarWindow : Window
             // find widget in XAML
             if (elementCache == null)
             {
-                if (_pendingAutomationTasks.TryGetValue(elementName, out var pendingTask) && !pendingTask.IsCompleted)
+                if (_pendingAutomationTasks.TryGetValue(pendingTaskKey, out var pendingTask) && !pendingTask.IsCompleted)
                     return (false, Rect.Empty);
 
                 AutomationElement? found = null;
@@ -678,9 +718,9 @@ public partial class TaskbarWindow : Window
                 {
                     var root = AutomationElement.FromHandle(taskbarHandle);
                     found = root.FindFirst(TreeScope.Descendants,
-                        new PropertyCondition(AutomationElement.AutomationIdProperty, elementName));
+                        new PropertyCondition(lookupProperty, elementName));
                 });
-                _pendingAutomationTasks[elementName] = findTask;
+                _pendingAutomationTasks[pendingTaskKey] = findTask;
 
                 if (!findTask.Wait(1000))
                 {
@@ -698,7 +738,7 @@ public partial class TaskbarWindow : Window
 
             try
             {
-                if (_pendingAutomationTasks.TryGetValue(elementName, out var pendingTask) && !pendingTask.IsCompleted)
+                if (_pendingAutomationTasks.TryGetValue(pendingTaskKey, out var pendingTask) && !pendingTask.IsCompleted)
                 {
                     elementCache = null;
                     return (false, Rect.Empty);
@@ -706,7 +746,7 @@ public partial class TaskbarWindow : Window
 
                 var cachedElement = elementCache;
                 var boundsTask = Task.Run(() => cachedElement.Current.BoundingRectangle);
-                _pendingAutomationTasks[elementName] = boundsTask;
+                _pendingAutomationTasks[pendingTaskKey] = boundsTask;
 
                 if (!boundsTask.Wait(500))
                 {
@@ -772,5 +812,14 @@ public partial class TaskbarWindow : Window
     private (bool, Rect) GetTaskbarFrameRect(IntPtr taskbarHandle)
     {
         return GetTaskbarXamlElementRect(taskbarHandle, ref _taskbarFrameElement, "TaskbarFrame");
+    }
+
+    private (bool, Rect) GetStartButtonRect(IntPtr taskbarHandle)
+    {
+        (bool foundById, Rect startRect) = GetTaskbarXamlElementRect(taskbarHandle, ref _startButtonElement, "StartButton");
+        if (foundById)
+            return (true, startRect);
+
+        return GetTaskbarXamlElementRect(taskbarHandle, ref _startButtonByNameElement, "Start", AutomationElement.NameProperty);
     }
 }


### PR DESCRIPTION
## Summary

This PR introduces an optional overlap-prevention feature for the Taskbar Widget in left alignment mode.
When enabled, FluentFlyout detects available space before the Start button and shrinks widget width as needed to avoid overlap in constrained taskbar layouts.

## Motivation

On small taskbars or when many apps are pinned or running, the left-aligned taskbar widget can overlap with Start-area UI.
This change improves layout reliability and user control by adding a dedicated setting to prevent overlap only when needed.

Partially addresses #447 by reducing taskbar widget overlap in constrained layouts via optional Start-boundary-aware width clamping.

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

- Added a new user setting: `TaskbarWidgetPreventStartOverlap` (default: off).
- Added a new toggle in Taskbar Widget settings UI for overlap prevention (left alignment only).
- Implemented Start-button-aware overlap prevention in taskbar widget positioning.
- Resolves Start button bounds using UI Automation.
- Validates Start bounds before applying clamping to avoid false-positive matches.
- Shrinks widget width only when overlap would occur.
- Preserves existing placement behavior when overlap prevention is disabled or Start bounds are unavailable.
- Extended taskbar element lookup helper to support property-based lookups for safer Start detection.
- Added English localization strings for the new setting.

## Additional Information

All screenshots were captured on the same monitor/taskbar scale for direct comparison.

Before (Windows Widgets disabled)
<img width="840" height="48" alt="overlap-before-no-widgets" src="https://github.com/user-attachments/assets/b4ffcb35-56ba-4c63-9f39-78b5f058c178" />

After enabling overlap prevention (Windows Widgets disabled)
<img width="840" height="48" alt="overlap-after-no-widgets" src="https://github.com/user-attachments/assets/56a4cec1-5d8e-4069-b7dc-18d1e3e19a70" />

Before (Windows Widgets enabled)
<img width="840" height="48" alt="overlap-before-with-widgets" src="https://github.com/user-attachments/assets/07ffafff-117e-4466-a071-7b1bc6921530" />

After enabling overlap prevention (Windows Widgets enabled)
<img width="840" height="48" alt="overlap-after-with-widgets" src="https://github.com/user-attachments/assets/a71d1e30-93e2-4503-8e15-74145464aa74" />

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).