### PR TITLE
Move Acrylic Window flyout settings into advanced settings

### DIFF
--- a/FluentFlyoutWPF/Pages/AdvancedPage.xaml
+++ b/FluentFlyoutWPF/Pages/AdvancedPage.xaml
@@ -110,7 +110,7 @@
                         <TextBlock Text="{DynamicResource LegacyTaskbarWidthDescription}" FontSize="12" Opacity="0.5" />
                     </StackPanel>
                 </ui:CardControl.Header>
-                <StackPanel Orientation="Horizontal" Opacity="{Binding IsPremiumUnlocked, Converter={StaticResource BoolToFullHalfOpacityConverter}}" >
+                <StackPanel Orientation="Horizontal">
                     <controls:ToggleSwitch IsChecked="{Binding LegacyTaskbarWidthEnabled, Mode=TwoWay}" />
                 </StackPanel>
             </ui:CardControl>

--- a/FluentFlyoutWPF/Pages/AdvancedPage.xaml
+++ b/FluentFlyoutWPF/Pages/AdvancedPage.xaml
@@ -8,7 +8,7 @@
       xmlns:viewModels="clr-namespace:FluentFlyoutWPF.ViewModels"
       xmlns:fluentflyoutcontrols="clr-namespace:FluentFlyout.Controls"
       mc:Ignorable="d"
-      d:DesignHeight="400" d:DesignWidth="800"
+      d:DesignHeight="800" d:DesignWidth="800"
       Title="AdvancedPage"
       d:DataContext="{d:DesignInstance viewModels:UserSettings}"
       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -16,9 +16,9 @@
 
     <StackPanel MaxWidth="1000" Margin="16">
         <TextBlock Text="{DynamicResource AdvancedSettingsTitle}" FontSize="24" FontWeight="SemiBold" Margin="0,0,0,24" />
-        <StackPanel>
-            <TextBlock Text="{DynamicResource SystemSettingsTitle}" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,6" />
-            <ui:CardExpander Icon="{ui:SymbolIcon Wrench24}" ContentPadding="6" Margin="0,0,0,3">
+        <StackPanel Margin="0,0,0,76">
+            <TextBlock Text="{DynamicResource AppearanceBehaviorSectionTitle}" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,6" />
+            <ui:CardExpander Icon="{ui:SymbolIcon Wrench24}" ContentPadding="8" Margin="0,0,0,3">
                 <ui:CardExpander.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource AnimationSettingsTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -63,18 +63,55 @@
                     <ui:InfoBar Title="{DynamicResource NativeExperienceInfo}" IsOpen="True" Severity="Informational" IsClosable="False" />
                 </StackPanel>
             </ui:CardExpander>
-            <ui:CardControl Icon="{ui:SymbolIcon ArrowCounterclockwise24}" Margin="0,0,0,76">
+
+            <ui:CardExpander Icon="{ui:SymbolIcon Blur24}" ContentPadding="8" Margin="0,0,0,3">
+                <ui:CardExpander.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource AcrylicWindowTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource AcrylicWindowDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardExpander.Header>
+                <StackPanel>
+                    <ui:CardControl Margin="0,0,0,3">
+                        <ui:CardControl.Header>
+                            <StackPanel Orientation="Vertical">
+                                <TextBlock Text="{DynamicResource MediaFlyoutTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </ui:CardControl.Header>
+                        <controls:ToggleSwitch IsChecked="{Binding MediaFlyoutAcrylicWindowEnabled, Mode=TwoWay}" />
+                    </ui:CardControl>
+
+                    <ui:CardControl Margin="0,0,0,3">
+                        <ui:CardControl.Header>
+                            <StackPanel Orientation="Vertical">
+                                <TextBlock Text="{DynamicResource NextUpCustomizationTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </ui:CardControl.Header>
+                        <controls:ToggleSwitch IsChecked="{Binding NextUpAcrylicWindowEnabled, Mode=TwoWay}" />
+                    </ui:CardControl>
+
+                    <ui:CardControl>
+                        <ui:CardControl.Header>
+                            <StackPanel Orientation="Vertical">
+                                <TextBlock Text="{DynamicResource LockKeysCustomizationTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </ui:CardControl.Header>
+                        <controls:ToggleSwitch IsChecked="{Binding LockKeysAcrylicWindowEnabled, Mode=TwoWay}" />
+                    </ui:CardControl>
+                </StackPanel>
+            </ui:CardExpander>
+
+            <ui:CardControl Icon="{ui:SymbolIcon ArrowCounterclockwise24}">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Text="{DynamicResource LegacyTaskbarWidthTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
-                            <fluentflyoutcontrols:AccentBadge Margin="6,0,0,0" />
                         </StackPanel>
                         <TextBlock Text="{DynamicResource LegacyTaskbarWidthDescription}" FontSize="12" Opacity="0.5" />
                     </StackPanel>
                 </ui:CardControl.Header>
                 <StackPanel Orientation="Horizontal" Opacity="{Binding IsPremiumUnlocked, Converter={StaticResource BoolToFullHalfOpacityConverter}}" >
