### PR TITLE
feat: add configurable visualizer frame rate setting (30/60/120 FPS)

### DIFF
--- a/FluentFlyoutWPF/Classes/Visualizer.cs
+++ b/FluentFlyoutWPF/Classes/Visualizer.cs
@@ -33,7 +33,7 @@ namespace FluentFlyoutWPF.Classes
         private int _fftPos = 0;
         private readonly Complex[] _fftBuffer;
 
-        private readonly int _targetFps = 30;
+        private static int _targetFps = 30;
         private DateTime _lastUpdateTime = DateTime.MinValue;
 
         private System.Timers.Timer? _captureWatchdog;
@@ -77,6 +77,7 @@ namespace FluentFlyoutWPF.Classes
             _fftBuffer = new Complex[_fftLength];
 
             ResizeBarList(SettingsManager.Current.TaskbarVisualizerBarCount);
+            _targetFps = SettingsManager.Current.TaskbarVisualizerFrameRate;
             AudioDeviceMonitor.Instance.DefaultDeviceChanged += OnDefaultDeviceChanged;
             TryRegisterSystemEvents();
         }
@@ -195,6 +196,11 @@ namespace FluentFlyoutWPF.Classes
         {
             BarCount = newBarCount;
             _barValues = new float[BarCount];
+        }
+
+        public static void UpdateTargetFps(int fps)
+        {
+            _targetFps = fps;
         }
 
         public void Start()

--- a/FluentFlyoutWPF/Pages/TaskbarVisualizerPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarVisualizerPage.xaml
@@ -179,6 +179,20 @@
                 </StackPanel>
             </ui:CardControl>
 
+            <ui:CardControl Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource TaskbarVisualizerFrameRateTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource TaskbarVisualizerFrameRateSubtitle}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <ComboBox SelectedIndex="{Binding TaskbarVisualizerFrameRateIndex, Mode=TwoWay}">
+                    <ComboBoxItem Content="{DynamicResource FrameRate30}" />
+                    <ComboBoxItem Content="{DynamicResource FrameRate60}" />
+                    <ComboBoxItem Content="{DynamicResource FrameRate120}" />
+                </ComboBox>
+            </ui:CardControl>
+
             <ui:CardControl Icon="{ui:SymbolIcon Speaker224}" Margin="0,0,0,12">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -89,6 +89,11 @@ hides repeat, shuffle and player info</System:String>
     <System:String x:Key="TaskbarVisualizerAudioSensitivityDescription">How loud audio must be before the bars start moving</System:String>
     <System:String x:Key="TaskbarVisualizerAudioPeakLevelTitle">Audio Peak Threshold</System:String>
     <System:String x:Key="TaskbarVisualizerAudioPeakLevelDescription">How loud audio must be for the bars to reach their maximum height</System:String>
+    <System:String x:Key="TaskbarVisualizerFrameRateTitle">Frame Rate</System:String>
+    <System:String x:Key="TaskbarVisualizerFrameRateSubtitle">Higher frame rates may increase CPU and battery usage</System:String>
+    <System:String x:Key="FrameRate30">30 FPS (Default)</System:String>
+    <System:String x:Key="FrameRate60">60 FPS</System:String>
+    <System:String x:Key="FrameRate120">120 FPS</System:String>
     <System:String x:Key="TaskbarVisualizerOutputDeviceTitle">Output Device</System:String>
     <System:String x:Key="TaskbarVisualizerOutputDeviceDescription">Change what the visualizer listens to by switching FluentFlyout's output device.</System:String>
     <System:String x:Key="TaskbarVisualizerClickableTitle">Click to open Settings</System:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -528,6 +528,20 @@ public partial class UserSettings : ObservableObject
     public partial int TaskbarVisualizerAudioPeakLevel { get; set; }
 
     /// <summary>
+    /// The target frame rate for the taskbar visualizer. Accepted values: 30, 60, 120.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(TaskbarVisualizerFrameRateIndex))]
+    public partial int TaskbarVisualizerFrameRate { get; set; }
+
+    [XmlIgnore]
+    public int TaskbarVisualizerFrameRateIndex
+    {
+        get => TaskbarVisualizerFrameRate switch { 60 => 1, 120 => 2, _ => 0 };
+        set => TaskbarVisualizerFrameRate = value switch { 1 => 60, 2 => 120, _ => 30 };
+    }
+
+    /// <summary>
     /// Gets whether premium features are unlocked (runtime only, not persisted)
     /// </summary>
     [XmlIgnore]
@@ -638,6 +652,7 @@ public partial class UserSettings : ObservableObject
         TaskbarVisualizerBaseline = false;
         TaskbarVisualizerAudioSensitivity = 2;
         TaskbarVisualizerAudioPeakLevel = 3;
+        TaskbarVisualizerFrameRate = 30;
         VolumeControlEnabled = false;
         VolumeControlAboveMediaFlyout = false;
         VolumeControlDuration = 3000;
@@ -781,6 +796,12 @@ public partial class UserSettings : ObservableObject
     {
         if (oldValue == newValue || _initializing) return;
         Visualizer.ResizeBarList(newValue);
+    }
+
+    partial void OnTaskbarVisualizerFrameRateChanged(int oldValue, int newValue)
+    {
+        if (oldValue == newValue || _initializing) return;
+        Visualizer.UpdateTargetFps(newValue);
     }
 
     partial void OnTaskbarVisualizerBaselineChanged(bool oldValue, bool newValue)


### PR DESCRIPTION
## Summary
Adds a configurable frame rate setting for the Taskbar Visualizer, allowing users to choose between 30, 60, and 120 FPS. Changes apply immediately without requiring a restart.

## Motivation
The visualizer's frame rate was previously hardcoded at 30 FPS with no way for users to adjust it. Users with higher refresh rate displays or more powerful hardware may prefer a smoother visualizer experience, while the default remains 30 FPS to keep CPU and battery usage low for everyone else.

Closes https://github.com/unchihugo/FluentFlyout/discussions/642

## Type of Change
- [x] Feature

## What Changed
- Added `TaskbarVisualizerFrameRate` persisted int property to `UserSettings.cs` with default value of 30, plus a `TaskbarVisualizerFrameRateIndex` helper for ComboBox binding
- Added `OnTaskbarVisualizerFrameRateChanged` partial method that notifies the Visualizer immediately on setting change
- Changed `_targetFps` in `Visualizer.cs` from a hardcoded `readonly` field to a mutable static, seeded from settings on startup
- Added `UpdateTargetFps()` static method in `Visualizer.cs` for live updates without restart
- Added Frame Rate ComboBox card to `TaskbarVisualizerPage.xaml` with a battery/CPU warning subtitle, available to all users
- Added 5 localization strings to `Dictionary-en-US.xaml`

## Additional Information
Default remains 30 FPS. The setting is not paywalled.

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).