### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-msix.yml
+++ b/.github/workflows/build-msix.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'FluentFlyoutMSIX/Package.appxmanifest'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -1,5 +1,7 @@
 name: Notify FluentFlyout-Pages of new Release
 
+permissions: {}
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/unchihugo/FluentFlyout/security/code-scanning/4](https://github.com/unchihugo/FluentFlyout/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token access unless overridden.  
For this workflow, `contents: read` is the minimal and appropriate setting (sufficient for `actions/checkout`; artifact upload does not require extra `GITHUB_TOKEN` scopes).

**Where to change:** `.github/workflows/build-msix.yml` near the top-level keys, immediately after `on:` block and before `jobs:`.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
