### PR TITLE
feat: Update cardexpander UI to match Windows more closely

### DIFF
--- a/FluentFlyoutWPF/Pages/AdvancedPage.xaml
+++ b/FluentFlyoutWPF/Pages/AdvancedPage.xaml
@@ -19,7 +19,7 @@
         <StackPanel Margin="0,0,0,76">
             <TextBlock Text="{DynamicResource AppearanceBehaviorSectionTitle}" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,6" />
             
-            <ui:CardExpander Icon="{ui:SymbolIcon Wrench24}" ContentPadding="8" Margin="0,0,0,3">
+            <ui:CardExpander Icon="{ui:SymbolIcon Wrench24}" ContentPadding="0" Margin="0,0,0,3">
                 <ui:CardExpander.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource AnimationSettingsTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -27,7 +27,8 @@
                     </StackPanel>
                 </ui:CardExpander.Header>
                 <StackPanel>
-                    <ui:CardControl Icon="{ui:SymbolIcon TopSpeed24}" Margin="0,0,0,4" Background="Transparent" BorderThickness="0" Padding="14,8">
+                    <ui:InfoBar Title="{DynamicResource NativeExperienceInfo}" IsOpen="True" Severity="Informational" IsClosable="False" Margin="8,8,8,0" />
+                    <ui:CardControl Icon="{ui:SymbolIcon TopSpeed24}" Background="Transparent" BorderBrush="{ui:ThemeResource CardStrokeColorDefaultSolidBrush}" BorderThickness="0,0,0,1" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource AnimationDurationScaleTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -45,7 +46,7 @@
                             </ComboBox>
                         </StackPanel>
                     </ui:CardControl>
-                    <ui:CardControl Icon="{ui:SymbolIcon BezierCurveSquare12}" Margin="0,0,0,12" Background="Transparent" BorderThickness="0" Padding="14,8">
+                    <ui:CardControl Icon="{ui:SymbolIcon BezierCurveSquare12}" Background="Transparent" BorderBrush="{ui:ThemeResource CardStrokeColorDefaultSolidBrush}" BorderThickness="0" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource AnimationEasingStyleTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -61,11 +62,10 @@
                             </ComboBox>
                         </StackPanel>
                     </ui:CardControl>
-                    <ui:InfoBar Title="{DynamicResource NativeExperienceInfo}" IsOpen="True" Severity="Informational" IsClosable="False" />
                 </StackPanel>
             </ui:CardExpander>
 
-            <ui:CardExpander Icon="{ui:SymbolIcon Blur24}" ContentPadding="8" Margin="0,0,0,3">
+            <ui:CardExpander Icon="{ui:SymbolIcon Blur24}" ContentPadding="0" Margin="0,0,0,3">
                 <ui:CardExpander.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource AcrylicWindowTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -73,7 +73,7 @@
                     </StackPanel>
                 </ui:CardExpander.Header>
                 <StackPanel>
-                    <ui:CardControl Margin="0,0,0,4" Background="Transparent" BorderThickness="0" Padding="14,8">
+                    <ui:CardControl Background="Transparent" BorderBrush="{ui:ThemeResource CardStrokeColorDefaultSolidBrush}" BorderThickness="0,0,0,1" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource MediaFlyoutTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -82,7 +82,7 @@
                         <controls:ToggleSwitch IsChecked="{Binding MediaFlyoutAcrylicWindowEnabled, Mode=TwoWay}" />
                     </ui:CardControl>
 
-                    <ui:CardControl Margin="0,0,0,4" Background="Transparent" BorderThickness="0" Padding="14,8">
+                    <ui:CardControl Background="Transparent" BorderBrush="{ui:ThemeResource CardStrokeColorDefaultSolidBrush}" BorderThickness="0,0,0,1" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource NextUpCustomizationTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -91,7 +91,7 @@
                         <controls:ToggleSwitch IsChecked="{Binding NextUpAcrylicWindowEnabled, Mode=TwoWay}" />
                     </ui:CardControl>
 
-                    <ui:CardControl Background="Transparent" BorderThickness="0" Padding="14,8">
+                    <ui:CardControl Background="Transparent" BorderBrush="{ui:ThemeResource CardStrokeColorDefaultSolidBrush}" BorderThickness="0" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource LockKeysCustomizationTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />

