### PR TITLE
Fix: Clear Uuid and IsStoreVersion on export

### DIFF
--- a/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
+++ b/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
@@ -22,6 +22,21 @@ public class SettingsManager
     );
 
     private static UserSettings? _current;
+    private static XmlSerializer? _exportSerializer;
+
+    private static XmlSerializer GetExportSerializer()
+    {
+        if (_exportSerializer == null)
+        {
+            XmlAttributeOverrides overrides = new XmlAttributeOverrides();
+            XmlAttributes ignoreAttrs = new XmlAttributes();
+            ignoreAttrs.XmlIgnore = true;
+            overrides.Add(typeof(UserSettings), "Uuid", ignoreAttrs);
+            overrides.Add(typeof(UserSettings), "IsStoreVersion", ignoreAttrs);
+            _exportSerializer = new XmlSerializer(typeof(UserSettings), overrides);
+        }
+        return _exportSerializer;
+    }
 
     private static bool DeserializeSettings(string filePath, out UserSettings? settings)
     {
@@ -110,8 +125,6 @@ public class SettingsManager
         return _current;
     }
 
-    private static XmlSerializer? _exportSerializer;
-
     /// <summary>
     /// Saves the app settings to the settings file.
     /// </summary>
@@ -139,16 +152,7 @@ public class SettingsManager
                     XmlSerializer xmlSerializer;
                     if (isExport)
                     {
-                        if (_exportSerializer == null)
-                        {
-                            XmlAttributeOverrides overrides = new XmlAttributeOverrides();
-                            XmlAttributes ignoreAttrs = new XmlAttributes();
-                            ignoreAttrs.XmlIgnore = true;
-                            overrides.Add(typeof(UserSettings), "Uuid", ignoreAttrs);
-                            overrides.Add(typeof(UserSettings), "IsStoreVersion", ignoreAttrs);
-                            _exportSerializer = new XmlSerializer(typeof(UserSettings), overrides);
-                        }
-                        xmlSerializer = _exportSerializer;
+                        xmlSerializer = GetExportSerializer();
                     }
                     else
                     {

--- a/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
+++ b/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024-2026 The FluentFlyout Authors
+// Copyright (c) 2024-2026 The FluentFlyout Authors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using FluentFlyoutWPF.ViewModels;
@@ -56,6 +56,7 @@ public class SettingsManager
     /// <returns>The restored settings.</returns>
     public static UserSettings RestoreSettings(string? filePath = null)
     {
+        bool isImport = filePath != null;
         filePath ??= SettingsFilePath;
         string backupPath = filePath + ".bak";
 
@@ -63,6 +64,12 @@ public class SettingsManager
         {
             if (DeserializeSettings(filePath, out var loadedSettings) && loadedSettings != null)
             {
+                if (isImport && _current != null)
+                {
+                    loadedSettings.Uuid = _current.Uuid;
+                    loadedSettings.IsStoreVersion = _current.IsStoreVersion;
+                }
+
                 _current = loadedSettings;
                 _current.CompleteInitialization();
 
@@ -103,11 +110,14 @@ public class SettingsManager
         return _current;
     }
 
+    private static XmlSerializer? _exportSerializer;
+
     /// <summary>
     /// Saves the app settings to the settings file.
     /// </summary>
     public static void SaveSettings(string? filePath = null)
     {
+        bool isExport = filePath != null;
         filePath ??= SettingsFilePath;
         string tempPath = filePath + ".tmp";
         string backupPath = filePath + ".bak";
@@ -126,7 +136,24 @@ public class SettingsManager
 
                 using (var writer = new StreamWriter(tempPath, false))
                 {
-                    XmlSerializer xmlSerializer = new(typeof(UserSettings));
+                    XmlSerializer xmlSerializer;
+                    if (isExport)
+                    {
+                        if (_exportSerializer == null)
+                        {
+                            XmlAttributeOverrides overrides = new XmlAttributeOverrides();
+                            XmlAttributes ignoreAttrs = new XmlAttributes();
+                            ignoreAttrs.XmlIgnore = true;
+                            overrides.Add(typeof(UserSettings), "Uuid", ignoreAttrs);
+                            overrides.Add(typeof(UserSettings), "IsStoreVersion", ignoreAttrs);
+                            _exportSerializer = new XmlSerializer(typeof(UserSettings), overrides);
+                        }
+                        xmlSerializer = _exportSerializer;
+                    }
+                    else
+                    {
+                        xmlSerializer = new XmlSerializer(typeof(UserSettings));
+                    }
                     xmlSerializer.Serialize(writer, _current);
                 }
 


### PR DESCRIPTION
Fixes #905

This PR clears the `Uuid` and `IsStoreVersion` fields when exporting settings so users don't share private IDs. When importing, these two fields are ignored from the file, and the user's current values are retained.

Changes:
- Uses `XmlAttributeOverrides` during export to ignore these fields without triggering the observable property background save.
- Caches the custom serializer to prevent memory leaks.
- Retains the active `Uuid` and `IsStoreVersion` during import by overwriting the deserialized settings.