### PR TITLE
Fix fullscreen application detection

### DIFF
--- a/FluentFlyoutWPF/Classes/FullscreenDetector.cs
+++ b/FluentFlyoutWPF/Classes/FullscreenDetector.cs
@@ -68,8 +68,8 @@ internal static class FullscreenDetector
         // Get the monitor the window is in
         MonitorUtil.MonitorInfo monitorInfo = MonitorUtil.GetMonitor(hwnd);
         
-        // If the flyout isn't going to be shown on the same monitor as the application is running, disregard this check
-        if (!flytoutMonitor.deviceId.Equals(monitorInfo.deviceId)) return false;
+        // If the flyout isn't going to be shown on the same monitor as the application is running and the setting to allow this is enabled, disregard this check
+        if (SettingsManager.Current.AllowOtherMonitors && !flytoutMonitor.deviceId.Equals(monitorInfo.deviceId)) return false;
         
         // Check if the foreground window's borders are in the same positions as the borders of the monitor (A.K.A, is in borderless fullscreen)
         return windowRect.Left == (int)monitorInfo.monitorArea.Left &&

--- a/FluentFlyoutWPF/Classes/FullscreenDetector.cs
+++ b/FluentFlyoutWPF/Classes/FullscreenDetector.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using FluentFlyout.Classes.Settings;
+using MicaWPF.Core.Interop;
+using System.Runtime.InteropServices;
 using static FluentFlyout.Classes.NativeMethods;
 
 namespace FluentFlyoutWPF.Classes;
@@ -15,16 +17,17 @@ internal class FullscreenDetector
     /// </summary>
     /// <returns>
     /// true if a fullscreen DirectX application is running;
-    /// false if no fullscreen application is detected, DisableIfFullscreen setting is false, or if the check fails
+    /// false if no fullscreen application is detected or if the check fails
     /// </returns>
-    public static bool IsFullscreenApplicationRunning()
+    private static bool IsDirectXApplicationRunning()
     {
-        if (!SettingsManager.Current.DisableIfFullscreen) return false;
         try
         {
             QUERY_USER_NOTIFICATION_STATE state;
             int result = SHQueryUserNotificationState(out state);
 
+            Logger.Debug(state);
+            
             if (result != 0) // 0 means SUCCESS
             {
                 throw new Exception($"SHQueryUserNotificationState failed with error code: {result}");
@@ -37,5 +40,64 @@ internal class FullscreenDetector
             Logger.Error(ex, "Error detecting fullscreen state");
             return false;
         }
+    }
+
+    /// <summary>
+    /// Checks if a borderless fullscreen application or game is currently running.
+    /// </summary>
+    /// <returns>
+    /// true if a borderless fullscreen application is running;
+    /// false if no borderless fullscreen application is detected or if the check fails
+    /// </returns>
+    private static bool IsBorderlessFullscreenApplicationRunning()
+    {
+        // Get the current foreground window
+        IntPtr hwnd = GetForegroundWindow();
+        
+        // If there's none, disregard this check
+        if (hwnd == IntPtr.Zero) return false;
+        
+        if (IsIconic(hwnd)) return false; // If the window is minimized, disregard this check
+
+        // Get window corners
+        if (!GetWindowRect(hwnd, out RECT windowRect))
+        {
+            Logger.Error($"Failed to get window rectangle for hwnd: {hwnd}");
+            return false;
+        }
+        
+        // Get the monitor the window is in
+        IntPtr monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+
+        // Get the information of this monitor
+        MONITORINFOEX monitorInfo = new() { cbSize = Marshal.SizeOf<MONITORINFOEX>() };
+        if (!GetMonitorInfo(monitor, ref monitorInfo))
+        {
+            Logger.Error($"Failed to get monitor info for monitor: {monitor}");
+            return false;
+        }
+        
+        // Check if the foreground window's borders are in the same positions as the borders of the monitor (A.K.A, is in borderless fullscreen)
+        return windowRect.Left == monitorInfo.rcMonitor.Left &&
+               windowRect.Top == monitorInfo.rcMonitor.Top &&
+               windowRect.Right == monitorInfo.rcMonitor.Right &&
+               windowRect.Bottom == monitorInfo.rcMonitor.Bottom;
+    }
+
+    /// <summary>
+    /// Checks if an exclusive or borderless fullscreen application or game is currently running.
+    /// </summary>
+    /// <returns>
+    /// true if an exclusive or borderless fullscreen application is running;
+    /// false if no exclusive or borderless fullscreen application is detected, DisableIfFullscreen setting is false, or if any of the previous checks fail
+    /// </returns>
+    public static bool IsFullscreenApplicationRunning()
+    {
+        bool directX = IsDirectXApplicationRunning();
+        bool borderless = IsBorderlessFullscreenApplicationRunning();
+        
+        Logger.Debug($"DirectX Fullscreen: {directX}, Borderless Fullscreen: {borderless}, DisableIfFullscreen Setting: {SettingsManager.Current.DisableIfFullscreen}");
+        
+        return SettingsManager.Current.DisableIfFullscreen && (directX || borderless);
     }
 }

