### PR TITLE
fix: app name resolution for Firefox-based browsers

### DIFF
--- a/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
+++ b/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -96,7 +97,20 @@ public static class MediaPlayerData
             })
             .FirstOrDefault(data => data != null); // use first result
 
-        if (processData == null) return (mediaTitle, mediaIcon);
+        if (processData == null)
+        {
+            var (shellTitle, shellIcon) = ResolveViaAppsFolder(mediaPlayerId);
+            if (shellTitle == null) return (mediaTitle, mediaIcon);
+
+            mediaPlayerCache[mediaPlayerId] = new CachedMediaPlayerInfo
+            {
+                Title = shellTitle,
+                Icon = shellIcon,
+                ProcessId = -1 // no process match, -1 avoids colliding with real PIDs
+            };
+
+            return (shellTitle, shellIcon);
+        }
 
         mediaTitle = !string.IsNullOrWhiteSpace(processData.Title) ? processData.Title : mediaPlayerId;
 
@@ -181,6 +195,40 @@ public static class MediaPlayerData
         catch
         {
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves an AppUserModelId through the shell Apps folder ("shell:AppsFolder"),
+    /// the same way the native media flyout does. Handles apps whose session id
+    /// doesn't match their process path, e.g. Firefox-based browsers (#949).
+    /// </summary>
+    private static (string? Title, ImageSource? Icon) ResolveViaAppsFolder(string appUserModelId)
+    {
+        try
+        {
+            var shellType = Type.GetTypeFromProgID("Shell.Application");
+            if (shellType == null) return (null, null);
+
+            dynamic shell = Activator.CreateInstance(shellType)!;
+            dynamic? item = shell.NameSpace("shell:AppsFolder")?.ParseName(appUserModelId);
+            if (item == null) return (null, null);
+
+            string name = item.Name;
+            if (string.IsNullOrWhiteSpace(name)) return (null, null);
+
+            // desktop apps expose their start menu shortcut target, so the icon can
+            // be extracted the same way as everywhere else; packaged apps don't
+            // have one and keep a null icon
+            var targetPath = item.ExtendedProperty("System.Link.TargetParsingPath") as string;
+            ImageSource? icon = targetPath != null ? GetIconFromPath(targetPath) : null;
+
+            return (name, icon);
+        }
+        catch
+        {
+            // id is not registered in the apps folder, nothing we can do
+            return (null, null);
         }
     }
 }


### PR DESCRIPTION
## Summary

fixes app name resolution for Firefox based browsers

## Motivation

I looked through the FluentFlyout repo's issues and found this bug report right away. Since I use Firefox myself (and somehow never noticed the install-hash displaying in the MediaFlyout instead of the app name) I decided to fix this myself.

Closes #949

## Type of Change

- [ ] Feature
- [X] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

Fall back to resolving the AppUserModelId through the shell Apps folder when no process path matches, so browsers reporting an install-hash id (like any Firefox based browser) show their correct app name and icon instead of their raw id

<img width="310" height="112" alt="image" src="https://github.com/user-attachments/assets/853cf040-f78a-4207-952c-d57b75ab6c2b" />


## Checklist
- [X] Code changes are manually tested and working.
- [X] Formatting and naming are consistent with the project.
- [X] Self-review of changes is done.
<!-- AI usage -->
- [ ] AI tools were used (if yes, I reviewed and fully understand the changes myself).