### PR TITLE
Add telemetry service and data toggle in system settings

### DIFF
--- a/FluentFlyoutWPF/Classes/LicenseManager.cs
+++ b/FluentFlyoutWPF/Classes/LicenseManager.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using FluentFlyout.Classes.Settings;
+using FluentFlyoutWPF.Classes.Services;
 using System.Windows;
 using System.Windows.Interop;
 using Windows.Services.Store;
@@ -249,6 +250,7 @@ public class LicenseManager
             {
                 _isPremiumUnlocked = true;
                 Logger.Info("Premium purchase successful");
+                _ = TelemetryService.SendTelemetryEventAsync("premium_purchase_succeeded");
                 return (true, string.Empty);
             }
             else if (status == StorePurchaseStatus.AlreadyPurchased)

--- a/FluentFlyoutWPF/Classes/Services/ExperimentsService.cs
+++ b/FluentFlyoutWPF/Classes/Services/ExperimentsService.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) 2024-2026 The FluentFlyout Authors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using FluentFlyout.Classes.Settings;
+using NLog;
+using System.Net.Http;
+
+namespace FluentFlyoutWPF.Classes.Services;
+
+internal class ExperimentsService
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+    private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromSeconds(2) };
+    private const string ApiEndpoint = "https://fluentflyout.com/api/experiments";
+
+    private static List<Experiment> _experiments = new();
+    private static bool _hasExperiments = false;
+
+    /// <summary>
+    /// Result of experiments
+    /// </summary>
+    public class ExperimentsResult
+    {
+        public List<Experiment> Experiments { get; set; } = new();
+        public bool Success { get; set; }
+    }
+
+    public class Experiment
+    {
+        public string Name { get; set; } = string.Empty;
+
+        [System.Text.Json.Serialization.JsonPropertyName("enabled")]
+        public bool Enabled { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("variants")]
+        public Dictionary<string, double> Variants { get; set; } = new();
+
+        // If Enabled is true, ForceVariant is ignored.
+        [System.Text.Json.Serialization.JsonPropertyName("forceVariant")]
+        public string? ForceVariant { get; set; }
+    }
+
+    public static List<Experiment> GetExperiments => _experiments;
+
+    public static bool HasExperiments => _hasExperiments;
+
+    public static async Task<ExperimentsResult> GetExperimentsAsync()
+    {
+        var result = new ExperimentsResult();
+        try
+        {
+            var response = await HttpClient.GetStringAsync(ApiEndpoint);
+            var experimentDict = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, Experiment>>(response);
+            if (experimentDict != null)
+            {
+                // Convert dictionary to list and set Name property from key
+                result.Experiments = experimentDict.Select(kvp =>
+                {
+                    kvp.Value.Name = kvp.Key;
+                    return kvp.Value;
+                }).ToList();
+                result.Success = true;
+                Logger.Debug($"Fetched {result.Experiments.Count} experiments successfully.");
+            }
+            else
+            {
+                Logger.Debug("No experiments found.");
+                result.Success = false;
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.Info($"Failed to fetch experiments - network error: {ex.Message}");
+            result.Success = false;
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            Logger.Error(ex, "Failed to parse experiments JSON.");
+            result.Success = false;
+        }
+
+        _experiments = result.Experiments;
+        _hasExperiments = result.Experiments.Count > 0;
+
+        return result;
+    }
+
+    // returns variantName
+    public static string CheckUuidInExperiment(string experimentName)
+    {
+        var experiment = _experiments.FirstOrDefault(e => e.Name.Equals(experimentName, StringComparison.OrdinalIgnoreCase));
+        Guid uuid = SettingsManager.Current.Uuid;
+
+        if (experiment == null)
+        {
+            Logger.Debug($"Experiment '{experimentName}' not found.");
+            return string.Empty;
+        }
+        if (!experiment.Enabled)
+        {
+            Logger.Debug($"Experiment '{experimentName}' is not enabled.");
+            return !string.IsNullOrEmpty(experiment.ForceVariant) ? experiment.ForceVariant : string.Empty;
+        }
+
+        // Calculate a hash of the UUID to determine the variant
+        int hash = uuid.GetHashCode();
+        double totalWeight = experiment.Variants.Values.Sum();
+        double cumulativeWeight = 0;
+        foreach (var variant in experiment.Variants)
+        {
+            cumulativeWeight += variant.Value;
+            if ((hash % totalWeight) < cumulativeWeight)
+            {
+                Logger.Debug($"UUID '{uuid}' is assigned to variant '{variant.Key}' of experiment '{experimentName}'.");
+                return variant.Key; // UUID is in the experiment
+            }
+        }
+        Logger.Debug($"UUID '{uuid}' is not assigned to any variant of experiment '{experimentName}'.");
+        return string.Empty; // UUID is not in the experiment
+    }
+}

