### PR TITLE
Fix user settings persistence bug

### DIFF
--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -10,8 +10,7 @@ using FluentFlyoutWPF.Classes;
 using FluentFlyoutWPF.Models;
 using FluentFlyoutWPF.Windows;
 using System.Collections.ObjectModel;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Reflection;
 using System.Windows;
 using System.Xml.Serialization;
 
@@ -22,6 +21,17 @@ namespace FluentFlyoutWPF.ViewModels;
  */
 public partial class UserSettings : ObservableObject
 {
+    private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+
+    // List of non-XmlIgnore property names
+    private static readonly HashSet<string> PersistedPropertyNames =
+    [
+        .. typeof(UserSettings)
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(property => property.CanWrite && property.GetCustomAttribute<XmlIgnoreAttribute>() is null)
+            .Select(property => property.Name)
+    ];
+
     /// <summary>
     /// Use a compact layout
     /// </summary>
@@ -661,6 +671,14 @@ public partial class UserSettings : ObservableObject
     {
         if (_initializing) return;
 
+        // Only trigger save if a persisted property changed
+        if (string.IsNullOrEmpty(e.PropertyName) || !PersistedPropertyNames.Contains(e.PropertyName))
+            return;
+
+#if DEBUG
+        Logger.Debug("Property '{PropertyName}' changed, scheduling settings save.", e.PropertyName);
+#endif
+
         var newCts = new CancellationTokenSource();
         var oldCts = Interlocked.Exchange(ref _saveSettingsCts, newCts);
         oldCts?.Cancel();
@@ -678,6 +696,13 @@ public partial class UserSettings : ObservableObject
         catch (OperationCanceledException)
         {
             // Expected when replaced by a new property change
+#if DEBUG
+            Logger.Debug("Settings save canceled due to another property change.");
+#endif
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "An error occurred while saving settings from property change.");
         }
         finally
         {

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -10,6 +10,8 @@ using FluentFlyoutWPF.Classes;
 using FluentFlyoutWPF.Models;
 using FluentFlyoutWPF.Windows;
 using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Xml.Serialization;
 
@@ -653,27 +655,36 @@ public partial class UserSettings : ObservableObject
     }
 
     [XmlIgnore]
-    private System.Threading.CancellationTokenSource? _saveSettingsCts;
+    private CancellationTokenSource? _saveSettingsCts;
 
     private async void OnPropertyChangedSaveSettings(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         if (_initializing) return;
 
-        _saveSettingsCts?.Cancel();
-        _saveSettingsCts = new System.Threading.CancellationTokenSource();
-        var token = _saveSettingsCts.Token;
+        var newCts = new CancellationTokenSource();
+        var oldCts = Interlocked.Exchange(ref _saveSettingsCts, newCts);
+        oldCts?.Cancel();
+        oldCts?.Dispose();
 
         try
         {
-            await System.Threading.Tasks.Task.Delay(500, token);
-            if (!token.IsCancellationRequested)
+            await Task.Delay(500, newCts.Token);
+
+            if (ReferenceEquals(_saveSettingsCts, newCts))
             {
                 SettingsManager.SaveSettings();
             }
         }
-        catch (System.Threading.Tasks.TaskCanceledException)
+        catch (OperationCanceledException)
         {
-            // Ignored
+            // Expected when replaced by a new property change
+        }
+        finally
+        {
+            if (Interlocked.CompareExchange(ref _saveSettingsCts, null, newCts) == newCts)
+            {
+                newCts.Dispose();
+            }
         }
     }
 

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -648,6 +648,33 @@ public partial class UserSettings : ObservableObject
         LastUpdateNotificationUnixSeconds = 0;
         ShowUpdateNotifications = true;
         LegacyTaskbarWidthEnabled = false;
+
+        PropertyChanged += OnPropertyChangedSaveSettings;
+    }
+
+    [XmlIgnore]
+    private System.Threading.CancellationTokenSource? _saveSettingsCts;
+
+    private async void OnPropertyChangedSaveSettings(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (_initializing) return;
+
+        _saveSettingsCts?.Cancel();
+        _saveSettingsCts = new System.Threading.CancellationTokenSource();
+        var token = _saveSettingsCts.Token;
+
+        try
+        {
+            await System.Threading.Tasks.Task.Delay(500, token);
+            if (!token.IsCancellationRequested)
+            {
+                SettingsManager.SaveSettings();
+            }
+        }
+        catch (System.Threading.Tasks.TaskCanceledException)
+        {
+            // Ignored
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

<!-- Implements an automated, debounced saving mechanism for user settings to ensure all configuration changes are reliably persisted to disk -->

## Motivation

 This resolves a critical data persistence issue where user settings were not being saved across application restarts. By automatically saving the configuration whenever a property changes, we prevent data loss during sudden application closure. The debouncing ensures that performance isn't impacted by excessive disk I/O when multiple settings are changed rapidly. I was myself irritated with issue so decided to fix. 

Related issue: #774 

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

 - Bound a `PropertyChanged` event handler (`OnPropertyChangedSaveSettings`) to the `UserSettings` model initialization.
- Implemented a 500ms debouncing mechanism using `CancellationTokenSource` to batch rapid property updates.
- Added a safe asynchronous call to `SettingsManager.SaveSettings()` once the debounce delay completes without cancellation. 


## Additional Information

The debounce delay is set to 500ms, which feels instantaneous to the user while being more than enough to capture rapid, consecutive changes (e.g., dragging a slider)

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
<!-- AI usage -->
- [ ] AI tools were used (if yes, I reviewed and fully understand the changes myself).