### PR TITLE
Fix: Master and mixer volume sliders not clearing mute state when raised from zero

### DIFF
--- a/FluentFlyoutWPF/Models/AudioSessionModel.cs
+++ b/FluentFlyoutWPF/Models/AudioSessionModel.cs
@@ -51,6 +51,9 @@ public partial class AudioSessionModel : ObservableObject
         if (Volume == 0f)
         {
             IsMuted = true;
+        } else
+        {
+            IsMuted = false;
         }
     }
 

--- a/FluentFlyoutWPF/Models/AudioSessionModel.cs
+++ b/FluentFlyoutWPF/Models/AudioSessionModel.cs
@@ -51,7 +51,8 @@ public partial class AudioSessionModel : ObservableObject
         if (Volume == 0f)
         {
             IsMuted = true;
-        } else
+        }
+        else
         {
             IsMuted = false;
         }

--- a/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
+++ b/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
@@ -102,6 +102,9 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
         if (MasterVolume == 0f)
         {
             IsMasterMuted = true;
+        } else
+        {
+            IsMasterMuted = false;
         }
     }
 

--- a/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
+++ b/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
@@ -102,7 +102,8 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
         if (MasterVolume == 0f)
         {
             IsMasterMuted = true;
-        } else
+        }
+        else
         {
             IsMasterMuted = false;
         }


### PR DESCRIPTION
## Summary

Fixes an issue where the master audio device remained muted after increasing the volume from zero.

## Motivation

When the master volume was set to 0, `IsMasterMuted` was correctly set to `true`. However, increasing the volume afterwards did not reset `IsMasterMuted` back to `false`, causing the mute icon to remain visible and audio output to stay muted.

## Type of Change

- [x] Bug fix

## What Changed

- Added missing logic to set `IsMasterMuted` to `false` when the master volume is greater than zero.
- Ensured the mute state always stays synchronized with the current master volume level.

## Additional Information

Here is how it was looking before:

<img width="403" height="333" alt="image" src="https://github.com/user-attachments/assets/2cca904d-fc31-497d-96a7-0f5e722c2e06" />

Before this change:
- Setting volume to 0 muted the device.
- Increasing the volume afterwards did not unmute it.

After this change:
- The mute state is automatically updated whenever the volume changes.
- Audio output and mute icon behavior now correctly reflect the current volume level.

## Checklist

- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
- [ ] AI tools were used (if yes, I reviewed and fully understand the changes myself).