### PR TITLE
Fix volume flyout slider behavior and UI changes

### DIFF
--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml
@@ -72,7 +72,7 @@
                 </ui:SymbolIcon>
             </ui:Button>
         </Grid>
-        <Border BorderThickness="0 1 0 0" BorderBrush="{DynamicResource TextFillColorDisabledBrush}" Opacity="0.5" Margin="8,6" />
+        <Border x:Name="SessionsSeparator" BorderThickness="0 1 0 0" BorderBrush="{DynamicResource TextFillColorDisabledBrush}" Opacity="0.5" Margin="8,6" Visibility="Collapsed" />
         <ui:PassiveScrollViewer VerticalScrollBarVisibility="Auto" MaxHeight="220" Margin="0" Padding="8,0,8,16" >
             <StackPanel x:Name="SessionsExpanded" Visibility="Collapsed" >
                 <TextBlock Text="{DynamicResource VolumeMixerSectionTitle}" FontWeight="Medium" Margin="8" />

--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml
@@ -60,7 +60,7 @@
                                    Visibility="{Binding ViewModel.IsMasterMuted, Converter={StaticResource BoolToVisibleCollapsedConverter}}" />
                 </Grid>
             </ui:Button>
-            <Slider Grid.Column="1" Value="{Binding ViewModel.MasterVolume, Mode=TwoWay}" Minimum="0" Maximum="1" TickFrequency="0.01" VerticalAlignment="Center" />
+            <Slider Grid.Column="1" Value="{Binding ViewModel.MasterVolume, Mode=TwoWay}" Minimum="0" Maximum="1" TickFrequency="0.01" SmallChange="0.01" LargeChange="0.01" VerticalAlignment="Center" />
             <TextBlock Grid.Column="2" Text="{Binding ViewModel.MasterVolume, Converter={StaticResource DecimalPercentage}}" FontSize="14" VerticalAlignment="Center" Margin="8,-2,8,0" Width="24" TextAlignment="Center" />
             <ui:Button Name="OpenVolumeMixerButton" Grid.Column="3" VerticalAlignment="Center" Padding="4" Margin="0,0,4,0"
                        Command="{Binding ViewModel.OpenVolumeMixerCommand}" Focusable="False"
@@ -96,7 +96,7 @@
                                                    Visibility="{Binding IsMuted, Converter={StaticResource BoolToVisibleCollapsedConverter}}" />
                                         </Grid>
                                     </ui:Button>
-                                    <Slider Grid.Column="1" Value="{Binding Volume, Mode=TwoWay}" Minimum="0" Maximum="1" TickFrequency="0.01" VerticalAlignment="Center" />
+                                    <Slider Grid.Column="1" Value="{Binding Volume, Mode=TwoWay}" Minimum="0" Maximum="1" TickFrequency="0.01" SmallChange="0.01" LargeChange="0.01" VerticalAlignment="Center" />
                                     <TextBlock Grid.Column="2" Text="{Binding Volume, Converter={StaticResource DecimalPercentage}}" FontSize="12" VerticalAlignment="Center" Margin="8,0" Width="24" TextAlignment="Center" />
                                 </Grid>
                             </Border>

--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml
@@ -72,11 +72,17 @@
                 </ui:SymbolIcon>
             </ui:Button>
         </Grid>
-        <Border x:Name="SessionsSeparator" BorderThickness="0 1 0 0" BorderBrush="{DynamicResource TextFillColorDisabledBrush}" Opacity="0.5" Margin="8,6" Visibility="Collapsed" />
-        <ui:PassiveScrollViewer VerticalScrollBarVisibility="Auto" MaxHeight="220" Margin="0" Padding="8,0,8,16" >
+        <Border x:Name="SessionsSeparator" BorderThickness="0 1 0 0" BorderBrush="{DynamicResource TextFillColorDisabledBrush}" Opacity="0.5" Margin="8,6,8,0" Visibility="Collapsed" />
+        <ui:PassiveScrollViewer VerticalScrollBarVisibility="Auto" MaxHeight="220" Margin="0" Padding="8,0" >
             <StackPanel x:Name="SessionsExpanded" Visibility="Collapsed" >
-                <TextBlock Text="{DynamicResource VolumeMixerSectionTitle}" FontWeight="Medium" Margin="8" />
-                <ItemsControl x:Name="SessionsPanel" ItemsSource="{Binding ViewModel.Sessions}" Focusable="False" >
+                <!-- hacky way to set top margin in scrollviewer -->
+                <Grid Height="24" Margin="8">
+                    <TextBlock
+                        Text="{DynamicResource VolumeMixerSectionTitle}"
+                        FontWeight="Medium"
+                        VerticalAlignment="Bottom" />
+                </Grid>
+                <ItemsControl x:Name="SessionsPanel" ItemsSource="{Binding ViewModel.Sessions}" Focusable="False" Margin="0,0,0,8" >
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Border CornerRadius="4" Background="{Binding IsActive, Converter={StaticResource ActiveToAccentBrush}}" >

--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
@@ -247,6 +247,7 @@ public partial class VolumeMixerWindow : MicaWindow
         if (expand)
         {
             SessionsExpanded.Visibility = Visibility.Visible;
+            SessionsSeparator.Visibility = Visibility.Visible;
             SessionsPanel.UpdateLayout();
         }
 
@@ -294,6 +295,7 @@ public partial class VolumeMixerWindow : MicaWindow
             heightAnimation.Completed += (s, e) =>
             {
                 SessionsExpanded.Visibility = Visibility.Collapsed;
+                SessionsSeparator.Visibility = Visibility.Collapsed;
             };
         }
 

--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
@@ -253,7 +253,7 @@ public partial class VolumeMixerWindow : MicaWindow
 
         // measure desired size
         SessionsExpanded.Measure(new Size(ActualWidth, double.PositiveInfinity));
-        expandedHeight = _collapsedHeight + Math.Min(SessionsExpanded.DesiredSize.Height + 16, 220); // 16 for padding
+        expandedHeight = _collapsedHeight + Math.Min(SessionsExpanded.DesiredSize.Height, 220);
 
         double targetHeight = expand ? expandedHeight : _collapsedHeight;
         double currentHeight = ActualHeight;


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->
Fixes the following issues in the volume flyout:
* Clicking the slider track jumps value to 0% or 100% -- updating the sliders' SmallChange/LargeChange properties to 0.01 changes the behavior to go up or down by 1% instead of 100%
* Fixes the separator line being visible on the bottom of the flyout when it's collapsed. This should only show on expanded flyouts now.
* Fixes clipping in the expanded volume mixer due to padding issues and updated margins slightly for more breathing room.

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Closes #772, closes #724 

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## Note
Note: look into `IsMoveToPointEnabled="True"`. Enabling this makes the slider move to the pointer, but it doesn't allow for sliding while the mouse is still held in. This limitation should be fixed before it's enabled.