### PR TITLE
feat: add taskbar lyrics real-time sync with adjustable delay slider

### DIFF
--- a/FluentFlyoutWPF/Controls/TaskbarLyricsControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarLyricsControl.xaml.cs
@@ -1,0 +1,414 @@
+// Copyright (c) 2024-2026 The FluentFlyout Authors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using FluentFlyout.Classes.Settings;
+using FluentFlyoutWPF;
+using FluentFlyoutWPF.Classes;
+using MicaWPF.Core.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Threading;
+using Windows.Media.Control;
+
+namespace FluentFlyout.Controls
+{
+    public partial class TaskbarLyricsControl : UserControl
+    {
+        private static DispatcherTimer? _lyricsTimer;
+        private static TaskbarLyricsControl? _instance;
+
+        private MainWindow? _mainWindow;
+        private string _currentTitle = string.Empty;
+        private string _currentArtist = string.Empty;
+        private List<LrcLine> _lyrics = new();
+        private string _lastLineText = string.Empty;
+        private bool _isFetching;
+        private Storyboard? _scrollStoryboard;
+
+        public TaskbarLyricsControl()
+        {
+            InitializeComponent();
+            _instance = this;
+
+            DataContext = SettingsManager.Current;
+
+            if (MainBorder.Background is not SolidColorBrush)
+            {
+                MainBorder.Background = new SolidColorBrush(Colors.Transparent);
+                MainBorder.Background.Opacity = 0;
+            }
+
+            Background = new SolidColorBrush(Color.FromArgb(1, 0, 0, 0));
+
+            if (SettingsManager.Current.TaskbarLyricsEnabled)
+            {
+                StartLyricsTimer();
+            }
+        }
+
+        public static void OnTaskbarLyricsEnabledChanged(bool value)
+        {
+            if (value)
+            {
+                StartLyricsTimer();
+            }
+            else
+            {
+                StopLyricsTimer();
+                if (_instance != null)
+                {
+                    _instance.SetLyricsText(string.Empty);
+                    _instance._lyrics.Clear();
+                    _instance._currentTitle = string.Empty;
+                    _instance._currentArtist = string.Empty;
+                }
+                SettingsManager.Current.TaskbarLyricsHasContent = false;
+            }
+        }
+
+        private static void StartLyricsTimer()
+        {
+            if (_lyricsTimer == null)
+            {
+                _lyricsTimer = new DispatcherTimer
+                {
+                    Interval = TimeSpan.FromMilliseconds(200)
+                };
+                _lyricsTimer.Tick += LyricsTimer_Tick;
+            }
+
+            if (!_lyricsTimer.IsEnabled)
+            {
+                _lyricsTimer.Start();
+            }
+        }
+
+        private static void StopLyricsTimer()
+        {
+            if (_lyricsTimer != null && _lyricsTimer.IsEnabled)
+            {
+                _lyricsTimer.Stop();
+            }
+        }
+
+        private static async void LyricsTimer_Tick(object? sender, EventArgs e)
+        {
+            if (_instance == null) return;
+            if (_instance._isFetching) return;
+
+            try
+            {
+                if (_instance._mainWindow == null)
+                {
+                    _instance._mainWindow = (MainWindow)Application.Current.MainWindow;
+                    if (_instance._mainWindow == null) return;
+                }
+
+                var session = _instance._mainWindow.GetActiveMediaSession();
+                if (session == null)
+                {
+                    _instance.SetLyricsText(string.Empty);
+                    _instance._currentTitle = string.Empty;
+                    _instance._currentArtist = string.Empty;
+                    _instance._lyrics.Clear();
+                    SettingsManager.Current.TaskbarLyricsHasContent = false;
+                    return;
+                }
+
+                var playbackInfo = session.ControlSession.GetPlaybackInfo();
+                if (playbackInfo == null || playbackInfo.PlaybackStatus == GlobalSystemMediaTransportControlsSessionPlaybackStatus.Closed)
+                {
+                    _instance.SetLyricsText(string.Empty);
+                    _instance._lyrics.Clear();
+                    SettingsManager.Current.TaskbarLyricsHasContent = false;
+                    return;
+                }
+
+                var mediaProps = await TryGetMediaPropertiesAsync(session.ControlSession);
+                if (mediaProps == null || string.IsNullOrEmpty(mediaProps.Title))
+                {
+                    _instance.SetLyricsText(string.Empty);
+                    _instance._lyrics.Clear();
+                    SettingsManager.Current.TaskbarLyricsHasContent = false;
+                    return;
+                }
+
+                if (mediaProps.Title != _instance._currentTitle || mediaProps.Artist != _instance._currentArtist)
+                {
+                    _instance._currentTitle = mediaProps.Title;
+                    _instance._currentArtist = mediaProps.Artist;
+                    _instance.SetLyricsText("...");
+                    _instance._lyrics.Clear();
+                    _instance._isFetching = true;
+                    SettingsManager.Current.TaskbarLyricsHasContent = true;
+
+                    string targetTitle = _instance._currentTitle;
+                    string targetArtist = _instance._currentArtist;
+                    var timeline = session.ControlSession.GetTimelineProperties();
+                    double duration = timeline.EndTime.TotalSeconds;
+
+                    _lyricsTimer?.Stop();
+                    try
+                    {
+                        var fetchedLyrics = await LyricsManager.FetchLyricsAsync(targetArtist, targetTitle, duration);
+                        try
+                        {
+                            NLog.LogManager.GetCurrentClassLogger().Info($"Fetched {fetchedLyrics.Count} lyric lines for '{targetArtist} - {targetTitle}'");
+                        }
+                        catch { }
+
+                        if (_instance != null && _instance._currentTitle == targetTitle && _instance._currentArtist == targetArtist)
+                        {
+                            _instance._lyrics = fetchedLyrics;
+                            if (_instance._lyrics.Count == 0)
+                            {
+                                _instance.SetLyricsText(string.Empty);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        if (_instance != null) _instance._isFetching = false;
+                        _lyricsTimer?.Start();
+                    }
+                    return;
+                }
+
+                if (_instance._lyrics.Count > 0)
+                {
+                    var timeline = session.ControlSession.GetTimelineProperties();
+                    var pos = timeline.Position;
+                    TimeSpan timeSinceLastUpdate = TimeSpan.Zero;
+                    if (playbackInfo.PlaybackStatus == GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing)
+                    {
+                        timeSinceLastUpdate = DateTimeOffset.UtcNow - timeline.LastUpdatedTime;
+                        if (timeSinceLastUpdate.TotalSeconds > 0)
+                        {
+                            pos += timeSinceLastUpdate;
+                        }
+                    }
+
+                    if (pos > timeline.EndTime)
+                    {
+                        pos = timeline.EndTime;
+                    }
+
+                    var lookupPos = pos + TimeSpan.FromMilliseconds(SettingsManager.Current.TaskbarLyricsDelay);
+                    if (lookupPos < TimeSpan.Zero)
+                    {
+                        lookupPos = TimeSpan.Zero;
+                    }
+                    else if (lookupPos > timeline.EndTime)
+                    {
+                        lookupPos = timeline.EndTime;
+                    }
+
+                    var currentLine = _instance._lyrics.LastOrDefault(x => x.Timestamp <= lookupPos);
+                    string newText = currentLine != null ? currentLine.Text : string.Empty;
+
+                    try
+                    {
+                        NLog.LogManager.GetCurrentClassLogger().Info($"Lyrics Sync: pos={pos.TotalSeconds:F2}s, lookupPos={lookupPos.TotalSeconds:F2}s, delay={SettingsManager.Current.TaskbarLyricsDelay}ms, timeline.Position={timeline.Position.TotalSeconds:F2}s, lastUpdated={timeline.LastUpdatedTime:yyyy-MM-dd HH:mm:ss.fff zzz}, utcNow={DateTimeOffset.UtcNow:yyyy-MM-dd HH:mm:ss.fff zzz}, diff={timeSinceLastUpdate.TotalSeconds:F2}s, lyricsCount={_instance._lyrics.Count}, text='{newText}'");
+                    }
+                    catch { }
+
+                    if (newText != _instance._lastLineText)
+                    {
+                        _instance._lastLineText = newText;
+                        _instance.SetLyricsText(newText);
+                    }
+                }
+                else
+                {
+                    try
+                    {
+                        NLog.LogManager.GetCurrentClassLogger().Info($"Lyrics Sync: No lyrics loaded (_lyrics.Count = 0). Current title: '{_instance._currentTitle}', artist: '{_instance._currentArtist}'");
+                    }
+                    catch { }
+                }
+
+                bool hasContent = _instance._lyrics.Count > 0;
+                if (SettingsManager.Current.TaskbarLyricsHasContent != hasContent)
+                {
+                    SettingsManager.Current.TaskbarLyricsHasContent = hasContent;
+                }
+            }
+            catch (Exception ex)
+            {
+                try { NLog.LogManager.GetCurrentClassLogger().Warn(ex, "LyricsTimer_Tick error (suppressed)"); } catch { }
+                if (_instance != null) _instance._isFetching = false;
+                if (SettingsManager.Current.TaskbarLyricsHasContent)
+                    SettingsManager.Current.TaskbarLyricsHasContent = false;
+                _lyricsTimer?.Start();
+            }
+        }
+
+        private static async Task<GlobalSystemMediaTransportControlsSessionMediaProperties?> TryGetMediaPropertiesAsync(GlobalSystemMediaTransportControlsSession controlSession)
+        {
+            try
+            {
+                return await controlSession.TryGetMediaPropertiesAsync();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private void Grid_MouseEnter(object sender, MouseEventArgs e)
+        {
+            if (!SettingsManager.Current.TaskbarLyricsClickable || !SettingsManager.Current.TaskbarLyricsHasContent) return;
+
+            SolidColorBrush targetBackgroundBrush;
+            WindowsThemeDetector.GetWindowsTheme(out _, out var systemTheme);
+            bool isDark = systemTheme == WindowsThemeDetector.ThemeMode.Dark;
+            if (isDark)
+            {
+                targetBackgroundBrush = new SolidColorBrush(Color.FromArgb(197, 255, 255, 255)) { Opacity = 0.075 };
+                TopBorder.BorderBrush = new SolidColorBrush(Color.FromArgb(93, 255, 255, 255)) { Opacity = 0.25 };
+            }
+            else
+            {
+                targetBackgroundBrush = new SolidColorBrush(Color.FromArgb(255, 255, 255, 255)) { Opacity = 0.6 };
+                TopBorder.BorderBrush = new SolidColorBrush(Color.FromArgb(93, 255, 255, 255)) { Opacity = 1 };
+            }
+
+            var backgroundAnimation = new ColorAnimation
+            {
+                To = targetBackgroundBrush.Color,
+                Duration = TimeSpan.FromMilliseconds(200),
+                EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
+            };
+
+            var backgroundOpacityAnimation = new DoubleAnimation
+            {
+                To = targetBackgroundBrush.Opacity,
+                Duration = TimeSpan.FromMilliseconds(200),
+                EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
+            };
+
+            if (MainBorder.Background is not SolidColorBrush)
+            {
+                MainBorder.Background = new SolidColorBrush(Colors.Transparent);
+                MainBorder.Background.Opacity = 0;
+            }
+
+            MainBorder.Background.BeginAnimation(SolidColorBrush.ColorProperty, backgroundAnimation);
+            MainBorder.Background.BeginAnimation(SolidColorBrush.OpacityProperty, backgroundOpacityAnimation);
+        }
+
+        private void Grid_MouseLeave(object sender, MouseEventArgs e)
+        {
+            if (!SettingsManager.Current.TaskbarLyricsClickable || !SettingsManager.Current.TaskbarLyricsHasContent) return;
+
+            var backgroundAnimation = new ColorAnimation
+            {
+                To = Colors.Transparent,
+                Duration = TimeSpan.FromMilliseconds(200),
+                EasingFunction = new CubicEase { EasingMode = EasingMode.EaseInOut }
+            };
+
+            var backgroundOpacityAnimation = new DoubleAnimation
+            {
+                To = 0,
+                Duration = TimeSpan.FromMilliseconds(200),
+                EasingFunction = new CubicEase { EasingMode = EasingMode.EaseInOut }
+            };
+
+            MainBorder.Background?.BeginAnimation(SolidColorBrush.ColorProperty, backgroundAnimation);
+            MainBorder.Background?.BeginAnimation(SolidColorBrush.OpacityProperty, backgroundOpacityAnimation);
+
+            TopBorder.BorderBrush = System.Windows.Media.Brushes.Transparent;
+        }
+
+        private void Grid_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            if (!SettingsManager.Current.TaskbarLyricsClickable || !SettingsManager.Current.TaskbarLyricsHasContent) return;
+
+            SettingsWindow.ShowInstance("TaskbarLyricsPage");
+        }
+
+        private void ClippedGrid_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            UpdateTextLayout();
+        }
+
+        private void LyricsText_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            UpdateTextLayout();
+        }
+
+        private void UpdateTextLayout()
+        {
+            if (ClippedGrid == null || LyricsText == null) return;
+
+            _scrollStoryboard?.Stop();
+            _scrollStoryboard = null;
+            LyricsText.BeginAnimation(Canvas.LeftProperty, null);
+            Canvas.SetLeft(LyricsText, 0);
+
+            double containerWidth = ClippedGrid.ActualWidth;
+            double textWidth = LyricsText.ActualWidth;
+
+            if (containerWidth <= 0 || textWidth <= 0)
+            {
+                return;
+            }
+
+            if (textWidth <= containerWidth)
+            {
+                double left = (containerWidth - textWidth) / 2.0;
+                Canvas.SetLeft(LyricsText, left);
+            }
+            else
+            {
+                Canvas.SetLeft(LyricsText, 0);
+
+                double scrollDistance = textWidth - containerWidth + 12;
+                double speed = 35.0;
+                double durationSec = scrollDistance / speed;
+
+                var keyFrameAnimation = new DoubleAnimationUsingKeyFrames();
+                keyFrameAnimation.RepeatBehavior = RepeatBehavior.Forever;
+
+                keyFrameAnimation.KeyFrames.Add(new LinearDoubleKeyFrame(0, KeyTime.FromTimeSpan(TimeSpan.Zero)));
+                keyFrameAnimation.KeyFrames.Add(new LinearDoubleKeyFrame(0, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(1.5))));
+
+                TimeSpan scrollTime = TimeSpan.FromSeconds(1.5 + durationSec);
+                keyFrameAnimation.KeyFrames.Add(new LinearDoubleKeyFrame(-scrollDistance, KeyTime.FromTimeSpan(scrollTime)));
+
+                TimeSpan pauseTime = scrollTime + TimeSpan.FromSeconds(1.5);
+                keyFrameAnimation.KeyFrames.Add(new LinearDoubleKeyFrame(-scrollDistance, KeyTime.FromTimeSpan(pauseTime)));
+
+                TimeSpan scrollBackTime = pauseTime + TimeSpan.FromSeconds(durationSec);
+                keyFrameAnimation.KeyFrames.Add(new LinearDoubleKeyFrame(0, KeyTime.FromTimeSpan(scrollBackTime)));
+
+                TimeSpan finalTime = scrollBackTime + TimeSpan.FromSeconds(1.5);
+                keyFrameAnimation.KeyFrames.Add(new LinearDoubleKeyFrame(0, KeyTime.FromTimeSpan(finalTime)));
+
+                Storyboard.SetTarget(keyFrameAnimation, LyricsText);
+                Storyboard.SetTargetProperty(keyFrameAnimation, new PropertyPath(Canvas.LeftProperty));
+
+                _scrollStoryboard = new Storyboard();
+                _scrollStoryboard.Children.Add(keyFrameAnimation);
+                _scrollStoryboard.Begin();
+            }
+        }
+
+        private void SetLyricsText(string text)
+        {
+            if (LyricsText == null) return;
+            if (LyricsText.Text == text) return;
+
+            LyricsText.Text = text;
+            var fadeIn = new DoubleAnimation(0.2, 1.0, TimeSpan.FromMilliseconds(200));
+            LyricsText.BeginAnimation(OpacityProperty, fadeIn);
+        }
+    }
+}

