### PR TITLE
Make sure the locale-specific FontFamily is applied correctly

### DIFF
--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml
@@ -9,7 +9,7 @@
              d:DataContext="{d:DesignInstance viewModels:UserSettings}"
              Height="40" Width="100"
              TextOptions.TextRenderingMode="ClearType" TextOptions.TextFormattingMode="Ideal"
-             FontFamily="Segoe UI Variable, Microsoft YaHei, Microsoft JhengHei, MS Gothic"
+             FontFamily="{Binding FontFamily}"
              FlowDirection="{Binding FlowDirection}">
     <Border Name="MainBorder" CornerRadius="6" MouseEnter="Grid_MouseEnter" MouseLeave="Grid_MouseLeave" MouseLeftButtonUp="Grid_MouseLeftButtonUp" ClipToBounds="True">
         <Grid>

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -138,6 +138,9 @@ public partial class MainWindow : MicaWindow
             Logger.Error(ex, "Failed to restore settings");
         }
 
+        // RestoreSettings may replace SettingsManager.Current instance, so rebind DataContext.
+        DataContext = SettingsManager.Current;
+
         if (SettingsManager.Current.Startup == true) // add to startup programs if enabled, needs improvement
         {
             RegistryKey? key = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);


### PR DESCRIPTION
## Summary

Try to fix #852 by different approach, with fewer changes.

|before|after|
|---|---|
|<img width="400" src="https://github.com/user-attachments/assets/61affe63-fab3-4cee-b81a-670ee089bf41" />|<img width="400" src="https://github.com/user-attachments/assets/8201e1ae-e9e8-4139-8e8f-fc01483ce551" />|

## Motivation

(same as #852)

The language‑specific font priority isn't working in both the Media Flyout and the Taskbar Widget ("Up Next" isn't affected). As a result, characters aren't rendered using the intended fonts (In the following example, selected font is not suitable for displaying Japanese).

> <img width="491" height="99" src="https://github.com/user-attachments/assets/d015c0a2-0c79-4fe6-b535-2d36a8839ed2" />
> 
> title `おしえてアンドロメダ` in "Up Next" is using `Yu Gothic UI` (Japanese font), but Taskbar Widget isn't.

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

<!-- Bullet points of key changes made in this PR. -->

* Media Flyout: Rebind `DataContext` after restoring settings
* Taskbar Widget: Change the FontFamily to {Binding FontFamily} from a hard-coded value

## Additional Information

<!-- Any other information, such as screenshots -->

### Media Flyout
Since the `DataContext` was set earlier in [MainWindow.xaml.cs](https://github.com/unchihugo/FluentFlyout/blob/c7dcc192fd667100fd1c2a1c155006d88960842a/FluentFlyoutWPF/MainWindow.xaml.cs#L83), there was a possibility that the [RestoreSettings()](https://github.com/unchihugo/FluentFlyout/blob/c7dcc192fd667100fd1c2a1c155006d88960842a/FluentFlyoutWPF/MainWindow.xaml.cs#L83) method in [MainWindow.xaml.cs](https://github.com/unchihugo/FluentFlyout/blob/c7dcc192fd667100fd1c2a1c155006d88960842a/FluentFlyoutWPF/MainWindow.xaml.cs#L133) — which replaces the `SettingsManager.Current` instance itself — would continue to reference the old settings object.

### Other PRs compatibility

- #889 : [OK](https://github.com/unchihugo/FluentFlyout/pull/852#issuecomment-4760772579)

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
<!-- AI usage -->
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).