--- a/FluentFlyoutWPF/Classes/FullscreenDetector.cs
+++ b/FluentFlyoutWPF/Classes/FullscreenDetector.cs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using FluentFlyout.Classes.Settings;
-using MicaWPF.Core.Interop;
 using System.Runtime.InteropServices;
 using static FluentFlyout.Classes.NativeMethods;
 
 namespace FluentFlyoutWPF.Classes;
 
-internal class FullscreenDetector
+internal static class FullscreenDetector
 {
     private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 

--- a/FluentFlyoutWPF/Classes/FullscreenDetector.cs
+++ b/FluentFlyoutWPF/Classes/FullscreenDetector.cs
@@ -87,6 +87,9 @@ internal static class FullscreenDetector
     /// </returns>
     public static bool IsFullscreenApplicationRunning(MonitorUtil.MonitorInfo flyoutMonitor)
     {
+        // If the setting isn't on, don't even try check of open apps
+        if (!SettingsManager.Current.DisableIfFullscreen) return false;
+        
         bool directX = IsDirectXApplicationRunning();
         bool borderless = IsBorderlessFullscreenApplicationRunning(flyoutMonitor);
         
@@ -94,6 +97,6 @@ internal static class FullscreenDetector
         Logger.Debug($"DirectX Fullscreen: {directX}, Borderless Fullscreen: {borderless}, DisableIfFullscreen Setting: {SettingsManager.Current.DisableIfFullscreen}");
 #endif
         
-        return SettingsManager.Current.DisableIfFullscreen && (directX || borderless);
+        return directX || borderless;
     }
 }

--- a/FluentFlyoutWPF/Classes/FullscreenDetector.cs
+++ b/FluentFlyoutWPF/Classes/FullscreenDetector.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using FluentFlyout.Classes.Settings;
-using System.Runtime.InteropServices;
+using FluentFlyoutWPF.Classes.Utils;
 using static FluentFlyout.Classes.NativeMethods;
 
 namespace FluentFlyoutWPF.Classes;
@@ -48,7 +48,7 @@ internal static class FullscreenDetector
     /// true if a borderless fullscreen application is running;
     /// false if no borderless fullscreen application is detected or if the check fails
     /// </returns>
-    private static bool IsBorderlessFullscreenApplicationRunning()
+    private static bool IsBorderlessFullscreenApplicationRunning(MonitorUtil.MonitorInfo flytoutMonitor)
     {
         // Get the current foreground window
         IntPtr hwnd = GetForegroundWindow();
@@ -66,21 +66,16 @@ internal static class FullscreenDetector
         }
         
         // Get the monitor the window is in
-        IntPtr monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-
-        // Get the information of this monitor
-        MONITORINFOEX monitorInfo = new() { cbSize = Marshal.SizeOf<MONITORINFOEX>() };
-        if (!GetMonitorInfo(monitor, ref monitorInfo))
-        {
-            Logger.Error($"Failed to get monitor info for monitor: {monitor}");
-            return false;
-        }
+        MonitorUtil.MonitorInfo monitorInfo = MonitorUtil.GetMonitor(hwnd);
+        
+        // If the flyout isn't going to be shown on the same monitor as the application is running, disregard this check
+        if (!flytoutMonitor.deviceId.Equals(monitorInfo.deviceId)) return false;
         
         // Check if the foreground window's borders are in the same positions as the borders of the monitor (A.K.A, is in borderless fullscreen)
