### PR TITLE
Fix default device logic and update visualizer and volume flyout handling

### DIFF
--- a/FluentFlyoutWPF/Classes/AudioDeviceMonitor.cs
+++ b/FluentFlyoutWPF/Classes/AudioDeviceMonitor.cs
@@ -4,140 +4,138 @@
 using NAudio.CoreAudioApi;
 using NAudio.CoreAudioApi.Interfaces;
 
-namespace FluentFlyoutWPF.Classes
+namespace FluentFlyoutWPF.Classes;
+
+public class AudioDeviceMonitor : IDisposable
 {
-    public class AudioDeviceMonitor : IDisposable
+    private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+    private static AudioDeviceMonitor? _instance;
+    private static readonly object _instanceLock = new();
+
+    private MMDeviceEnumerator? _deviceEnumerator;
+    private AudioDeviceNotificationClient? _notificationClient;
+
+    public event EventHandler<DefaultDeviceChangedEventArgs>? DefaultDeviceChanged;
+
+    public static AudioDeviceMonitor Instance
     {
-        private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
-        private static AudioDeviceMonitor? _instance;
-        private static readonly object _instanceLock = new();
-
-        private MMDeviceEnumerator? _deviceEnumerator;
-        private AudioDeviceNotificationClient? _notificationClient;
-
-        public event EventHandler<DefaultDeviceChangedEventArgs>? DefaultDeviceChanged;
-
-        public static AudioDeviceMonitor Instance
+        get
         {
-            get
+            if (_instance == null)
             {
-                if (_instance == null)
+                lock (_instanceLock)
                 {
-                    lock (_instanceLock)
-                    {
-                        _instance ??= new AudioDeviceMonitor();
-                    }
+                    _instance ??= new AudioDeviceMonitor();
                 }
-                return _instance;
             }
-        }
-
-        private AudioDeviceMonitor()
-        {
-            Initialize();
-        }
-
-        private void Initialize()
-        {
-            try
-            {
-                _deviceEnumerator = new MMDeviceEnumerator();
-                _notificationClient = new AudioDeviceNotificationClient();
-                _notificationClient.DefaultDeviceChanged += OnDefaultDeviceChanged;
-                _deviceEnumerator.RegisterEndpointNotificationCallback(_notificationClient);
-
-                Logger.Info("Audio device monitoring initialized");
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Failed to initialize audio device monitoring");
-            }
-        }
-
-        private void OnDefaultDeviceChanged(object? sender, DefaultDeviceChangedEventArgs e)
-        {
-            // Windows fires this for every Role (Console, Multimedia, Communications).
-            // Only forward Render/Multimedia to avoid triple-firing on a single switch.
-            if (e.DataFlow != DataFlow.Render)
-                return;
-
-            Logger.Info("Default audio output device changed");
-            DefaultDeviceChanged?.Invoke(this, e);
-        }
-
-        public MMDevice? GetDefaultRenderDevice()
-        {
-            try
-            {
-                var device = _deviceEnumerator?.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-                Logger.Debug("New device: {0}", device);
-                return device;
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Failed to get default render device");
-                return null;
-            }
-        }
-
-        public MMDevice? GetDeviceById(string deviceId)
-        {
-            try
-            {
-                var device = _deviceEnumerator?.GetDevice(deviceId);
-                Logger.Debug("Got device by id {0}: {1}", deviceId, device);
-                return device;
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Failed to get device by id {0}", deviceId);
-                return null;
-            }
-        }
-
-        public void Dispose()
-        {
-            _notificationClient?.DefaultDeviceChanged -= OnDefaultDeviceChanged;
-
-            if (_deviceEnumerator != null && _notificationClient != null)
-            {
-                try
-                {
-                    _deviceEnumerator.UnregisterEndpointNotificationCallback(_notificationClient);
-                }
-                catch (Exception ex)
-                {
-                    Logger.Error(ex, "Failed to unregister device notification callback");
-                }
-                _deviceEnumerator = null;
-            }
-
-            _notificationClient = null;
-
-            GC.SuppressFinalize(this);
+            return _instance;
         }
     }
 
-    // classes to handle audio device notifications
-    public class AudioDeviceNotificationClient : IMMNotificationClient
+    private AudioDeviceMonitor()
     {
-        public event EventHandler<DefaultDeviceChangedEventArgs>? DefaultDeviceChanged;
+        Initialize();
+    }
 
-        public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)
+    private void Initialize()
+    {
+        try
         {
-            DefaultDeviceChanged?.Invoke(this, new DefaultDeviceChangedEventArgs(flow, role, defaultDeviceId));
+            _deviceEnumerator = new MMDeviceEnumerator();
+            _notificationClient = new AudioDeviceNotificationClient();
+            _notificationClient.DefaultDeviceChanged += OnDefaultDeviceChanged;
+            _deviceEnumerator.RegisterEndpointNotificationCallback(_notificationClient);
+
+            Logger.Info("Audio device monitoring initialized");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to initialize audio device monitoring");
+        }
+    }
+
+    private void OnDefaultDeviceChanged(object? sender, DefaultDeviceChangedEventArgs e)
+    {
+        // Render devices are output devices
+        if (e.DataFlow != DataFlow.Render)
+            return;
+
+        Logger.Info("Default audio output device changed");
+        DefaultDeviceChanged?.Invoke(this, e);
+    }
+
+    public MMDevice? GetDefaultRenderDevice()
+    {
+        try
+        {
+            var device = _deviceEnumerator?.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+            Logger.Debug("New device: {0}", device);
+            return device;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to get default render device");
+            return null;
+        }
+    }
+
+    public MMDevice? GetDeviceById(string deviceId)
+    {
+        try
+        {
+            var device = _deviceEnumerator?.GetDevice(deviceId);
+            Logger.Debug("Got device by id {0}: {1}", deviceId, device);
+            return device;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to get device by id {0}", deviceId);
+            return null;
+        }
+    }
+
+    public void Dispose()
+    {
+        _notificationClient?.DefaultDeviceChanged -= OnDefaultDeviceChanged;
+
+        if (_deviceEnumerator != null && _notificationClient != null)
+        {
+            try
+            {
+                _deviceEnumerator.UnregisterEndpointNotificationCallback(_notificationClient);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to unregister device notification callback");
+            }
+            _deviceEnumerator = null;
         }
 
-        public void OnDeviceStateChanged(string deviceId, DeviceState newState) { }
-        public void OnDeviceAdded(string pwstrDeviceId) { }
-        public void OnDeviceRemoved(string deviceId) { }
-        public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key) { }
+        _notificationClient = null;
+
+        GC.SuppressFinalize(this);
+    }
+}
+
+// classes to handle audio device notifications
+public class AudioDeviceNotificationClient : IMMNotificationClient
+{
+    public event EventHandler<DefaultDeviceChangedEventArgs>? DefaultDeviceChanged;
+
+    public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)
+    {
+        DefaultDeviceChanged?.Invoke(this, new DefaultDeviceChangedEventArgs(flow, role, defaultDeviceId));
     }
 
