### PR TITLE
Fix volume flyout behavior in fullscreen applications

### DIFF
--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
@@ -59,6 +59,9 @@ public partial class VolumeMixerWindow : MicaWindow
     // one day we might want to convert these to an interface
     public async void ShowFlyout()
     {
+        if (FullscreenDetector.IsFullscreenApplicationRunning())
+            return;
+
         long currentTime = Environment.TickCount64;
 
         if (currentTime - _lastFlyoutTime < _flyoutCooldown.TotalMilliseconds)


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->
Fixes volume flyout not respecting the DirectX fullscreen program detection setting. Now the flyout will not open anymore if a DirectX game is detected and the setting is on (like other flyouts).

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Closes #760 

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other
