### PR TITLE
Add locale-aware GlobalFontFamily and enable dynamic FontFamily

### DIFF
--- a/FluentFlyoutWPF/App.xaml
+++ b/FluentFlyoutWPF/App.xaml
@@ -6,6 +6,7 @@
              StartupUri="MainWindow.xaml"
              xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
              xmlns:mica="clr-namespace:MicaWPF.Styles;assembly=MicaWPF"
+             xmlns:controls="clr-namespace:MicaWPF.Controls;assembly=MicaWPF"
              xmlns:utils="clr-namespace:FluentFlyoutWPF.Classes.Utils"
              ShutdownMode="OnExplicitShutdown">
     <Application.Resources>
@@ -21,7 +22,23 @@
                 <ResourceDictionary Source="Resources/Localization/Dictionary-en-US.xaml"/>
             </ResourceDictionary.MergedDictionaries>
             <FontFamily x:Key="SegoeFluentIcons">pack://application:,,,/;component/Fonts/#Segoe Fluent Icons</FontFamily>
-            
+
+            <!-- set global font family -->
+            <FontFamily x:Key="GlobalFontFamily">Segoe UI Variable, Microsoft YaHei UI, Yu Gothic UI, Malgun Gothic</FontFamily>
+
+            <!-- apply global font family to TextBlocks except ones inside icon controls -->
+            <Style TargetType="TextBlock">
+                <Style.Triggers>
+                    <!-- If not inside a MicaWPF SymbolIcon, apply the GlobalFontFamily -->
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type controls:SymbolIcon}}}" Value="{x:Null}">
+                        <Setter Property="FontFamily" Value="{DynamicResource GlobalFontFamily}" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+            <Style TargetType="Control">
+                <Setter Property="FontFamily" Value="{DynamicResource GlobalFontFamily}" />
+            </Style>
+
             <!-- override default background colors -->
             <SolidColorBrush x:Key="NavigationViewContentBackground" Color="Transparent" />
             <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="Transparent" />

--- a/FluentFlyoutWPF/Classes/LocalizationManager.cs
+++ b/FluentFlyoutWPF/Classes/LocalizationManager.cs
@@ -181,6 +181,17 @@ public static class LocalizationManager
         }
         SettingsManager.Current.FontFamily = fontFamily;
 
+        // apply the font family to the entire application
+        try
+        {
+            var ff = new System.Windows.Media.FontFamily(fontFamily);
+            Application.Current.Resources["GlobalFontFamily"] = ff;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "Failed to apply GlobalFontFamily, keeping SettingsManager value only.");
+        }
+
         Logger.Debug("Applied font family: " + fontFamily);
     }
 }

--- a/FluentFlyoutWPF/Windows/LockWindow.xaml
+++ b/FluentFlyoutWPF/Windows/LockWindow.xaml
@@ -12,7 +12,7 @@
     WindowStyle="None" ShowInTaskbar="False"
     ChangeTitleColorWhenInactive="False" Visibility="Visible"
     TextOptions.TextRenderingMode="ClearType" TextOptions.TextFormattingMode="Ideal"
-    FontFamily="{Binding FontFamily}"
+    FontFamily="{DynamicResource GlobalFontFamily}"
     FlowDirection="{Binding FlowDirection}"
     d:DataContext="{d:DesignInstance viewModels:UserSettings}"
     >


### PR DESCRIPTION
## Summary

Switched to changing the font family dynamically to use correct one.

|before|after|
|---|---|
|<img width="400" src="https://github.com/user-attachments/assets/61affe63-fab3-4cee-b81a-670ee089bf41" />|<img width="400" src="https://github.com/user-attachments/assets/8201e1ae-e9e8-4139-8e8f-fc01483ce551" />|


## Motivation

The language‑specific font priority isn't working in both the Media Flyout and the Taskbar Widget ("Up Next" isn't affected). As a result, characters aren't rendered using the intended fonts (In the following example, selected font is not suitable for displaying Japanese).

> <img width="491" height="99" src="https://github.com/user-attachments/assets/d015c0a2-0c79-4fe6-b535-2d36a8839ed2" />
> 
> title `おしえてアンドロメダ` in "Up Next" is using `Yu Gothic UI` (Japanese font), but Taskbar Widget isn't.

For Japanese users, being forced into an inappropriate fallback font significantly degrades readability and user experience — much like replacing all English text with Comic Sans🙃


```cs
  // dictionary of font families for specific languages, priorities are switched around
  private static readonly Dictionary<string, string> _languageFontFamilies = new()
  {
      { "default", "Segoe UI Variable, Microsoft YaHei UI, Yu Gothic UI, Malgun Gothic" }, // default support for multiple languages
      //{ "zh-CN", "Segoe UI Variable, Microsoft YaHei UI, Yu Gothic UI, Malgun Gothic" }, // same as default
      { "zh-TW", "Segoe UI Variable, Microsoft JhengHei UI, Yu Gothic UI, Malgun Gothic" },
      { "ja", "Segoe UI Variable, Yu Gothic UI, Microsoft YaHei UI, Malgun Gothic" },
      { "ko", "Segoe UI Variable, Malgun Gothic, Microsoft YaHei UI, Yu Gothic UI" },
  };
```

The logic was in place (eg. #317 ), but it wasn’t actually taking effect in all relevant parts of the UI.

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

- Added locale-aware global font selection in LocalizationManager.cs
  - Applied dynamic `GlobalFontFamily` via `Application.Current.Resources` so UI updates at runtime
  - Kept existing localization loading logic while enabling dynamic font switching based on current culture
- Ensured `TextBlock` and `Control` styles in App.xaml use `DynamicResource GlobalFontFamily` for consistent font application
  - Excluded MicaWPF SymbolIcon from `GlobalFontFamily` so icon rendering is not broken

## Additional Information

<!-- Any other information, such as screenshots -->

## Checklist
- [x] Code changes are manually tested and working.
- [ ] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
<!-- AI usage -->
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).