--- a/FluentFlyoutWPF/Classes/Services/TelemetryService.cs
+++ b/FluentFlyoutWPF/Classes/Services/TelemetryService.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) 2024-2026 The FluentFlyout Authors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using FluentFlyout.Classes.Settings;
+using NLog;
+using System.Net.Http;
+using System.Net.Http.Json;
+
+namespace FluentFlyoutWPF.Classes.Services;
+
+public static class TelemetryService
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+    private const string ApiEndpoint = "https://fluentflyout.com/api/events";
+
+    public static async Task SendTelemetryEventAsync(string eventName, string? experimentId = null)
+    {
+        if (!SettingsManager.Current.AnonymousTelemetryAllowed) return;
+
+        try
+        {
+            using HttpClient client = new() { Timeout = TimeSpan.FromSeconds(2) };
+
+            var telemetryData = new
+            {
+                eventName,
+                experimentId = experimentId ?? string.Empty,
+                variant = ExperimentsService.CheckUuidInExperiment(experimentId ?? string.Empty),
+                userId = SettingsManager.Current.Uuid,
+                sessionId = SettingsManager.Current.SessionId
+            };
+
+            await client.PostAsJsonAsync(ApiEndpoint, telemetryData);
+        }
+        catch (Exception ex)
+        {
+            Logger.Debug(ex, "Failed to send telemetry event: {0}", eventName);
+        }
+    }
+}

--- a/FluentFlyoutWPF/Classes/Services/UpdateCheckerService.cs
+++ b/FluentFlyoutWPF/Classes/Services/UpdateCheckerService.cs
@@ -5,12 +5,12 @@ using NLog;
 using System.Net.Http;
 using System.Text.Json;
 
-namespace FluentFlyout.Classes;
+namespace FluentFlyoutWPF.Classes.Services;
 
 /// <summary>
 /// Handles checking for application updates from the API
 /// </summary>