-                    <controls:ToggleSwitch IsChecked="{Binding LegacyTaskbarWidthEnabled, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
+                    <controls:ToggleSwitch IsChecked="{Binding LegacyTaskbarWidthEnabled, Mode=TwoWay}" />
                 </StackPanel>
             </ui:CardControl>
         </StackPanel>

--- a/FluentFlyoutWPF/Pages/LockKeysPage.xaml
+++ b/FluentFlyoutWPF/Pages/LockKeysPage.xaml
@@ -46,15 +46,6 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="LockKeysSwitch" IsChecked="{Binding LockKeysEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="2" Icon="{ui:SymbolIcon Blur24}" Margin="0,0,0,3">
-                <ui:CardControl.Header>
-                    <StackPanel Orientation="Vertical">
-                        <TextBlock Text="{DynamicResource AcrylicWindowTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
-                        <TextBlock Text="{DynamicResource AcrylicWindowDescription}" FontSize="12" Opacity="0.5" />
-                    </StackPanel>
-                </ui:CardControl.Header>
-                <controls:ToggleSwitch Name="LockKeysAcrylicWindowSwitch" IsChecked="{Binding LockKeysAcrylicWindowEnabled, Mode=TwoWay}" />
-            </ui:CardControl>
             <ui:CardControl Grid.Row="3" Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">

--- a/FluentFlyoutWPF/Pages/MediaFlyoutPage.xaml
+++ b/FluentFlyoutWPF/Pages/MediaFlyoutPage.xaml
@@ -65,15 +65,6 @@
                     <ComboBoxItem Content="{DynamicResource BackgroundBlurOption4}" />
                 </ComboBox>
             </ui:CardControl>
-            <ui:CardControl Grid.Row="3" Icon="{ui:SymbolIcon Blur24}" Margin="0,0,0,3">
-                <ui:CardControl.Header>
-                    <StackPanel Orientation="Vertical">
-                        <TextBlock Text="{DynamicResource AcrylicWindowTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
-                        <TextBlock Text="{DynamicResource AcrylicWindowDescription}" FontSize="12" Opacity="0.5" />
-                    </StackPanel>
-                </ui:CardControl.Header>
-                <controls:ToggleSwitch Name="AcrylicWindowSwitch" IsChecked="{Binding MediaFlyoutAcrylicWindowEnabled, Mode=TwoWay}" />
-            </ui:CardControl>
             <ui:CardControl Grid.Row="4" Icon="{ui:SymbolIcon ArrowAutofitWidth24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">

--- a/FluentFlyoutWPF/Pages/NextUpPage.xaml
+++ b/FluentFlyoutWPF/Pages/NextUpPage.xaml
@@ -39,15 +39,6 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="NextUpSwitch" IsChecked="{Binding NextUpEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl Grid.Row="2" Icon="{ui:SymbolIcon Blur24}" Margin="0,0,0,3">
-                <ui:CardControl.Header>
-                    <StackPanel Orientation="Vertical">
-                        <TextBlock Text="{DynamicResource AcrylicWindowTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
-                        <TextBlock Text="{DynamicResource AcrylicWindowDescription}" FontSize="12" Opacity="0.5" />
-                    </StackPanel>
-                </ui:CardControl.Header>
-                <controls:ToggleSwitch Name="NextUpAcrylicWindowSwitch"  IsChecked="{Binding NextUpAcrylicWindowEnabled, Mode=TwoWay}" />
-            </ui:CardControl>
             <ui:CardControl Grid.Row="3" Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,76">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -19,8 +19,8 @@
     <System:String x:Key="BackgroundBlurOption3" xml:space="preserve"> Style 2 (Rising Glow)</System:String>
     <System:String x:Key="BackgroundBlurOption4" xml:space="preserve"> Style 3 (Blur)</System:String>
     <System:String x:Key="BackgroundBlurTitle">Background Blur</System:String>
-    <System:String x:Key="AcrylicWindowTitle">Acrylic Window</System:String>
-    <System:String x:Key="AcrylicWindowDescription">Apply transparent acrylic blur effect to the flyout (off reverts to Mica)</System:String>
+    <System:String x:Key="AcrylicWindowTitle">Acrylic Flyouts</System:String>
+    <System:String x:Key="AcrylicWindowDescription">Apply transparent acrylic blur effect to the flyouts</System:String>
     <System:String x:Key="CompactLayoutTitle">Compact Layout</System:String>
     <System:String x:Key="CompactLayoutDescription" xml:space="preserve">Slimmer and less intrusive layout
 hides repeat, shuffle and player info</System:String>


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->
Move Acrylic Window flyout settings into advanced settings, into a collapsible menu.

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Declutters settings to what's necessary/more important, most users will leave this setting enabled and it creates friction.

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other