-    public class DefaultDeviceChangedEventArgs(DataFlow dataFlow, Role role, string deviceId) : EventArgs
-    {
-        public DataFlow DataFlow { get; } = dataFlow;
-        public Role Role { get; } = role;
-        public string DeviceId { get; } = deviceId;
-    }
+    public void OnDeviceStateChanged(string deviceId, DeviceState newState) { }
+    public void OnDeviceAdded(string pwstrDeviceId) { }
+    public void OnDeviceRemoved(string deviceId) { }
+    public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key) { }
+}
+
+public class DefaultDeviceChangedEventArgs(DataFlow dataFlow, Role role, string deviceId) : EventArgs
+{
+    public DataFlow DataFlow { get; } = dataFlow;
+    public Role Role { get; } = role;
+    public string DeviceId { get; } = deviceId;
 }

--- a/FluentFlyoutWPF/Classes/AudioDeviceMonitor.cs
+++ b/FluentFlyoutWPF/Classes/AudioDeviceMonitor.cs
@@ -56,7 +56,7 @@ public class AudioDeviceMonitor : IDisposable
 
     private void OnDefaultDeviceChanged(object? sender, DefaultDeviceChangedEventArgs e)
     {
-        // Render devices are output devices
+        // Render devices are output devices, no e.Role check because roles are quite often randomly assigned
         if (e.DataFlow != DataFlow.Render)
             return;
 
@@ -90,6 +90,7 @@ public class AudioDeviceMonitor : IDisposable
         catch (Exception ex)
         {
             Logger.Error(ex, "Failed to get device by id {0}", deviceId);
+            // TODO: we could investigate if returning GetDefaultRenderDevice() works as a fallback for returning null
             return null;
         }
     }
@@ -108,7 +109,22 @@ public class AudioDeviceMonitor : IDisposable
             {
                 Logger.Error(ex, "Failed to unregister device notification callback");
             }
-            _deviceEnumerator = null;
+        }
+
+        if (_deviceEnumerator != null)
+        {
+            try
+            {
+                _deviceEnumerator.Dispose();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to dispose device enumerator");
+            }
+            finally
+            {
+                _deviceEnumerator = null;
+            }
         }
 
         _notificationClient = null;