--- a/FluentFlyoutWPF/Pages/TaskbarLyricsPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarLyricsPage.xaml
@@ -1,0 +1,133 @@
+<Page x:Class="FluentFlyoutWPF.Pages.TaskbarLyricsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+      xmlns:controls="clr-namespace:MicaWPF.Controls;assembly=MicaWPF"
+      xmlns:viewModels="clr-namespace:FluentFlyoutWPF.ViewModels"
+      xmlns:fluentflyoutcontrols="clr-namespace:FluentFlyout.Controls"
+      mc:Ignorable="d"
+      d:DesignHeight="1000" d:DesignWidth="800"
+      Title="TaskbarLyricsPage"
+      d:DataContext="{d:DesignInstance viewModels:UserSettings}"
+      Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+      d:Background="White">
+
+    <StackPanel MaxWidth="1000" Margin="16">
+        <TextBlock Text="{DynamicResource TaskbarLyricsTitle}" FontSize="24" FontWeight="SemiBold" FontFamily="Segoe UI Variable" Margin="0,0,0,20" />
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,24">
+                <Border CornerRadius="10" ClipToBounds="True" Width="164" Height="98">
+                    <Border.Background>
+                        <ImageBrush ImageSource="/Resources/FluentFlyoutTaskbar-NoTitle-Zoomed.png" Stretch="UniformToFill" />
+                    </Border.Background>
+                </Border>
+                <TextBlock FontSize="14" FontWeight="Regular" HorizontalAlignment="Stretch" Opacity="0.75" Margin="12,0,0,0" MaxWidth="450" TextWrapping="WrapWithOverflow" Text="{DynamicResource TaskbarLyricsDescription}" />
+            </StackPanel>
+
+            <!-- Premium Status InfoBar -->
+            <ui:InfoBar Grid.Row="1" Title="{DynamicResource PremiumUnlockedMessage}" Severity="Success" IsClosable="True" Margin="0,0,0,3">
+                <ui:InfoBar.Style>
+                    <Style TargetType="ui:InfoBar" BasedOn="{StaticResource {x:Type ui:InfoBar}}">
+                        <Setter Property="IsOpen" Value="False" />
+                        <Style.Triggers>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding IsStoreVersion}" Value="True" />
+                                    <Condition Binding="{Binding IsPremiumUnlocked}" Value="True" />
+                                </MultiDataTrigger.Conditions>
+                                <Setter Property="IsOpen" Value="True" />
+                            </MultiDataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ui:InfoBar.Style>
+            </ui:InfoBar>
+
+            <!-- Premium Locked InfoBar -->
+            <ui:InfoBar Grid.Row="1" IsOpen="True" Severity="Warning" IsClosable="False" Margin="0,0,0,3">
+                <ui:InfoBar.Style>
+                    <Style TargetType="ui:InfoBar">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding IsStoreVersion}" Value="True" />
+                                    <Condition Binding="{Binding IsPremiumUnlocked}" Value="False" />
+                                </MultiDataTrigger.Conditions>
+                                <Setter Property="Visibility" Value="Visible" />
+                            </MultiDataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ui:InfoBar.Style>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="{DynamicResource PremiumLockedMessage}" VerticalAlignment="Center" />
+                    <ui:Button Name="UnlockPremiumButton" Content="{DynamicResource UnlockPremiumButton}" 
+                            Click="UnlockPremiumButton_Click" 
+                            Appearance="Primary"
+                            Margin="12,2,0,2" FontSize="12"/>
+                </StackPanel>
+            </ui:InfoBar>
+
+            <!-- GitHub Version InfoBar -->
+            <ui:InfoBar Grid.Row="1" Title="{DynamicResource PremiumGitHubMessage}" Severity="Informational" IsOpen="True" IsClosable="False" Margin="0,0,0,3" Visibility="{Binding IsStoreVersion, Converter={StaticResource BoolToCollapsedVisibleConverter}}" />
+        </Grid>
+
+        <StackPanel Opacity="{Binding IsPremiumUnlocked, Converter={StaticResource BoolToFullHalfOpacityConverter}}">
+            <ui:CardControl Icon="{ui:SymbolIcon MusicNote224}" Margin="0,0,0,24">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{DynamicResource TaskbarLyricsEnabledTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                            <fluentflyoutcontrols:AccentBadge Margin="6,0,0,0" />
+                        </StackPanel>
+                        <TextBlock Text="{DynamicResource TaskbarLyricsEnabledDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <controls:ToggleSwitch IsChecked="{Binding TaskbarLyricsEnabled, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
+            </ui:CardControl>
+
+            <ui:CardControl Icon="{ui:SymbolIcon ArrowMove24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource TaskbarLyricsPositionTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <ComboBox SelectedIndex="{Binding TaskbarLyricsPosition}" IsEnabled="{Binding IsPremiumUnlocked}">
+                    <ComboBoxItem Content="{DynamicResource PositionBottomLeft}" />
+                    <ComboBoxItem Content="{DynamicResource PositionBottomRight}" />
+                </ComboBox>
+            </ui:CardControl>
+
+            <ui:CardControl Icon="{ui:SymbolIcon ExpandUpRight24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{DynamicResource TaskbarLyricsClickableTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        </StackPanel>
+                        <TextBlock Text="{DynamicResource TaskbarLyricsClickableDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <controls:ToggleSwitch IsChecked="{Binding TaskbarLyricsClickable, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
+            </ui:CardControl>
+
+            <ui:CardControl Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,76">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource TaskbarLyricsDelayTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource TaskbarLyricsDelayDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <StackPanel Orientation="Horizontal" Opacity="{Binding IsPremiumUnlocked, Converter={StaticResource BoolToFullHalfOpacityConverter}}">
+                    <Slider Minimum="-2000" Maximum="2000" Value="{Binding TaskbarLyricsDelay, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" TickFrequency="100" IsSnapToTickEnabled="True" Width="150" />
+                    <ui:TextBlock Text="{Binding TaskbarLyricsDelay, StringFormat={}{0} ms}" Width="60" TextAlignment="Center" Margin="12,0,0,0" />
+                </StackPanel>
+            </ui:CardControl>
+        </StackPanel>
+    </StackPanel>
+</Page>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -81,6 +81,16 @@ hides repeat, shuffle and player info</System:String>
     <System:String x:Key="TaskbarVisualizerEnabledTitle">Enable Taskbar Visualizer (Experimental)</System:String>
     <System:String x:Key="TaskbarVisualizerEnabledDescription">Experimental: This feature will only work if the Taskbar Widget is enabled</System:String>
     <System:String x:Key="TaskbarVisualizerPositionTitle">Visualizer Position Relative to Taskbar Widget</System:String>
+
+    <System:String x:Key="TaskbarLyricsTitle">Taskbar Lyrics</System:String>
+    <System:String x:Key="TaskbarLyricsDescription">Displays real-time synced lyrics of the current playing song next to the taskbar widget using LRCLIB.</System:String>
+    <System:String x:Key="TaskbarLyricsEnabledTitle">Enable Taskbar Lyrics (Experimental)</System:String>
+    <System:String x:Key="TaskbarLyricsEnabledDescription">Experimental: This feature will only work if the Taskbar Widget is enabled</System:String>
+    <System:String x:Key="TaskbarLyricsPositionTitle">Lyrics Position Relative to Taskbar Widget</System:String>
+    <System:String x:Key="TaskbarLyricsClickableTitle">Click to open Settings</System:String>
+    <System:String x:Key="TaskbarLyricsClickableDescription">Clicking the lyrics will open its settings page</System:String>
+    <System:String x:Key="TaskbarLyricsDelayTitle">Lyrics Time Offset</System:String>
+    <System:String x:Key="TaskbarLyricsDelayDescription">Fine-tune the synchronization (positive to advance, negative to delay)</System:String>
     <System:String x:Key="TaskbarVisualizerBarCountTitle">Bar Count</System:String>
     <System:String x:Key="TaskbarVisualizerBarCountDescription">The amount of visualizer bars</System:String>
     <System:String x:Key="TaskbarVisualizerCenteredBarsTitle">Centered Bars</System:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-es.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-es.xaml
@@ -175,6 +175,16 @@ Nota: Como proyecto de código abierto, estas opciones también están disponibl
     <system:String x:Key="TaskbarVisualizerEnabledTitle">Activar Visualizador de la Barra de Tareas (Experimental)</system:String>
     <system:String x:Key="TaskbarVisualizerEnabledDescription">Experimental: Esta funcionalidad solo funciona si el Widget de la Barra de Tareas esta activado</system:String>
     <system:String x:Key="TaskbarVisualizerPositionTitle">Posición del Visualizador Relativa al Widget de la Barra de Tareas</system:String>
+
+    <system:String x:Key="TaskbarLyricsTitle">Letras en Barra de Tareas</system:String>
+    <system:String x:Key="TaskbarLyricsDescription">Muestra la letra sincronizada en tiempo real de la canción que está sonando junto al widget de la barra de tareas usando LRCLIB.</system:String>
+    <system:String x:Key="TaskbarLyricsEnabledTitle">Activar Letras en la Barra de Tareas (Experimental)</system:String>
+    <system:String x:Key="TaskbarLyricsEnabledDescription">Experimental: Esta funcionalidad solo funciona si el Widget de la Barra de Tareas está activado</system:String>
+    <system:String x:Key="TaskbarLyricsPositionTitle">Posición de las Letras Relativa al Widget</system:String>
+    <system:String x:Key="TaskbarLyricsClickableTitle">Hacer clic para abrir Ajustes</system:String>
+    <system:String x:Key="TaskbarLyricsClickableDescription">Al hacer clic en las letras se abrirá su página de configuración</system:String>
+    <system:String x:Key="TaskbarLyricsDelayTitle">Ajuste de tiempo de las letras</system:String>
+    <system:String x:Key="TaskbarLyricsDelayDescription">Ajusta la sincronización (positivo para adelantar, negativo para retrasar)</system:String>
     <system:String x:Key="TaskbarVisualizerBarCountTitle">Número de Barras</system:String>
     <system:String x:Key="TaskbarVisualizerBarCountDescription">La cantidad de barras del visualizador</system:String>
     <system:String x:Key="TaskbarVisualizerCenteredBarsTitle">Barras Centradas</system:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -466,6 +466,37 @@ public partial class UserSettings : ObservableObject
     public partial bool TaskbarVisualizerEnabled { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the taskbar lyrics viewer is enabled.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool TaskbarLyricsEnabled { get; set; }
+
+    /// <summary>
+    /// Position of the lyrics viewer relative to the widget.
+    /// </summary>
+    [ObservableProperty]
+    public partial int TaskbarLyricsPosition { get; set; }
+
+    /// <summary>
+    /// Whether the lyrics viewer is clickable.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool TaskbarLyricsClickable { get; set; }
+
+    /// <summary>
+    /// Time offset in milliseconds to adjust lyrics sync (positive to advance, negative to delay).
+    /// </summary>
+    [ObservableProperty]
+    public partial int TaskbarLyricsDelay { get; set; }
+
+    /// <summary>
+    /// Indicates whether the lyrics viewer has content to display.
+    /// </summary>
+    [XmlIgnore]
+    [ObservableProperty]
+    public partial bool TaskbarLyricsHasContent { get; set; }
+
+    /// <summary>
     /// Returns whether app filtering is enabled or disabled.
     /// </summary>
     [ObservableProperty]
@@ -687,6 +718,10 @@ public partial class UserSettings : ObservableObject
         TaskbarWidgetControlsPosition = 1;
         TaskbarWidgetAnimated = true;
         TaskbarVisualizerEnabled = false;
+        TaskbarLyricsEnabled = false;
+        TaskbarLyricsPosition = 1;
+        TaskbarLyricsClickable = false;
+        TaskbarLyricsDelay = 0;
         AppFilteringEnabled = false;
         AppFilteringMode = 0;
         TaskbarVisualizerPosition = 1;
@@ -873,6 +908,12 @@ public partial class UserSettings : ObservableObject
         UpdateTaskbar();
     }
 
+    partial void OnTaskbarLyricsPositionChanged(int oldValue, int newValue)
+    {
+        if (oldValue == newValue || _initializing) return;
+        UpdateTaskbar();
+    }
+
     partial void OnLegacyTaskbarWidthEnabledChanged(bool oldValue, bool newValue)
     {
         if (oldValue == newValue || _initializing) return;
@@ -889,6 +930,13 @@ public partial class UserSettings : ObservableObject
     {
         if (oldValue == newValue || _initializing) return;
         TaskbarVisualizerControl.OnTaskbarVisualizerEnabledChanged(newValue);
+        UpdateTaskbar();
+    }
+
+    partial void OnTaskbarLyricsEnabledChanged(bool oldValue, bool newValue)
+    {
+        if (oldValue == newValue || _initializing) return;
+        TaskbarLyricsControl.OnTaskbarLyricsEnabledChanged(newValue);
         UpdateTaskbar();
     }
 


### PR DESCRIPTION
## Summary

This PR adds a real-time synchronized lyrics widget directly to the Windows taskbar using LRCLIB.

## Motivation

Currently, there is no built-in widget to view real-time synced lyrics next to the taskbar widget. This addition enhances the music flyout experience by fetching and displaying lyrics dynamically as the song plays.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

- Created `TaskbarLyricsControl` to handle LRCLIB lyrics queries, matching, real-time sync, and animation transitions.
- Implemented marquee scrolling behavior for long lyrics lines.
- Added user settings page (`TaskbarLyricsPage`) allowing users to enable/disable lyrics, change position relative to the taskbar widget, toggle click-to-open settings, and adjust a millisecond delay offset slider (from -2000ms to 2000ms).
- Integrated settings variables and localization strings (English/Spanish).

## Additional Information
<img width="607" height="49" alt="image" src="https://github.com/user-attachments/assets/3d163aea-0838-46a8-8d9e-74594fef8f15" />
<img width="900" height="700" alt="image" src="https://github.com/user-attachments/assets/ee50b44b-6a17-471c-8a75-9a6d67bc3ddd" />

> [!NOTE]
> The settings page currently uses the visualizer banner image (`FluentFlyoutTaskbar-NoTitle-Zoomed.png`). Please feel free to replace it with a lyrics-specific banner image when merging.

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).