### PR TITLE
feat: add options to individually toggle lock key indicators

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -745,17 +745,17 @@ public partial class MainWindow : MicaWindow
                 && !FullscreenDetector.IsFullscreenApplicationRunning()
                 && wParam == WM_KEYUP)
             {
-                if (vkCode == 0x14) // Caps Lock
+                if (vkCode == 0x14 && SettingsManager.Current.LockKeysCapsEnabled) // Caps Lock
                 {
                     lockWindow ??= new LockWindow();
                     lockWindow.ShowLockFlyout(FindResource("LockWindow_CapsLock").ToString(), Keyboard.IsKeyToggled(Key.CapsLock));
                 }
-                else if (vkCode == 0x90) // Num Lock
+                else if (vkCode == 0x90 && SettingsManager.Current.LockKeysNumEnabled) // Num Lock
                 {
                     lockWindow ??= new LockWindow();
                     lockWindow.ShowLockFlyout(FindResource("LockWindow_NumLock").ToString(), Keyboard.IsKeyToggled(Key.NumLock));
                 }
-                else if (vkCode == 0x91) // Scroll Lock
+                else if (vkCode == 0x91 && SettingsManager.Current.LockKeysScrollEnabled) // Scroll Lock
                 {
                     lockWindow ??= new LockWindow();
                     lockWindow.ShowLockFlyout(FindResource("LockWindow_ScrollLock").ToString(), Keyboard.IsKeyToggled(Key.Scroll));

--- a/FluentFlyoutWPF/Pages/LockKeysPage.xaml
+++ b/FluentFlyoutWPF/Pages/LockKeysPage.xaml
@@ -46,38 +46,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="LockKeysSwitch" IsChecked="{Binding LockKeysEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-
-            <ui:CardControl Grid.Row="2" Icon="{ui:SymbolIcon TextCaseTitle24}" Margin="0,0,0,3">
-                <ui:CardControl.Header>
-                    <StackPanel Orientation="Vertical">
-                        <TextBlock Text="{DynamicResource EnableCapsTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
-                        <TextBlock Text="{DynamicResource EnableCapsDescription}" FontSize="12" Opacity="0.5" />
-                    </StackPanel>
-                </ui:CardControl.Header>
-                <controls:ToggleSwitch Name="LockKeysCapsSwitch" IsChecked="{Binding LockKeysCapsEnabled, Mode=TwoWay}" />
-            </ui:CardControl>
-
-            <ui:CardControl Grid.Row="3" Icon="{ui:SymbolIcon NumberSymbol24}" Margin="0,0,0,3">
-                <ui:CardControl.Header>
-                    <StackPanel Orientation="Vertical">
-                        <TextBlock Text="{DynamicResource EnableNumTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
-                        <TextBlock Text="{DynamicResource EnableNumDescription}" FontSize="12" Opacity="0.5" />
-                    </StackPanel>
-                </ui:CardControl.Header>
-                <controls:ToggleSwitch Name="LockKeysNumSwitch" IsChecked="{Binding LockKeysNumEnabled, Mode=TwoWay}" />
-            </ui:CardControl>
-
-            <ui:CardControl Grid.Row="4" Icon="{ui:SymbolIcon ArrowBetweenDown24}" Margin="0,0,0,24">
-                <ui:CardControl.Header>
-                    <StackPanel Orientation="Vertical">
-                        <TextBlock Text="{DynamicResource EnableScrollTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
-                        <TextBlock Text="{DynamicResource EnableScrollDescription}" FontSize="12" Opacity="0.5" />
-                    </StackPanel>
-                </ui:CardControl.Header>
-                <controls:ToggleSwitch Name="LockKeysScrollSwitch" IsChecked="{Binding LockKeysScrollEnabled, Mode=TwoWay}" />
-            </ui:CardControl>
-
-            <ui:CardControl Grid.Row="5" Icon="{ui:SymbolIcon Blur24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="2" Icon="{ui:SymbolIcon Blur24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource AcrylicWindowTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -86,7 +55,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="LockKeysAcrylicWindowSwitch" IsChecked="{Binding LockKeysAcrylicWindowEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="6" Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="3" Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource LockKeysStayDurationTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -98,7 +67,7 @@
                     <TextBlock Text="{DynamicResource MillisecondsUnit}" FontSize="14" FontWeight="Regular" Margin="10,0,0,0" VerticalAlignment="Center" />
                 </StackPanel>
             </ui:CardControl>
-            <ui:CardControl Grid.Row="7" Icon="{ui:SymbolIcon TextBold24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="4" Icon="{ui:SymbolIcon TextBold24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource LockKeysBoldUITitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -107,7 +76,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="LockKeysBoldUISwitch" IsChecked="{Binding LockKeysBoldUi, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="8" Icon="{ui:SymbolIcon Wand24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="5" Icon="{ui:SymbolIcon Wand24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource LockKeysAnimatedTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -116,7 +85,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="LockKeysAnimatedSwitch" IsChecked="{Binding LockKeysAnimated, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="9" Icon="{ui:SymbolIcon ProjectionScreen24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="6" Icon="{ui:SymbolIcon ProjectionScreen24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <StackPanel Orientation="Horizontal">
@@ -132,7 +101,7 @@
                     <ComboBoxItem Content="{DynamicResource MonitorWithCursor}" />
                 </ComboBox>
             </ui:CardControl>
-            <ui:CardControl Grid.Row="10" Icon="{ui:SymbolIcon Info24}" Margin="0,0,0,76">
+            <ui:CardControl Grid.Row="7" Icon="{ui:SymbolIcon Info24}" Margin="0,0,0,24">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource EnableInsertKeyTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -140,6 +109,33 @@
                     </StackPanel>
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="LockKeysEnableInsertSwitch" IsChecked="{Binding LockKeysInsertEnabled, Mode=TwoWay}" />
+            </ui:CardControl>
+            <ui:CardControl Grid.Row="8" Icon="{ui:SymbolIcon TextCaseTitle24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource EnableCapsTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource EnableCapsDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <controls:ToggleSwitch Name="LockKeysCapsSwitch" IsChecked="{Binding LockKeysCapsEnabled, Mode=TwoWay}" />
+            </ui:CardControl>
+            <ui:CardControl Grid.Row="9" Icon="{ui:SymbolIcon NumberSymbol24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource EnableNumTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource EnableNumDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <controls:ToggleSwitch Name="LockKeysNumSwitch" IsChecked="{Binding LockKeysNumEnabled, Mode=TwoWay}" />
+            </ui:CardControl>
+            <ui:CardControl Grid.Row="10" Icon="{ui:SymbolIcon ArrowBetweenDown24}" Margin="0,0,0,76">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource EnableScrollTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource EnableScrollDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <controls:ToggleSwitch Name="LockKeysScrollSwitch" IsChecked="{Binding LockKeysScrollEnabled, Mode=TwoWay}" />
             </ui:CardControl>
         </Grid>
     </StackPanel>

--- a/FluentFlyoutWPF/Pages/LockKeysPage.xaml
+++ b/FluentFlyoutWPF/Pages/LockKeysPage.xaml
@@ -25,6 +25,9 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <StackPanel Orientation="Horizontal" Margin="0,0,0,24">
                 <Border CornerRadius="10" ClipToBounds="True" Width="164" Height="98">
@@ -43,7 +46,38 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="LockKeysSwitch" IsChecked="{Binding LockKeysEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="2" Icon="{ui:SymbolIcon Blur24}" Margin="0,0,0,3">
+
+            <ui:CardControl Grid.Row="2" Icon="{ui:SymbolIcon TextCaseTitle24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource EnableCapsTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource EnableCapsDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <controls:ToggleSwitch Name="LockKeysCapsSwitch" IsChecked="{Binding LockKeysCapsEnabled, Mode=TwoWay}" />
+            </ui:CardControl>
+
+            <ui:CardControl Grid.Row="3" Icon="{ui:SymbolIcon NumberSymbol24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource EnableNumTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource EnableNumDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <controls:ToggleSwitch Name="LockKeysNumSwitch" IsChecked="{Binding LockKeysNumEnabled, Mode=TwoWay}" />
+            </ui:CardControl>
+
+            <ui:CardControl Grid.Row="4" Icon="{ui:SymbolIcon ArrowBetweenDown24}" Margin="0,0,0,24">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource EnableScrollTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource EnableScrollDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <controls:ToggleSwitch Name="LockKeysScrollSwitch" IsChecked="{Binding LockKeysScrollEnabled, Mode=TwoWay}" />
+            </ui:CardControl>
+
+            <ui:CardControl Grid.Row="5" Icon="{ui:SymbolIcon Blur24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource AcrylicWindowTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -52,7 +86,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="LockKeysAcrylicWindowSwitch" IsChecked="{Binding LockKeysAcrylicWindowEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="3" Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="6" Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource LockKeysStayDurationTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -64,7 +98,7 @@
                     <TextBlock Text="{DynamicResource MillisecondsUnit}" FontSize="14" FontWeight="Regular" Margin="10,0,0,0" VerticalAlignment="Center" />
                 </StackPanel>
             </ui:CardControl>
-            <ui:CardControl Grid.Row="4" Icon="{ui:SymbolIcon TextBold24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="7" Icon="{ui:SymbolIcon TextBold24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource LockKeysBoldUITitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -73,7 +107,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="LockKeysBoldUISwitch" IsChecked="{Binding LockKeysBoldUi, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="5" Icon="{ui:SymbolIcon Wand24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="8" Icon="{ui:SymbolIcon Wand24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource LockKeysAnimatedTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -82,7 +116,7 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="LockKeysAnimatedSwitch" IsChecked="{Binding LockKeysAnimated, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="6" Icon="{ui:SymbolIcon ProjectionScreen24}" Margin="0,0,0,3">
+            <ui:CardControl Grid.Row="9" Icon="{ui:SymbolIcon ProjectionScreen24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <StackPanel Orientation="Horizontal">
@@ -98,7 +132,7 @@
                     <ComboBoxItem Content="{DynamicResource MonitorWithCursor}" />
                 </ComboBox>
             </ui:CardControl>
-            <ui:CardControl Grid.Row="7" Icon="{ui:SymbolIcon Info24}" Margin="0,0,0,76">
+            <ui:CardControl Grid.Row="10" Icon="{ui:SymbolIcon Info24}" Margin="0,0,0,76">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource EnableInsertKeyTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -120,6 +120,12 @@ Note: As an open-source project, these features are also available for free via 
     <System:String x:Key="LockKeysDescription" xml:space="preserve">Check your lock key status at a glance. Appears after pressing Caps Lock, Num Lock or Scroll Lock. Convenient for laptops/keyboards without lock key indicators.</System:String>
     <System:String x:Key="EnableLockKeysTitle">Enable Lock Keys Flyout</System:String>
     <System:String x:Key="EnableLockKeysDescription">Displays whether the specified lock key is on or off</System:String>
+    <System:String x:Key="EnableCapsTitle">Enable Caps Lock indicator</System:String>
+    <System:String x:Key="EnableCapsDescription">Shows when the Caps Lock key is pressed</System:String>
+    <System:String x:Key="EnableNumTitle">Enable Num Lock indicator</System:String>
+    <System:String x:Key="EnableNumDescription">Shows when the Num Lock key is pressed</System:String>
+    <System:String x:Key="EnableScrollTitle">Enable Scroll Lock indicator</System:String>
+    <System:String x:Key="EnableScrollDescription">Shows when the Scroll Lock key is pressed</System:String>
     <System:String x:Key="LockKeysStayDurationTitle">Lock Keys Stay Duration</System:String>
     <System:String x:Key="LockKeysStayDurationDescription">(default: 2000 ms)</System:String>
     <System:String x:Key="LockKeysBoldUITitle">Bold Symbol and Font</System:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -182,6 +182,15 @@ public partial class UserSettings : ObservableObject
     [ObservableProperty]
     public partial bool LockKeysEnabled { get; set; }
 
+    [ObservableProperty]
+    public partial bool LockKeysCapsEnabled { get; set; }
+
+    [ObservableProperty]
+    public partial bool LockKeysNumEnabled { get; set; }
+
+    [ObservableProperty]
+    public partial bool LockKeysScrollEnabled { get; set; }
+
     /// <summary>
     /// Lock keys flyout display duration (milliseconds)
     /// </summary>
@@ -608,6 +617,9 @@ public partial class UserSettings : ObservableObject
         CenterTitleArtist = false;
         FlyoutAnimationEasingStyle = 2;
         LockKeysEnabled = true;
+        LockKeysCapsEnabled = true;
+        LockKeysNumEnabled = true;
+        LockKeysScrollEnabled = true;
         LockKeysDuration = 2000;
         AppTheme = 0;
         MediaFlyoutEnabled = true;


### PR DESCRIPTION
## Description
This PR adds toggles in the Lock Keys flyout settings page to individually enable or disable the on-screen display for Caps Lock, Num Lock, and Scroll Lock keys.

## Changes Made
- Added LockKeysCapsEnabled, LockKeysNumEnabled, and LockKeysScrollEnabled boolean properties in UserSettings.cs.
- Updated the key hook logic in MainWindow.xaml.cs to check these new properties before showing the flyout.
- Added three new ToggleSwitches in LockKeysPage.xaml for the UI.
- Added the necessary localized strings for the new options in English.