--- a/FluentFlyoutWPF/Classes/AudioDeviceMonitor.cs
+++ b/FluentFlyoutWPF/Classes/AudioDeviceMonitor.cs
@@ -2,18 +2,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
 
 namespace FluentFlyoutWPF.Classes
 {
     public class AudioDeviceMonitor : IDisposable
     {
-        // TODO: implement OnDefaultDeviceChanged event - currently gets handled by Visualizer and VolumeMixerViewModel
-
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
         private static AudioDeviceMonitor? _instance;
         private static readonly object _instanceLock = new();
 
         private MMDeviceEnumerator? _deviceEnumerator;
+        private AudioDeviceNotificationClient? _notificationClient;
 
         public event EventHandler<DefaultDeviceChangedEventArgs>? DefaultDeviceChanged;
 
@@ -42,6 +42,10 @@ namespace FluentFlyoutWPF.Classes
             try
             {
                 _deviceEnumerator = new MMDeviceEnumerator();
+                _notificationClient = new AudioDeviceNotificationClient();
+                _notificationClient.DefaultDeviceChanged += OnDefaultDeviceChanged;
+                _deviceEnumerator.RegisterEndpointNotificationCallback(_notificationClient);
+
                 Logger.Info("Audio device monitoring initialized");
             }
             catch (Exception ex)
@@ -50,11 +54,24 @@ namespace FluentFlyoutWPF.Classes
             }
         }
 
+        private void OnDefaultDeviceChanged(object? sender, DefaultDeviceChangedEventArgs e)
+        {
+            // Windows fires this for every Role (Console, Multimedia, Communications).
+            // Only forward Render/Multimedia to avoid triple-firing on a single switch.
+            if (e.DataFlow != DataFlow.Render)
+                return;
+
+            Logger.Info("Default audio output device changed");
+            DefaultDeviceChanged?.Invoke(this, e);
+        }
+
         public MMDevice? GetDefaultRenderDevice()
         {
             try
             {
-                return _deviceEnumerator?.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                var device = _deviceEnumerator?.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                Logger.Debug("New device: {0}", device);
+                return device;
             }
             catch (Exception ex)
             {
@@ -63,24 +80,64 @@ namespace FluentFlyoutWPF.Classes
             }
         }
 
+        public MMDevice? GetDeviceById(string deviceId)
+        {
+            try
+            {
+                var device = _deviceEnumerator?.GetDevice(deviceId);
+                Logger.Debug("Got device by id {0}: {1}", deviceId, device);
+                return device;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to get device by id {0}", deviceId);
+                return null;
+            }
+        }
+
         public void Dispose()
         {
-            _deviceEnumerator?.Dispose();
+            _notificationClient?.DefaultDeviceChanged -= OnDefaultDeviceChanged;
+
+            if (_deviceEnumerator != null && _notificationClient != null)
+            {
+                try
+                {
+                    _deviceEnumerator.UnregisterEndpointNotificationCallback(_notificationClient);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "Failed to unregister device notification callback");
+                }
+                _deviceEnumerator = null;
+            }
+
+            _notificationClient = null;
+
             GC.SuppressFinalize(this);
         }
     }
 
-    public class DefaultDeviceChangedEventArgs : EventArgs
+    // classes to handle audio device notifications
+    public class AudioDeviceNotificationClient : IMMNotificationClient
     {
-        public DataFlow DataFlow { get; }
-        public Role Role { get; }
-        public string DeviceId { get; }
+        public event EventHandler<DefaultDeviceChangedEventArgs>? DefaultDeviceChanged;
 
-        public DefaultDeviceChangedEventArgs(DataFlow dataFlow, Role role, string deviceId)
+        public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)
         {
-            DataFlow = dataFlow;
-            Role = role;
-            DeviceId = deviceId;
+            DefaultDeviceChanged?.Invoke(this, new DefaultDeviceChangedEventArgs(flow, role, defaultDeviceId));
         }
+
+        public void OnDeviceStateChanged(string deviceId, DeviceState newState) { }
+        public void OnDeviceAdded(string pwstrDeviceId) { }
+        public void OnDeviceRemoved(string deviceId) { }
+        public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key) { }
+    }
+
+    public class DefaultDeviceChangedEventArgs(DataFlow dataFlow, Role role, string deviceId) : EventArgs
+    {
+        public DataFlow DataFlow { get; } = dataFlow;
+        public Role Role { get; } = role;
+        public string DeviceId { get; } = deviceId;
     }
 }