--- a/FluentFlyoutWPF/Pages/AdvancedPage.xaml
+++ b/FluentFlyoutWPF/Pages/AdvancedPage.xaml
@@ -18,6 +18,7 @@
         <TextBlock Text="{DynamicResource AdvancedSettingsTitle}" FontSize="24" FontWeight="SemiBold" Margin="0,0,0,24" />
         <StackPanel Margin="0,0,0,76">
             <TextBlock Text="{DynamicResource AppearanceBehaviorSectionTitle}" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,6" />
+            
             <ui:CardExpander Icon="{ui:SymbolIcon Wrench24}" ContentPadding="8" Margin="0,0,0,3">
                 <ui:CardExpander.Header>
                     <StackPanel Orientation="Vertical">
@@ -26,7 +27,7 @@
                     </StackPanel>
                 </ui:CardExpander.Header>
                 <StackPanel>
-                    <ui:CardControl Icon="{ui:SymbolIcon TopSpeed24}" Margin="0,0,0,3">
+                    <ui:CardControl Icon="{ui:SymbolIcon TopSpeed24}" Margin="0,0,0,4" Background="Transparent" BorderThickness="0" Padding="14,8">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource AnimationDurationScaleTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -44,7 +45,7 @@
                             </ComboBox>
                         </StackPanel>
                     </ui:CardControl>
-                    <ui:CardControl Icon="{ui:SymbolIcon BezierCurveSquare12}" Margin="0,0,0,3">
+                    <ui:CardControl Icon="{ui:SymbolIcon BezierCurveSquare12}" Margin="0,0,0,12" Background="Transparent" BorderThickness="0" Padding="14,8">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource AnimationEasingStyleTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -72,7 +73,7 @@
                     </StackPanel>
                 </ui:CardExpander.Header>
                 <StackPanel>
-                    <ui:CardControl Margin="0,0,0,3">
+                    <ui:CardControl Margin="0,0,0,4" Background="Transparent" BorderThickness="0" Padding="14,8">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource MediaFlyoutTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -81,7 +82,7 @@
                         <controls:ToggleSwitch IsChecked="{Binding MediaFlyoutAcrylicWindowEnabled, Mode=TwoWay}" />
                     </ui:CardControl>
 
-                    <ui:CardControl Margin="0,0,0,3">
+                    <ui:CardControl Margin="0,0,0,4" Background="Transparent" BorderThickness="0" Padding="14,8">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource NextUpCustomizationTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -90,7 +91,7 @@
                         <controls:ToggleSwitch IsChecked="{Binding NextUpAcrylicWindowEnabled, Mode=TwoWay}" />
                     </ui:CardControl>
 
-                    <ui:CardControl>
+                    <ui:CardControl Background="Transparent" BorderThickness="0" Padding="14,8">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource LockKeysCustomizationTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />

--- a/FluentFlyoutWPF/Pages/TaskbarVisualizerPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarVisualizerPage.xaml
@@ -138,7 +138,7 @@
                 <controls:ToggleSwitch IsChecked="{Binding TaskbarVisualizerCenteredBars, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
             </ui:CardControl>
 
-            <ui:CardExpander Icon="{ui:SymbolIcon LineHorizontal120}" ContentPadding="8" Margin="0,0,0,12">
+            <ui:CardExpander Icon="{ui:SymbolIcon LineHorizontal120}" ContentPadding="0" Margin="0,0,0,12">
                 <ui:CardExpander.Header>
                     <Grid ColumnDefinitions="*, Auto">
                         <StackPanel Orientation="Vertical" Grid.Column="0">
@@ -148,8 +148,8 @@
                         <controls:ToggleSwitch Grid.Column="1" IsChecked="{Binding TaskbarVisualizerBaseline, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" Margin="0,0,16,0" />
                     </Grid>
                 </ui:CardExpander.Header>
-                <StackPanel>
-                    <ui:CardControl Opacity="{Binding TaskbarVisualizerBaseline, Converter={StaticResource BoolToFullHalfOpacityConverter}}" Background="Transparent" BorderThickness="0" Padding="14,8" >
+                <StackPanel Opacity="{Binding TaskbarVisualizerBaseline, Converter={StaticResource BoolToFullHalfOpacityConverter}}">
+                    <ui:CardControl Background="Transparent" BorderBrush="{ui:ThemeResource CardStrokeColorDefaultSolidBrush}" BorderThickness="0" CornerRadius="0" Padding="52,12,16,12">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource TaskbarWidgetAutoHideTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />

