### PR TITLE
Respect current font family when calculating string width

### DIFF
--- a/FluentFlyoutWPF/Classes/Utils/StringWidth.cs
+++ b/FluentFlyoutWPF/Classes/Utils/StringWidth.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2024-2026 The FluentFlyout Authors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+using FluentFlyout.Classes.Settings;
 using System.Windows;
 using System.Windows.Media;
 
@@ -8,9 +9,9 @@ namespace FluentFlyout.Classes.Utils
 {
     internal static class StringWidth
     {
-        private static readonly FontFamily fontFamily = new FontFamily("Segoe UI Variable, Microsoft YaHei, Microsoft JhengHei, MS Gothic");
-        private static readonly Typeface normalTypeface = new Typeface(fontFamily, new FontStyle(), FontWeights.Normal, FontStretches.Normal);
-        private static readonly Typeface mediumTypeface = new Typeface(fontFamily, new FontStyle(), FontWeights.Medium, FontStretches.Normal);
+        private static FontFamily? fontFamily;
+        private static string cachedFontFamily = string.Empty;
+        private static Dictionary<string, Typeface> _cachedTypefaces = new();
 
         /// <summary>
         /// Gets the width of the specified string when rendered with the specified font weight.
@@ -27,13 +28,41 @@ namespace FluentFlyout.Classes.Utils
                 text,
                 System.Globalization.CultureInfo.CurrentCulture,
                 FlowDirection.LeftToRight,
-                fontWeight == 400 ? normalTypeface : mediumTypeface,
+                GetCurrentTypeface(fontWeight),
                 fontSize,
                 Brushes.Black,
                 null,
                 1);
 
             return formattedText.Width + 8;
+        }
+
+        // Returns the current Typeface based on the font family and weight, caching it for performance.
+        private static Typeface GetCurrentTypeface(int fontWeight)
+        {
+            string currentFontFamily = SettingsManager.Current.FontFamily ?? "Segoe UI Variable, Microsoft YaHei UI, Yu Gothic UI, Malgun Gothic";
+
+            // determine if the font family has changed since the last call, and if so, update the cached font family
+            if (fontFamily == null || cachedFontFamily != currentFontFamily)
+            {
+                // get the current font family from user settings or use the default one
+                fontFamily = new FontFamily(currentFontFamily);
+                cachedFontFamily = currentFontFamily;
+            }
+
+            _cachedTypefaces.TryGetValue(currentFontFamily + fontWeight, out var cachedTypeface);
+
+            // if exists, return the cached typeface. Otherwise, create a new one and cache it.
+            if (cachedTypeface != null)
+            {
+                return cachedTypeface;
+            }
+            else
+            {
+                var newTypeface = new Typeface(fontFamily, new FontStyle(), fontWeight == 400 ? FontWeights.Normal : FontWeights.Medium, FontStretches.Normal);
+                _cachedTypefaces[currentFontFamily + fontWeight] = newTypeface;
+                return newTypeface;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->
Previously, string width was calculated with a Typeface with the default FontFamily (Latin alphabet prioritized). Languages where the FontFamily is changed from default (Japanese, Traditional Chinese, Korean) the string width was always calculated incorrectly. This patch dynamically creates new Typefaces to calculate the string width with.

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

<!-- Bullet points of key changes made in this PR. -->

- Update StringWidth.cs to respect current font family
- cache Typefaces so we don't continuously create new ones when calculating string width