-        return windowRect.Left == monitorInfo.rcMonitor.Left &&
-               windowRect.Top == monitorInfo.rcMonitor.Top &&
-               windowRect.Right == monitorInfo.rcMonitor.Right &&
-               windowRect.Bottom == monitorInfo.rcMonitor.Bottom;
+        return windowRect.Left == (int)monitorInfo.monitorArea.Left &&
+               windowRect.Top == (int)monitorInfo.monitorArea.Top &&
+               windowRect.Right == (int)monitorInfo.monitorArea.Right &&
+               windowRect.Bottom == (int)monitorInfo.monitorArea.Bottom;
     }
 
     /// <summary>
@@ -90,10 +85,10 @@ internal static class FullscreenDetector
     /// true if an exclusive or borderless fullscreen application is running;
     /// false if no exclusive or borderless fullscreen application is detected, DisableIfFullscreen setting is false, or if any of the previous checks fail
     /// </returns>
-    public static bool IsFullscreenApplicationRunning()
+    public static bool IsFullscreenApplicationRunning(MonitorUtil.MonitorInfo flyoutMonitor)
     {
         bool directX = IsDirectXApplicationRunning();
-        bool borderless = IsBorderlessFullscreenApplicationRunning();
+        bool borderless = IsBorderlessFullscreenApplicationRunning(flyoutMonitor);
         
 #if DEBUG
         Logger.Debug($"DirectX Fullscreen: {directX}, Borderless Fullscreen: {borderless}, DisableIfFullscreen Setting: {SettingsManager.Current.DisableIfFullscreen}");

--- a/FluentFlyoutWPF/Classes/FullscreenDetector.cs
+++ b/FluentFlyoutWPF/Classes/FullscreenDetector.cs
@@ -95,7 +95,9 @@ internal static class FullscreenDetector
         bool directX = IsDirectXApplicationRunning();
         bool borderless = IsBorderlessFullscreenApplicationRunning();
         
+#if DEBUG
         Logger.Debug($"DirectX Fullscreen: {directX}, Borderless Fullscreen: {borderless}, DisableIfFullscreen Setting: {SettingsManager.Current.DisableIfFullscreen}");
+#endif
         
         return SettingsManager.Current.DisableIfFullscreen && (directX || borderless);
     }

--- a/FluentFlyoutWPF/Classes/FullscreenDetector.cs
+++ b/FluentFlyoutWPF/Classes/FullscreenDetector.cs
@@ -26,7 +26,7 @@ internal static class FullscreenDetector
             int result = SHQueryUserNotificationState(out state);
 
             Logger.Debug(state);
-            
+
             if (result != 0) // 0 means SUCCESS
             {
                 throw new Exception($"SHQueryUserNotificationState failed with error code: {result}");
@@ -52,10 +52,10 @@ internal static class FullscreenDetector
     {
         // Get the current foreground window
         IntPtr hwnd = GetForegroundWindow();
-        
+
         // If there's none, disregard this check
         if (hwnd == IntPtr.Zero) return false;
-        
+
         if (IsIconic(hwnd)) return false; // If the window is minimized, disregard this check
 
         // Get window corners
@@ -64,13 +64,13 @@ internal static class FullscreenDetector
             Logger.Error($"Failed to get window rectangle for hwnd: {hwnd}");
             return false;
         }
-        
+
         // Get the monitor the window is in
         MonitorUtil.MonitorInfo monitorInfo = MonitorUtil.GetMonitor(hwnd);
-        
+
         // If the flyout isn't going to be shown on the same monitor as the application is running and the setting to allow this is enabled, disregard this check
         if (SettingsManager.Current.AllowOtherMonitors && !flytoutMonitor.deviceId.Equals(monitorInfo.deviceId)) return false;
-        
+
         // Check if the foreground window's borders are in the same positions as the borders of the monitor (A.K.A, is in borderless fullscreen)
         return windowRect.Left == (int)monitorInfo.monitorArea.Left &&
                windowRect.Top == (int)monitorInfo.monitorArea.Top &&
@@ -89,14 +89,14 @@ internal static class FullscreenDetector
     {
         // If the setting isn't on, don't even try check of open apps
         if (!SettingsManager.Current.DisableIfFullscreen) return false;
-        
+
         bool directX = IsDirectXApplicationRunning();
         bool borderless = IsBorderlessFullscreenApplicationRunning(flyoutMonitor);
-        
+
 #if DEBUG
         Logger.Debug($"DirectX Fullscreen: {directX}, Borderless Fullscreen: {borderless}, DisableIfFullscreen Setting: {SettingsManager.Current.DisableIfFullscreen}");
 #endif
-        
+
         return directX || borderless;
     }
 }

