### PR TITLE
Fix taskbar widget song text and buttons

### DIFF
--- a/FluentFlyoutWPF/Classes/ThemeManager.cs
+++ b/FluentFlyoutWPF/Classes/ThemeManager.cs
@@ -104,7 +104,8 @@ internal static class ThemeManager
             {
                 if (SettingsManager.Current.NIconSymbol == true)
                 {
-                    var iconUri = new Uri(WindowsThemeHelper.GetCurrentWindowsTheme() == WindowsTheme.Dark
+                    WindowsThemeDetector.GetWindowsTheme(out _, out var systemTheme);
+                    var iconUri = new Uri(systemTheme == WindowsThemeDetector.ThemeMode.Dark
                         ? "pack://application:,,,/Resources/TrayIcons/FluentFlyoutWhite.png"
                         : "pack://application:,,,/Resources/TrayIcons/FluentFlyoutBlack.png");
                     nIcon.Icon = new BitmapImage(iconUri);

--- a/FluentFlyoutWPF/Classes/Utils/WindowsThemeDetector.cs
+++ b/FluentFlyoutWPF/Classes/Utils/WindowsThemeDetector.cs
@@ -1,5 +1,5 @@
-using System;
 using Microsoft.Win32;
+using System;
 
 // Custom Theme detector from checking the Windows Registry.
 // WindowsThemeHelper.GetCurrentWindowsTheme and MicaWPFServiceUtility.ThemeService.CurrentTheme will return the wrong value

--- a/FluentFlyoutWPF/Classes/Utils/WindowsThemeDetector.cs
+++ b/FluentFlyoutWPF/Classes/Utils/WindowsThemeDetector.cs
@@ -1,0 +1,58 @@
+using System;
+using Microsoft.Win32;
+
+// Custom Theme detector from checking the Windows Registry.
+// WindowsThemeHelper.GetCurrentWindowsTheme and MicaWPFServiceUtility.ThemeService.CurrentTheme will return the wrong value
+// for custom themes (ie. Windows mode = dark and App mode = light and vice versa).
+// If for some reason the registry read fails or somehow explodes, default to light...
+
+// Usage:
+// WindowsThemeDetector.GetWindowsTheme(out var appTheme, out var systemTheme);
+// Console.WriteLine($"App Theme: {appTheme}");
+// Console.WriteLine($"System Theme: {systemTheme}");
+
+public class WindowsThemeDetector
+{
+    private const string RegistryKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize";
+    private const string AppThemeValueName = "AppsUseLightTheme";
+    private const string SystemThemeValueName = "SystemUsesLightTheme";
+
+    public enum ThemeMode
+    {
+        Light,
+        Dark,
+        Unknown
+    }
+
+    /// <summary>
+    /// Gets the current theme for Applications and the System.
+    /// </summary>
+    public static void GetWindowsTheme(out ThemeMode appTheme, out ThemeMode systemTheme)
+    {
+        appTheme = GetThemeFromRegistry(AppThemeValueName);
+        systemTheme = GetThemeFromRegistry(SystemThemeValueName);
+    }
+
+    private static ThemeMode GetThemeFromRegistry(string valueName)
+    {
+        try
+        {
+            using (RegistryKey key = Registry.CurrentUser.OpenSubKey(RegistryKeyPath))
+            {
+                object registryValue = key?.GetValue(valueName);
+
+                if (registryValue == null)
+                    // On error, default to light
+                    return ThemeMode.Light;
+
+                // 1 means Light Mode, 0 means Dark Mode
+                return (int)registryValue > 0 ? ThemeMode.Light : ThemeMode.Dark;
+            }
+        }
+        catch (Exception)
+        {
+            // On error, default to light
+            return ThemeMode.Light;
+        }
+    }
+}

--- a/FluentFlyoutWPF/Classes/Utils/WindowsThemeDetector.cs
+++ b/FluentFlyoutWPF/Classes/Utils/WindowsThemeDetector.cs
@@ -37,9 +37,9 @@ public class WindowsThemeDetector
     {
         try
         {
-            using (RegistryKey key = Registry.CurrentUser.OpenSubKey(RegistryKeyPath))
+            using (RegistryKey? key = Registry.CurrentUser.OpenSubKey(RegistryKeyPath))
             {
-                object registryValue = key?.GetValue(valueName);
+                object? registryValue = key?.GetValue(valueName);
 
                 if (registryValue == null)
                     // On error, default to light

--- a/FluentFlyoutWPF/Controls/TaskbarVisualizerControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarVisualizerControl.xaml.cs
@@ -77,7 +77,9 @@ public partial class TaskbarVisualizerControl : UserControl
 
         SolidColorBrush targetBackgroundBrush;
         // hover effects with animations, hard-coded colors because I can't find the resource brushes
-        if (WindowsThemeHelper.GetCurrentWindowsTheme() == WindowsTheme.Dark)
+        WindowsThemeDetector.GetWindowsTheme(out _, out var systemTheme);
+        bool isDark = systemTheme == WindowsThemeDetector.ThemeMode.Dark;
+        if (isDark)
         { // dark mode
             targetBackgroundBrush = new SolidColorBrush(Color.FromArgb(197, 255, 255, 255)) { Opacity = 0.075 };
             TopBorder.BorderBrush = new SolidColorBrush(Color.FromArgb(93, 255, 255, 255)) { Opacity = 0.25 };

--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
@@ -107,10 +107,13 @@ public partial class TaskbarWidgetControl : UserControl
 
     public void ApplyWindowsTheme()
     {
-        bool isDark = WindowsThemeHelper.GetCurrentWindowsTheme() == WindowsTheme.Dark;
+        WindowsThemeDetector.GetWindowsTheme(out _, out var systemTheme);
+        bool isDark = systemTheme == WindowsThemeDetector.ThemeMode.Dark;
+
         var foreground = new SolidColorBrush(isDark
             ? Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF)
             : Color.FromArgb(0xE4, 0x1C, 0x1C, 0x1C));
+
         SongTitle.Foreground = foreground;
         SongArtist.Foreground = foreground;
     }
@@ -121,7 +124,10 @@ public partial class TaskbarWidgetControl : UserControl
 
         SolidColorBrush targetBackgroundBrush;
         // hover effects with animations, hard-coded colors because I can't find the resource brushes
-        if (WindowsThemeHelper.GetCurrentWindowsTheme() == WindowsTheme.Dark)
+        WindowsThemeDetector.GetWindowsTheme(out _, out var systemTheme);
+        bool isDark = systemTheme == WindowsThemeDetector.ThemeMode.Dark;
+
+        if (isDark)
         { // dark mode
             targetBackgroundBrush = new SolidColorBrush(Color.FromArgb(197, 255, 255, 255)) { Opacity = 0.075 };
             TopBorder.BorderBrush = new SolidColorBrush(Color.FromArgb(93, 255, 255, 255)) { Opacity = 0.25 };

--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
@@ -116,6 +116,9 @@ public partial class TaskbarWidgetControl : UserControl
 
         SongTitle.Foreground = foreground;
         SongArtist.Foreground = foreground;
+        PreviousButton.Foreground = foreground;
+        PlayPauseButton.Foreground = foreground;
+        NextButton.Foreground = foreground;
     }
 
     private void Grid_MouseEnter(object sender, MouseEventArgs e)


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->

Judging from the conversation in #537 the intended behavior is for the Taskbar Widget to follow Windows theming and not the FluentFlyout app theme. This adds a reg check to determine user's settings. It also fixes what I think is a bug where the Media Player buttons followed the FluentFlyout App theme settings. Now both of them will respect the Windows custom theme settings. 

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Closes #614, #513
Supersedes #537

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

<!-- Bullet points of key changes made in this PR. -->

- Moved to using a Registry Check instead of `WindowsThemeHelper` to detect user themes.
- Made the Taskbar Widget player buttons follow system settings similar to the song text rather than FluentFlyout app theme.

## Additional Information
- I've only checked the changes for Windows 11. Reg key should be the same in [Windows 10](https://superuser.com/questions/1245923/registry-keys-to-change-personalization-settings), but I don't have Win10 box to check. 
<!-- Any other information, such as screenshots -->

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
<!-- AI usage -->
- [ ] AI tools were used (if yes, I reviewed and fully understand the changes myself).