### PR TITLE
Fix settings not saving by retrying replace attempts

### DIFF
--- a/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
+++ b/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
@@ -131,13 +131,9 @@ public class SettingsManager
                 }
 
                 if (File.Exists(filePath))
-                {
-                    File.Replace(tempPath, filePath, backupPath, true);
-                }
+                    TryReplaceSettingsFile(filePath, tempPath, backupPath);
                 else
-                {
-                    File.Move(tempPath, filePath, true);
-                }
+                    File.Move(tempPath, filePath);
             }
         }
         catch (UnauthorizedAccessException ex)
@@ -165,5 +161,41 @@ public class SettingsManager
                 }
             }
         }
+    }
+
+    private static void TryReplaceSettingsFile(string filePath, string tempPath, string backupPath)
+    {
+        int maxAttempts = 5;
+        // The following steps try to avoid issues with file locks and permissions on some systems.
+        for (int attempts = 1; attempts <= maxAttempts; attempts++)
+        {
+            try
+            {
+                File.Replace(tempPath, filePath, backupPath, ignoreMetadataErrors: true);
+                break;
+            }
+            catch (IOException ex) when (attempts < maxAttempts)
+            {
+                // if the file is locked, wait and retry
+                Logger.Warn(ex, "Settings file is locked, retrying...");
+                Thread.Sleep(75);
+            }
+            catch (IOException ex)
+            {
+                Logger.Warn(ex, "File.Replace failed after retries, manually replacing...");
+                ManualReplace(filePath, tempPath, backupPath);
+                return;
+            }
+        }
+    }
+
+    private static void ManualReplace(string filePath, string tempPath, string backupPath)
+    {
+        if (File.Exists(backupPath))
+            File.Delete(backupPath);
+
+        File.Copy(filePath, backupPath);
+        File.Delete(filePath);
+        File.Move(tempPath, filePath);
     }
 }

--- a/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
+++ b/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
@@ -131,9 +131,35 @@ public class SettingsManager
                 }
 
                 if (File.Exists(filePath))
-                    TryReplaceSettingsFile(filePath, tempPath, backupPath);
+                    _ = Task.Run(async () =>
+                    {
+                        // Run asynchronously to avoid blocking the UI thread
+                        try
+                        {
+                            await TryReplaceSettingsFileAsync(filePath, tempPath, backupPath);
+                            Logger.Info("Settings successfully saved to {0}", filePath);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error(ex, "Error replacing settings file");
+                        }
+                        finally
+                        {
+                            TryDeleteFileIfExists(tempPath);
+                        }
+                    });
                 else
-                    File.Move(tempPath, filePath, true);
+                {
+                    try
+                    {
+                        File.Move(tempPath, filePath, true);
+                        Logger.Info("Settings successfully saved to {0}", filePath);
+                    }
+                    finally
+                    {
+                        TryDeleteFileIfExists(tempPath);
+                    }
+                }
             }
         }
         catch (UnauthorizedAccessException ex)
@@ -146,25 +172,11 @@ public class SettingsManager
             // if the settings file cannot be saved
             Logger.Error(ex, "Error saving settings");
         }
-        finally
-        {
-            // delete temp file if it still exists
-            if (File.Exists(tempPath))
-            {
-                try
-                {
-                    File.Delete(tempPath);
-                }
-                catch (Exception ex)
-                {
-                    Logger.Error(ex, "Error deleting temporary settings file");
-                }
-            }
-        }
     }
 
-    private static void TryReplaceSettingsFile(string filePath, string tempPath, string backupPath)
+    private async static Task TryReplaceSettingsFileAsync(string filePath, string tempPath, string backupPath)
     {
+        Logger.Debug("Initializing replacing settings file at {0}", filePath);
         int maxAttempts = 5;
         // The following steps try to avoid issues with file locks and permissions on some systems.
         for (int attempts = 1; attempts <= maxAttempts; attempts++)
@@ -191,11 +203,25 @@ public class SettingsManager
 
     private static void ManualReplace(string filePath, string tempPath, string backupPath)
     {
-        if (File.Exists(backupPath))
-            File.Delete(backupPath);
-
+        TryDeleteFileIfExists(backupPath);
         File.Copy(filePath, backupPath);
-        File.Delete(filePath);
+        TryDeleteFileIfExists(filePath);
         File.Move(tempPath, filePath);
+    }
+
+    private static void TryDeleteFileIfExists(string path)
+    {
+        // delete file if it still exists
+        if (File.Exists(path))
+        {
+            try
+            {
+                File.Delete(path);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Error deleting file at {0}", path);
+            }
+        }
     }
 }

--- a/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
+++ b/FluentFlyoutWPF/Classes/Settings/SettingsManager.cs
@@ -133,7 +133,7 @@ public class SettingsManager
                 if (File.Exists(filePath))
                     TryReplaceSettingsFile(filePath, tempPath, backupPath);
                 else
-                    File.Move(tempPath, filePath);
+                    File.Move(tempPath, filePath, true);
             }
         }
         catch (UnauthorizedAccessException ex)


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->

Update saving settings system by:
1. Retrying File.Replace five times with a short wait. 
2. If that didn't work, try manually replacing by deleting and creating a new settings file. 

Previously, File.Replace was only tried once before cancelling.

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Hopefully fixes issue where settings do not save on some machines, specifically the error: `System.IO.IOException: Cannot delete the file to be replaced`.

Closes #935 
Closes #755
Closes #880 
Closes #774 
Closes #855 
Closes #699 
Closes #660 

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other