--- a/FluentFlyoutWPF/Classes/NativeMethods.cs
+++ b/FluentFlyoutWPF/Classes/NativeMethods.cs
@@ -327,6 +327,10 @@ public static partial class NativeMethods
 
     [LibraryImport("user32.dll", SetLastError = true)]
     internal static partial IntPtr GetForegroundWindow();
+    
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool IsIconic(IntPtr hWnd);
     #endregion
 
     #region gdi32.dll

--- a/FluentFlyoutWPF/Classes/NativeMethods.cs
+++ b/FluentFlyoutWPF/Classes/NativeMethods.cs
@@ -327,7 +327,7 @@ public static partial class NativeMethods
 
     [LibraryImport("user32.dll", SetLastError = true)]
     internal static partial IntPtr GetForegroundWindow();
-    
+
     [LibraryImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static partial bool IsIconic(IntPtr hWnd);

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -712,7 +712,7 @@ public partial class MainWindow : MicaWindow
 
         pauseOtherMediaSessionsIfNeeded(mediaSession);
 
-        if (SettingsManager.Current.NextUpEnabled && !FullscreenDetector.IsFullscreenApplicationRunning()) // show NextUpWindow if enabled in settings
+        if (SettingsManager.Current.NextUpEnabled && !FullscreenDetector.IsFullscreenApplicationRunning(GetSelectedMonitor(SettingsManager.Current.FlyoutSelectedMonitor))) // show NextUpWindow if enabled in settings
         {
             void createNewNextUpWindow()
             {
@@ -830,7 +830,15 @@ public partial class MainWindow : MicaWindow
             }
 
             if (SettingsManager.Current.LockKeysEnabled
-                && !FullscreenDetector.IsFullscreenApplicationRunning()
+                && !FullscreenDetector.IsFullscreenApplicationRunning(
+                    SettingsManager.Current.LockKeysMonitorPreference switch
+                    {
+                        0 => GetSelectedMonitor(SettingsManager.Current.FlyoutSelectedMonitor), // same as media flyout
+                        1 => GetMonitorWithFocusedWindow(), // Monitor with focused window
+                        2 => GetMonitorWithCursor(), // Monitor with cursor
+                        _ => GetSelectedMonitor(SettingsManager.Current.FlyoutSelectedMonitor), // default to same as media flyout
+                    }
+                )
                 && wParam == WM_KEYUP)
             {
                 if (vkCode == 0x14 && SettingsManager.Current.LockKeysCapsEnabled) // Caps Lock
@@ -877,7 +885,7 @@ public partial class MainWindow : MicaWindow
         var activeSession = GetActiveMediaSession();
         if (activeSession == null ||
             (!forceShow && !SettingsManager.Current.MediaFlyoutEnabled) ||
-            FullscreenDetector.IsFullscreenApplicationRunning())
+            FullscreenDetector.IsFullscreenApplicationRunning(GetSelectedMonitor(SettingsManager.Current.FlyoutSelectedMonitor)))
             return;
 
         // If in toggle mode and flyout is visible, close it

--- a/FluentFlyoutWPF/Pages/SystemPage.xaml
+++ b/FluentFlyoutWPF/Pages/SystemPage.xaml
@@ -121,6 +121,15 @@
                 </ui:CardControl.Header>
                 <controls:ToggleSwitch Name="DisableIfFullscreenSwitch" IsChecked="{Binding DisableIfFullscreen, Mode=TwoWay}" />
             </ui:CardControl>
+            <ui:CardControl x:Name="AllowOtherMonitorsCard" Tag="Indexable" Icon="{ui:SymbolIcon DualScreenGroup24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource AllowOtherMonitorsTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource AllowOtherMonitorsDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <controls:ToggleSwitch Name="AllowOtherMonitorsSwitch" IsChecked="{Binding AllowOtherMonitors, Mode=TwoWay}" IsEnabled="{Binding DisableIfFullscreen}"/>
+            </ui:CardControl>
 
             <!-- tray icon section -->
             <TextBlock Text="{DynamicResource TrayIconSectionTitle}" FontSize="14" FontWeight="SemiBold" Margin="0,12,0,6" />

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -179,8 +179,8 @@ Note: As an open-source project, these features are also available for free via 
     <System:String x:Key="EasingQuadratic" xml:space="preserve"> Quadratic</System:String>
     <System:String x:Key="EasingCubic" xml:space="preserve"> Cubic</System:String>
     <System:String x:Key="NativeExperienceInfo">For the native Windows 11 experience, the settings should be kept at default.</System:String>
-    <System:String x:Key="DisableOnFullscreenTitle">Disable Flyouts if DirectX fullscreen program is detected</System:String>
-    <System:String x:Key="DisableOnFullscreenDescription">Prevents DirectX games in exclusive fullscreen from minimizing if a flyout pops up</System:String>
+    <System:String x:Key="DisableOnFullscreenTitle">Disable Flyouts if an Exclusive or Borderless Fullscreen program is detected</System:String>
+    <System:String x:Key="DisableOnFullscreenDescription">Prevents games or programs running in Exclusive or Borderless FullScreen from being minimized or having their performance affected from flyout pop ups</System:String>
     <System:String x:Key="AcrylicBlurOpacityTitle">Acrylic Blur Opacity</System:String>
     <System:String x:Key="AcrylicBlurOpacityDescription">Adjust the see-through effect on Acrylic flyouts (default: 175)</System:String>
     <System:String x:Key="HomeUpdateDescription">Learn what's new</System:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -179,10 +179,10 @@ Note: As an open-source project, these features are also available for free via 
     <System:String x:Key="EasingQuadratic" xml:space="preserve"> Quadratic</System:String>
     <System:String x:Key="EasingCubic" xml:space="preserve"> Cubic</System:String>
     <System:String x:Key="NativeExperienceInfo">For the native Windows 11 experience, the settings should be kept at default.</System:String>
-    <System:String x:Key="DisableOnFullscreenTitle">Disable Flyouts if an Exclusive or Borderless Fullscreen program is detected</System:String>
-    <System:String x:Key="DisableOnFullscreenDescription">Prevents games or programs running in Exclusive or Borderless FullScreen from being minimized or having their performance affected from flyout pop ups</System:String>
-    <System:String x:Key="AllowOtherMonitorsTitle">Allow Flyouts if on another Monitor</System:String>
-    <System:String x:Key="AllowOtherMonitorsDescription">Show the flyout anyway if it's going to appear in a different monitor than the one with the fullscreen app</System:String>
+    <System:String x:Key="DisableOnFullscreenTitle">Disable Flyouts when an Exclusive or Borderless Fullscreen App is Running</System:String>
+    <System:String x:Key="DisableOnFullscreenDescription">Prevents flyouts from appearing while an app or game is running in Exclusive or Borderless Fullscreen mode to avoid interruptions and potential performance impact</System:String>
+    <System:String x:Key="AllowOtherMonitorsTitle">Allow Flyouts on other Monitors</System:String>
+    <System:String x:Key="AllowOtherMonitorsDescription">Shows flyouts only when they appear on a different monitor than the one running the fullscreen app</System:String>
     <System:String x:Key="AcrylicBlurOpacityTitle">Acrylic Blur Opacity</System:String>
     <System:String x:Key="AcrylicBlurOpacityDescription">Adjust the see-through effect on Acrylic flyouts (default: 175)</System:String>
     <System:String x:Key="HomeUpdateDescription">Learn what's new</System:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -181,6 +181,8 @@ Note: As an open-source project, these features are also available for free via 
     <System:String x:Key="NativeExperienceInfo">For the native Windows 11 experience, the settings should be kept at default.</System:String>
     <System:String x:Key="DisableOnFullscreenTitle">Disable Flyouts if an Exclusive or Borderless Fullscreen program is detected</System:String>
     <System:String x:Key="DisableOnFullscreenDescription">Prevents games or programs running in Exclusive or Borderless FullScreen from being minimized or having their performance affected from flyout pop ups</System:String>
+    <System:String x:Key="AllowOtherMonitorsTitle">Allow Flyouts if on another Monitor</System:String>
+    <System:String x:Key="AllowOtherMonitorsDescription">Show the flyout anyway if it's going to appear in a different monitor than the one with the fullscreen app</System:String>
     <System:String x:Key="AcrylicBlurOpacityTitle">Acrylic Blur Opacity</System:String>
     <System:String x:Key="AcrylicBlurOpacityDescription">Adjust the see-through effect on Acrylic flyouts (default: 175)</System:String>
     <System:String x:Key="HomeUpdateDescription">Learn what's new</System:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -255,11 +255,17 @@ public partial class UserSettings : ObservableObject
     public partial bool NIconHide { get; set; }
 
     /// <summary>
-    /// Disable flyout when a DirectX exclusive fullscreen app is detected
+    /// Disable flyout when an Exclusive or Borderless app is detected
     /// </summary>
     [ObservableProperty]
     public partial bool DisableIfFullscreen { get; set; }
 
+    /// <summary>
+    /// Allow flyout to be shown when there's a fullscreen app in another monitor other than the one where the flyout will appear
+    /// </summary>
+    [ObservableProperty]
+    public partial bool AllowOtherMonitors { get; set; }
+    
     /// <summary>
     /// Use bold symbol and font in the lock keys flyout
     /// </summary>
@@ -718,6 +724,7 @@ public partial class UserSettings : ObservableObject
         NIconSymbol = false;
         NIconHide = false;
         DisableIfFullscreen = true;
+        AllowOtherMonitors = false;
         LockKeysBoldUi = false;
         LockKeysMonitorPreference = 0;
         LastKnownVersion = "";

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -265,7 +265,7 @@ public partial class UserSettings : ObservableObject
     /// </summary>
     [ObservableProperty]
     public partial bool AllowOtherMonitors { get; set; }
-    
+
     /// <summary>
     /// Use bold symbol and font in the lock keys flyout
     /// </summary>

--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
@@ -10,6 +10,7 @@
 using FluentFlyout.Classes;
 using FluentFlyout.Classes.Settings;
 using FluentFlyoutWPF.Classes;
+using FluentFlyoutWPF.Classes.Utils;
 using FluentFlyoutWPF.ViewModels;
 using MicaWPF.Controls;
 using NLog;
@@ -59,7 +60,7 @@ public partial class VolumeMixerWindow : MicaWindow
     // one day we might want to convert these to an interface
     public async void ShowFlyout()
     {
-        if (FullscreenDetector.IsFullscreenApplicationRunning())
+        if (FullscreenDetector.IsFullscreenApplicationRunning(MonitorUtil.GetSelectedMonitor(SettingsManager.Current.FlyoutSelectedMonitor)))
             return;
 
         long currentTime = Environment.TickCount64;


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->
This PR fixes the current implementation of Fullscreen applications
## Motivation

<!-- Why is this change needed? Link issues if applicable. -->
I have noticed that, as a Borderless gamer, FluentFlyout doesn't properly detect when a game is running in Borderless Fullscreen, causing the flyouts to appear nonetheless.

Even though this doesn't have the same impact as it does in Exclusive Fullscreen (game minimizes) it can have other types of outcomes like Framerate drops or enormous Input Lag.

Fixes #797
Fixes #748 
Fixes #708 

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

<!-- Bullet points of key changes made in this PR. -->

- Created method `IsBorderlessFullscreenApplicationRunning` in`FullscreenDetector.cs` that contains the logic that returns if there is any borderless application running in the foreground of the monitor where the Flyout will appear
- Split method `IsFullscreenApplicationRunning` in two other methods - `IsBorderlessFullscreenApplicationRunning` (mentioned previously) and `IsDirectXApplicationRunning` (contains the original body of `IsFullscreenApplicationRunning`) - that returns the combined result
- Converted the class `FullscreenDetector.cs` to `static` as it only serves static members
- Added a setting to allow flyouts to appear in different monitors, even if a borderless fullscreen application is in the foreground
- Changed text of existing setting to disable flyouts if a DirectX fullscreen application is in the foreground

## Additional Information

<!-- Any other information, such as screenshots -->
<img width="1078" height="181" alt="image" src="https://github.com/user-attachments/assets/bc7406d7-3192-4de0-acf7-c5e95d9aa3ce" />

### Notes
- To check if there was a DirectX application running, the `SHQueryUserNotificationState` function from the `user32.dll` was used. I though about using the same method, however checking for `QUNS_BUSY` instead of `QUNS_RUNNING_D3D_FULL_SCREEN`, however that would trigger even if the borderless app was not focused or minimized, so I decided to calculate the size of the foreground window and compare it to the current monitor's size
- I've noticed that FluentFlyout checks for fullscreen apps every time a keypress is registered, even if that keypress doesn't have anything to do with media, volume or lock keys. I haven't touched this as, accordingly with the profiling I've done, it doesn't seem to affect PC performance that much, but it might be something to be looked into.

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
<!-- AI usage -->
- [ ] AI tools were used (if yes, I reviewed and fully understand the changes myself).