### PR TITLE
Fix volume mixer sessions not updating

### DIFF
--- a/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
+++ b/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
@@ -137,7 +137,9 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
 
         try
         {
-            var sessionManager = _device.AudioSessionManager;
+            // update device reference because previous _device doesn't have updated sessions
+            var updatedDevice = AudioDeviceMonitor.Instance.GetDeviceById(_device.ID) ?? _device;
+            var sessionManager = updatedDevice.AudioSessionManager;
             var sessions = sessionManager.Sessions;
 
             for (int i = 0; i < sessions.Count; i++)


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->

Fixes volume mixer not updating audio sessions properly when a session is added or removed.

## Motivation

Previously, the volume mixer only kept the audio sessions that were detected on startup. This behavior is incorrect, as it should track changes and adjust accordingly.
<!-- Why is this change needed? Link issues if applicable. -->

fixes #721, fixes #777, fixes #735

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other