-public static class UpdateChecker
+public static class UpdateCheckerService
 {
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
     private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromSeconds(10) };

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -220,7 +220,7 @@ public partial class MainWindow : MicaWindow
     private void OnboardingExperiment(string previousVersion)
     {
         // show onboarding to new users (no previous version stored = user has never run the app before)
-        if (previousVersion != string.Empty)
+        if (previousVersion == string.Empty)
         {
             if (ExperimentsService.HasExperiments)
             {

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using FluentFlyout.Classes.Utils;
 using FluentFlyout.Controls;
 using FluentFlyout.Windows;
 using FluentFlyoutWPF.Classes;
+using FluentFlyoutWPF.Classes.Services;
 using FluentFlyoutWPF.Classes.Utils;
 using FluentFlyoutWPF.ViewModels;
 using FluentFlyoutWPF.Windows;
@@ -178,14 +179,16 @@ public partial class MainWindow : MicaWindow
             UpdateSeekbarCurrentDuration(session.ControlSession.GetTimelineProperties().Position);
         }
 
+        string previousVersion = SettingsManager.Current.LastKnownVersion;
+        _ = CheckForExperimentsOnStartupAsync(previousVersion);
+        // show onboarding to new users (no previous version stored = user has never run the app before)
+        //if (previousVersion == string.Empty)
+        //    OnboardingWindow.ShowInstance();
+
         // apply other things on new thread
         Dispatcher.Invoke(() =>
         {
             LocalizationManager.ApplyLocalization();
-            string previousVersion = SettingsManager.Current.LastKnownVersion;
-            // show onboarding to new users (no previous version stored = user has never run the app before)
-            if (previousVersion == string.Empty)
-                OnboardingWindow.ShowInstance();
 
             try // update last known version. gets the version of the app, works only in release mode
             {
@@ -207,11 +210,35 @@ public partial class MainWindow : MicaWindow
         });
     }
 
+    private async Task CheckForExperimentsOnStartupAsync(string previousVersion)
+    {
+        await ExperimentsService.GetExperimentsAsync();
+
+        OnboardingExperiment(previousVersion);
+    }
+
+    private void OnboardingExperiment(string previousVersion)
+    {
+        // show onboarding to new users (no previous version stored = user has never run the app before)
+        if (previousVersion != string.Empty)
+        {
+            if (ExperimentsService.HasExperiments)
+            {
+                if (ExperimentsService.CheckUuidInExperiment("onboarding") == "A")
+                    OnboardingWindow.ShowInstance();
+                else
+                    SettingsWindow.ShowInstance();
+            }
+            else
+                OnboardingWindow.ShowInstance();
+        }
+    }
+
     private async Task CheckForUpdatesOnStartupAsync()
     {
         try
         {
-            var result = await UpdateChecker.CheckForUpdatesAsync(SettingsManager.Current.LastKnownVersion);
+            var result = await UpdateCheckerService.CheckForUpdatesAsync(SettingsManager.Current.LastKnownVersion);
 
             if (result.Success)
             {
@@ -1643,6 +1670,9 @@ public partial class MainWindow : MicaWindow
         {
             Logger.Error(ex, "Failed to initialize license");
         }
+
+        // Add the experiments loading here
+        await ExperimentsService.GetExperimentsAsync();
 
         BitmapHelper.GetDominantColors(1);
         taskbarWindow = new TaskbarWindow();

--- a/FluentFlyoutWPF/Pages/HomePage.xaml.cs
+++ b/FluentFlyoutWPF/Pages/HomePage.xaml.cs
@@ -3,6 +3,7 @@
 
 using FluentFlyout.Classes;
 using FluentFlyout.Classes.Settings;
+using FluentFlyoutWPF.Classes.Services;
 using FluentFlyoutWPF.Classes.Utils;
 using FluentFlyoutWPF.ViewModels;
 using NLog;
@@ -72,7 +73,7 @@ public partial class HomePage : Page
         if (UpdateState.Current.IsUpdateAvailable)
         {
             string url = !string.IsNullOrEmpty(UpdateState.Current.UpdateUrl) ? UpdateState.Current.UpdateUrl : "https://fluentflyout.com/changelog/";
-            UpdateChecker.OpenUpdateUrl(url);
+            UpdateCheckerService.OpenUpdateUrl(url);
         }
         else
         {
@@ -86,7 +87,7 @@ public partial class HomePage : Page
         {
             UpdateStatusText.Text = Application.Current.FindResource("CheckingForUpdates")?.ToString();
 
-            var result = await UpdateChecker.CheckForUpdatesAsync(SettingsManager.Current.LastKnownVersion);
+            var result = await UpdateCheckerService.CheckForUpdatesAsync(SettingsManager.Current.LastKnownVersion);
 
             if (result.Success)
             {

--- a/FluentFlyoutWPF/Pages/SystemPage.xaml
+++ b/FluentFlyoutWPF/Pages/SystemPage.xaml
@@ -103,6 +103,15 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch x:Name="StartupSwitch" Click="StartupSwitch_Click" IsChecked="{Binding Startup, Mode=TwoWay}" />
             </ui:CardControl>
+            <ui:CardControl Icon="{ui:SymbolIcon Bug24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource AnonymousUsageDataTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource AnonymousUsageDataDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <controls:ToggleSwitch IsChecked="{Binding AnonymousTelemetryAllowed, Mode=TwoWay}" />
+            </ui:CardControl>
             <ui:CardControl Icon="{ui:SymbolIcon ArrowMinimize24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -150,6 +150,8 @@ Note: As an open-source project, these features are also available for free via 
     <System:String x:Key="LaunchOnStartupDescription">Start minimized to tray when you log in to Windows</System:String>
     <System:String x:Key="StartupAppsHyperlinkText">Startup Apps</System:String>
     <System:String x:Key="StartupAppsSettingsInfo">If this setting does not work as expected, check</System:String>
+    <System:String x:Key="AnonymousUsageDataTitle">Send Anonymous Usage Data</System:String>
+    <System:String x:Key="AnonymousUsageDataDescription">Help improve the app by sending anonymous, non-identifiable usage data</System:String>
     <System:String x:Key="AppThemeTitle">App Theme</System:String>
     <System:String x:Key="AppThemeDefault"> Windows Default</System:String>
     <System:String x:Key="AppThemeLight"> Light</System:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -623,6 +623,16 @@ public partial class UserSettings : ObservableObject
     [ObservableProperty]
     public partial bool LegacyTaskbarWidthEnabled { get; set; }
 
+    [ObservableProperty]
+    public partial Guid Uuid { get; set; }
+
+    [XmlIgnore]
+    [ObservableProperty]
+    public partial Guid SessionId { get; set; } = Guid.NewGuid();
+
+    [ObservableProperty]
+    public partial bool AnonymousTelemetryAllowed { get; set; }
+
     [XmlIgnore]
     private bool _initializing = true;
 
@@ -706,6 +716,8 @@ public partial class UserSettings : ObservableObject
         LastUpdateNotificationUnixSeconds = 0;
         ShowUpdateNotifications = true;
         LegacyTaskbarWidthEnabled = false;
+        Uuid = Guid.NewGuid();
+        AnonymousTelemetryAllowed = true;
 
         PropertyChanged += OnPropertyChangedSaveSettings;
     }

--- a/FluentFlyoutWPF/Windows/OnboardingWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/OnboardingWindow.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2024-2026 The FluentFlyout Authors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+using FluentFlyoutWPF.Classes.Services;
 using FluentFlyoutWPF.ViewModels;
 using MicaWPF.Controls;
 using System.ComponentModel;
@@ -143,6 +144,8 @@ public partial class OnboardingWindow : MicaWindow
         {
             new OnboardingWindow().Show();
             instance?.Activate();
+
+            _ = TelemetryService.SendTelemetryEventAsync("onboarding_started", "onboarding");
         }
         else
         {
@@ -158,6 +161,8 @@ public partial class OnboardingWindow : MicaWindow
 
     private void OnOnboardingCompleted(object? sender, EventArgs e)
     {
+        _ = TelemetryService.SendTelemetryEventAsync("onboarding_completed", "onboarding");
+
         SettingsWindow.ShowInstance();
         Close();
     }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->

Add experiments and telemetry service. GET from https://fluentflyout.com/api/experiments and POST to https://fluentflyout.com/api/events. Anonymous usage data can be disabled in FluentFlyout Settings > System.

Current experiments/payload:
```js
        "onboarding": {
            "enabled": true,
            "variants": {
                "A": 0.5,
                "B": 0.5
            },
            "forceVariant": "A"
        }
```
50% of new users will see the new onboarding screen, and 50% will see settings opened (previous behavior).

Data included in telemetry:
* eventName (for example "onboarding_started")
* userId: Guid (generated on first time start)
* sessionId: Guid (generated each time the app starts)
* experimentId (optional, for example "onboarding")
* variant (optional, for example "A" or "B")

Currently logged events:
* onboarding_started (onboarding window is opened)
* onboarding_finished (finish pressed in onboarding)
* premium_purchase_succeeded (user successfully purchased premium)

Additionally, UpdateChecker.cs is renamed to UpdateCheckerService.cs and moved into /Services/ folder, along with the new services.

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no functional changes)
- [x] Style (formatting, naming)
- [ ] Other
