### PR TITLE
Replace WPF-UI package with unchihugo.WPF-UI fork

### DIFF
--- a/FluentFlyoutWPF/FluentFlyout.csproj
+++ b/FluentFlyoutWPF/FluentFlyout.csproj
@@ -46,7 +46,7 @@
 	<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
 	<PackageReference Include="NAudio" Version="2.3.0" />
     <PackageReference Include="NLog" Version="6.1.3" />
-    <PackageReference Include="WPF-UI" Version="4.3.0" />
+    <PackageReference Include="unchihugo.WPF-UI" Version="4.4.0" />
     <PackageReference Include="WPF-UI.Tray" Version="4.3.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
   </ItemGroup>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -997,6 +997,14 @@ public partial class UserSettings : ObservableObject
         TaskbarVisualizerHasContent = true;
     }
 
+    partial void OnTaskbarVisualizerBaselineAutoHideChanged(bool oldValue, bool newValue)
+    {
+        if (oldValue == newValue || _initializing) return;
+        // If newValue is true, refresh the visualizer by hiding it:
+        // if audio is playing, it will be shown again, if not, it will remain hidden.
+        TaskbarVisualizerHasContent = !newValue;
+    }
+
     partial void OnUseAlbumArtAsAccentColorChanged(bool oldValue, bool newValue)
     {
         if (oldValue == newValue || _initializing) return;


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->
Replace the WPF-UI NuGet package with unchihugo.WPF-UI (my) fork. The fork is WPF-UI with opinionated changes and fast-tracked fixes:
* Fixed a bug where the button's foreground colors are wrong in dark mode
* Updated AutoSuggestBox:
  * Include drop shadows around the suggestions list and match the rounded corners to WinUI
  * Clicking away from the AutoSuggestBox will now unfocus the text box
  * Refocusing the text box will bring up the suggestions list instead of having to add/remove a letter for it to show up
  
Unrelated change: [Fix autohide baseline toggling issue](https://github.com/unchihugo/FluentFlyout/commit/c6dbcf6e69eefd3d0ab81e1c1908f125ad488a04) where the baseline would still be visible if no audio was being played when the setting was toggled on.

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## Additional Information

<!-- Any other information, such as screenshots -->
Fork repository: https://github.com/unchihugo/unchihugo.wpfui
NuGet gallery: https://www.nuget.org/packages/unchihugo.WPF-UI/