--- a/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
@@ -137,7 +137,7 @@
             </ui:CardControl>
 
             <!-- Padding settings -->
-            <ui:CardExpander Grid.Row="6" Icon="{ui:SymbolIcon Wrench24}" ContentPadding="6" Margin="0,0,0,12">
+            <ui:CardExpander Grid.Row="6" Icon="{ui:SymbolIcon Wrench24}" ContentPadding="0" Margin="0,0,0,12">
                 <ui:CardExpander.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TaskbarWidgetPaddingSettingsTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -145,7 +145,7 @@
                     </StackPanel>
                 </ui:CardExpander.Header>
                 <StackPanel>
-                    <ui:CardControl Grid.Row="5" Icon="{ui:SymbolIcon PaddingRight24}" Margin="0,0,0,3">
+                    <ui:CardControl Grid.Row="5" Icon="{ui:SymbolIcon PaddingRight24}" Background="Transparent" BorderBrush="{ui:ThemeResource TextPlaceholderColorBrush}" BorderThickness="0,0,0,1" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource TaskbarWidgetPaddingTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -176,7 +176,7 @@
                             </controls:ToggleSwitch.Style>
                         </controls:ToggleSwitch>
                     </ui:CardControl>
-                    <ui:CardControl Icon="{ui:SymbolIcon ArrowFit20}" Margin="0,0,0,0">
+                    <ui:CardControl Icon="{ui:SymbolIcon ArrowFit20}" Background="Transparent" BorderBrush="{ui:ThemeResource TextPlaceholderColorBrush}" BorderThickness="0" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource TaskbarWidgetManualPaddingTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -261,7 +261,7 @@
                 <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetAnimated, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
             </ui:CardControl>
 
-            <ui:CardExpander Grid.Row="14" Icon="{ui:SymbolIcon TextDirectionHorizontalRight24}" ContentPadding="6" Margin="0,0,0,3">
+            <ui:CardExpander Grid.Row="14" Icon="{ui:SymbolIcon TextDirectionHorizontalRight24}" ContentPadding="0" Margin="0,0,0,3">
                 <ui:CardExpander.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTextTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -269,17 +269,16 @@
                     </StackPanel>
                 </ui:CardExpander.Header>
                 <StackPanel>
-                    <ui:CardControl Margin="0,0,0,3">
+                    <ui:CardControl Background="Transparent" BorderBrush="{ui:ThemeResource TextPlaceholderColorBrush}" BorderThickness="0,0,0,1" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
-                                <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTextDescription}" FontSize="12" Opacity="0.5" />
                             </StackPanel>
                         </ui:CardControl.Header>
                         <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetScrollingEnabled, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
                     </ui:CardControl>
 
-                    <ui:CardControl Margin="0,0,0,3">
+                    <ui:CardControl Background="Transparent" BorderBrush="{ui:ThemeResource TextPlaceholderColorBrush}" BorderThickness="0,0,0,1" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTextLoopForeverTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -288,7 +287,7 @@
                         </ui:CardControl.Header>
                         <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetScrollingTextLoopForever, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
                     </ui:CardControl>
-                    <ui:CardControl Margin="0,0,0,0">
+                    <ui:CardControl Background="Transparent" BorderBrush="{ui:ThemeResource TextPlaceholderColorBrush}" BorderThickness="0" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTextSpeedTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />

--- a/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
@@ -145,7 +145,7 @@
                     </StackPanel>
                 </ui:CardExpander.Header>
                 <StackPanel>
-                    <ui:CardControl Grid.Row="5" Icon="{ui:SymbolIcon PaddingRight24}" Background="Transparent" BorderBrush="{ui:ThemeResource TextPlaceholderColorBrush}" BorderThickness="0,0,0,1" CornerRadius="0" Padding="52,16,16,16">
+                    <ui:CardControl Grid.Row="5" Icon="{ui:SymbolIcon PaddingRight24}" Background="Transparent" BorderBrush="{ui:ThemeResource CardStrokeColorDefaultSolidBrush}" BorderThickness="0,0,0,1" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource TaskbarWidgetPaddingTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -176,7 +176,7 @@
                             </controls:ToggleSwitch.Style>
                         </controls:ToggleSwitch>
                     </ui:CardControl>