--- a/FluentFlyoutWPF/Classes/Visualizer.cs
+++ b/FluentFlyoutWPF/Classes/Visualizer.cs
@@ -39,6 +39,7 @@ namespace FluentFlyoutWPF.Classes
         private System.Timers.Timer? _captureWatchdog;
         private DateTime _lastDataAvailableUtc = DateTime.MinValue;
         private int _restartInProgress; // 0=false, 1=true (Interlocked)
+        private string _deviceId; // track current device ID for restart logic
 
         private readonly struct BarGeometry
         {
@@ -145,8 +146,7 @@ namespace FluentFlyoutWPF.Classes
 
         private void OnDefaultDeviceChanged(object? sender, DefaultDeviceChangedEventArgs e)
         {
-            if (e.DataFlow != DataFlow.Render || e.Role != Role.Multimedia)
-                return;
+            _deviceId = e.DeviceId;
 
             // Even if capture isn't currently running (e.g. restart attempt failed while the device was reconfiguring),
             // we still want to try restarting as soon as Windows reports a usable default endpoint again.
@@ -211,7 +211,7 @@ namespace FluentFlyoutWPF.Classes
                 // Using the parameterless capture can throw transient COM errors when the default endpoint is
                 // reconfiguring (e.g. Bluetooth earbuds disconnect/reconnect around lock/unlock).
                 _renderDevice?.Dispose();
-                _renderDevice = AudioDeviceMonitor.Instance.GetDefaultRenderDevice();
+                _renderDevice = AudioDeviceMonitor.Instance.GetDeviceById(_deviceId) ?? AudioDeviceMonitor.Instance.GetDefaultRenderDevice();
 
                 if (_renderDevice == null)
                 {

--- a/FluentFlyoutWPF/Classes/Visualizer.cs
+++ b/FluentFlyoutWPF/Classes/Visualizer.cs
@@ -211,7 +211,9 @@ namespace FluentFlyoutWPF.Classes
                 // Using the parameterless capture can throw transient COM errors when the default endpoint is
                 // reconfiguring (e.g. Bluetooth earbuds disconnect/reconnect around lock/unlock).
                 _renderDevice?.Dispose();
-                _renderDevice = AudioDeviceMonitor.Instance.GetDeviceById(_deviceId) ?? AudioDeviceMonitor.Instance.GetDefaultRenderDevice();
+                _renderDevice = string.IsNullOrWhiteSpace(_deviceId)
+                     ? AudioDeviceMonitor.Instance.GetDefaultRenderDevice()
+                     : AudioDeviceMonitor.Instance.GetDeviceById(_deviceId) ?? AudioDeviceMonitor.Instance.GetDefaultRenderDevice();
 
                 if (_renderDevice == null)
                 {

--- a/FluentFlyoutWPF/Classes/Visualizer.cs
+++ b/FluentFlyoutWPF/Classes/Visualizer.cs
@@ -39,7 +39,7 @@ namespace FluentFlyoutWPF.Classes
         private System.Timers.Timer? _captureWatchdog;
         private DateTime _lastDataAvailableUtc = DateTime.MinValue;
         private int _restartInProgress; // 0=false, 1=true (Interlocked)
-        private string _deviceId; // track current device ID for restart logic
+        private string? _deviceId; // track current device ID for restart logic
 
         private readonly struct BarGeometry
         {

--- a/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
+++ b/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
@@ -80,14 +80,11 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
 
     private void OnDefaultDeviceChanged(object? sender, DefaultDeviceChangedEventArgs e)
     {
-        if (e.DataFlow != DataFlow.Render || e.Role != Role.Multimedia)
-            return;
-
         Logger.Info("Default render device changed, reattaching volume mixer");
 
         System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
         {
-            AttachDevice(AudioDeviceMonitor.Instance.GetDefaultRenderDevice());
+            AttachDevice(AudioDeviceMonitor.Instance.GetDeviceById(e.DeviceId));
         });
     }
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->
* `AudioDeviceMonitor.cs` fixes and additions:
  * Fixes default device changed listening logic. Previous refactors to this file removed the IMMNotificationClient interface crucial for sending device change updates. This PR reimplements a newer version, restoring the functionality.
  * Added `GetDeviceById` method - through testing I've noticed that the `GetDefaultRenderDevice` almost never returns the actual new default device for some reason, though it used to work iirc. Perhaps more investigation into this would help.
* `Visualizer.cs` and `VolumeMixerViewModel.cs` both now use the new `GetDeviceById` method instead, which takes the DeviceId item from the DefaultDeviceChangedEventArgs argument. This parameter is passed through when the default output device changed and encompasses details about the new device.

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Visualizer and Volume Flyout did not adapt to output device changes.

Closes #773, closes #769, closes #763, closes #753

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other