### PR TITLE
Fix empty space when player info is disabled

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1080,7 +1080,9 @@ public partial class MainWindow : MicaWindow
         {
             int extraWidth = SettingsManager.Current.RepeatEnabled ? 36 : 0;
             extraWidth += SettingsManager.Current.ShuffleEnabled ? 36 : 0;
-            extraWidth += SettingsManager.Current.PlayerInfoEnabled ? 72 : 72; // disabled player info should temporarily keep the widget the same width as no one seems to like the small version
+            extraWidth += SettingsManager.Current.PlayerInfoEnabled ? 72 : 0;
+            // keep minimum width at 72 even if all extra features are disabled to prevent the widget from being too small
+            extraWidth = Math.Max(extraWidth, 72);
 
             int extraHeight = SettingsManager.Current.SeekbarEnabled && _mediaSessionSupportsSeekbar ? 36 : 0;
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->
Fixes the empty space next to the player controls in the media flyout when the player info setting is disabled; now there is a minimum width calculation to keep the flyout from being too small.

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Closes #307 

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other