-                    <ui:CardControl Icon="{ui:SymbolIcon ArrowFit20}" Background="Transparent" BorderBrush="{ui:ThemeResource TextPlaceholderColorBrush}" BorderThickness="0" CornerRadius="0" Padding="52,16,16,16">
+                    <ui:CardControl Icon="{ui:SymbolIcon ArrowFit20}" Background="Transparent" BorderBrush="{ui:ThemeResource CardStrokeColorDefaultSolidBrush}" BorderThickness="0" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource TaskbarWidgetManualPaddingTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -263,31 +263,25 @@
 
             <ui:CardExpander Grid.Row="14" Icon="{ui:SymbolIcon TextDirectionHorizontalRight24}" ContentPadding="0" Margin="0,0,0,3">
                 <ui:CardExpander.Header>
-                    <StackPanel Orientation="Vertical">
-                        <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTextTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
-                        <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTextDescription}" FontSize="12" Opacity="0.5" />
-                    </StackPanel>
+                    <Grid ColumnDefinitions="*, Auto">
+                        <StackPanel Orientation="Vertical">
+                            <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTextTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                            <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTextDescription}" FontSize="12" Opacity="0.5" />
+                        </StackPanel>
+                        <controls:ToggleSwitch Grid.Column="1" IsChecked="{Binding TaskbarWidgetScrollingEnabled, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" Margin="0,0,16,0" />
+                    </Grid>
                 </ui:CardExpander.Header>
-                <StackPanel>
-                    <ui:CardControl Background="Transparent" BorderBrush="{ui:ThemeResource TextPlaceholderColorBrush}" BorderThickness="0,0,0,1" CornerRadius="0" Padding="52,16,16,16">
-                        <ui:CardControl.Header>
-                            <StackPanel Orientation="Vertical">
-                                <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
-                            </StackPanel>
-                        </ui:CardControl.Header>
-                        <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetScrollingEnabled, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
-                    </ui:CardControl>
-
-                    <ui:CardControl Background="Transparent" BorderBrush="{ui:ThemeResource TextPlaceholderColorBrush}" BorderThickness="0,0,0,1" CornerRadius="0" Padding="52,16,16,16">
+                <StackPanel  Opacity="{Binding TaskbarWidgetScrollingEnabled, Converter={StaticResource BoolToFullHalfOpacityConverter}}">
+                    <ui:CardControl Background="Transparent" BorderBrush="{ui:ThemeResource CardStrokeColorDefaultSolidBrush}" BorderThickness="0,0,0,1" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTextLoopForeverTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
                                 <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTextLoopForeverDescription}" FontSize="12" Opacity="0.5" />
                             </StackPanel>
                         </ui:CardControl.Header>
-                        <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetScrollingTextLoopForever, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
+                        <controls:ToggleSwitch IsChecked="{Binding TaskbarWidgetScrollingTextLoopForever, Mode=TwoWay}" IsEnabled="{Binding TaskbarWidgetScrollingEnabled}" />
                     </ui:CardControl>
-                    <ui:CardControl Background="Transparent" BorderBrush="{ui:ThemeResource TextPlaceholderColorBrush}" BorderThickness="0" CornerRadius="0" Padding="52,16,16,16">
+                    <ui:CardControl Background="Transparent" BorderBrush="{ui:ThemeResource CardStrokeColorDefaultSolidBrush}" BorderThickness="0" CornerRadius="0" Padding="52,16,16,16">
                         <ui:CardControl.Header>
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="{DynamicResource TaskbarWidgetScrollingTextSpeedTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -295,7 +289,7 @@
                             </StackPanel>
                         </ui:CardControl.Header>
                         <StackPanel Orientation="Horizontal">
-                            <ui:TextBox Width="60" ClearButtonEnabled="False" Text="{Binding TaskbarWidgetScrollingTextSpeedText, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
+                            <ui:TextBox Width="60" ClearButtonEnabled="False" Text="{Binding TaskbarWidgetScrollingTextSpeedText, Mode=TwoWay}" IsEnabled="{Binding TaskbarWidgetScrollingEnabled}" />
                         </StackPanel>
                     </ui:CardControl>
                 </StackPanel>


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->

Update the CardExpander elements to match Windows more closely. This should be slightly more readable and feel much more native compared to the old version:

Before:
<img width="1236" height="345" alt="image" src="https://github.com/user-attachments/assets/72fb8212-3832-4c16-814c-7ac16f742b12" />

After:
<img width="auto" alt="image" src="https://github.com/user-attachments/assets/e9d47260-83ee-40ac-a16f-b0c38a876cba" />

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other