### PR TITLE
Remove unnecessary language initialization on startup

### DIFF
--- a/FluentFlyoutWPF/App.xaml.cs
+++ b/FluentFlyoutWPF/App.xaml.cs
@@ -23,10 +23,7 @@ public partial class App : Application
 
         // Register AUMID for toast notifications
         ToastNotificationManagerCompat.OnActivated += Notifications.HandleNotificationActivation;
-        
-        // Apply localization before any windows are created
-        LocalizationManager.ApplyLocalization();
-        
+
         base.OnStartup(e);
     }
 }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->

Optimizes startup times by removing the redundant language initialization in App.xaml.cs as settings are not loaded in by then anyway and will always be overwritten by MainWindow initialization code.