### PR TITLE
Fix: Update Acrylic fallback colors to match Windows (#928)

### DIFF
--- a/FluentFlyoutWPF/Classes/WindowBlurHelper.cs
+++ b/FluentFlyoutWPF/Classes/WindowBlurHelper.cs
@@ -17,8 +17,8 @@ public static class WindowBlurHelper
     /// </summary>
     /// <param name="window">The window to apply blur to</param>
     /// <param name="blurOpacity">Opacity of the blur (0-255)</param>
-    /// <param name="blurBackgroundColor">Background color in BGR format (default: 0x000000)</param>
-    public static void EnableBlur(Window window, uint blurOpacity = 175, uint blurBackgroundColor = 0x000000)
+    /// <param name="blurBackgroundColor">Background color in BGR format (default: 0x202020)</param>
+    public static void EnableBlur(Window window, uint blurOpacity = 175, uint blurBackgroundColor = 0x202020)
     {
         // override opacity if premium is unlocked
         if (SettingsManager.Current.IsPremiumUnlocked) blurOpacity = SettingsManager.Current.AcrylicBlurOpacity;
@@ -29,7 +29,11 @@ public static class WindowBlurHelper
         var currentTheme = ApplicationThemeManager.GetAppTheme();
         if (currentTheme == ApplicationTheme.Light)
         {
-            blurBackgroundColor = 0xFFFFFF; // use light background for light theme
+            blurBackgroundColor = 0xF3F3F3; // use light background for light theme
+        }
+        else
+        {
+            blurBackgroundColor = 0x202020; // use dark background for dark theme
         }
 
         var accent = new AccentPolicy
@@ -102,7 +106,7 @@ public static class WindowBlurHelper
             if (ShouldHaveAcrylicBlur(window))
             {
                 var currentTheme = ApplicationThemeManager.GetAppTheme();
-                uint blurBackgroundColor = currentTheme == ApplicationTheme.Light ? 0xFFFFFFu : 0x000000u;
+                uint blurBackgroundColor = currentTheme == ApplicationTheme.Light ? 0xF3F3F3u : 0x202020u;
 
                 var accent = new AccentPolicy
                 {


### PR DESCRIPTION
 ## Summary                                                                                                                                    
                                                                                                                                                  
    Updates the fallback background colors for the Acrylic window effect to match the native Windows defaults. Also cleans up method formatting   
  and docstrings in the WindowBlurHelper.                                                                                                         
                                                                                                                                                  
    ## Motivation                                                                                                                                 
                                                                                                                                                  
    When background blur is disabled (e.g. by disabling transparency effects or enabling battery saver in Windows Settings), the background colors
  became solid fully white or black, which didn't look native. This updates them to `#f3f3f3` (Light) and `#202020` (Dark) to align correctly with
  Windows styling.                                                                                                                                
                                                                                                                                                  
    Closes #928                                                                                                                                   
                                                                                                                                                  
    ## Type of Change                                                                                                                             
                                                                                                                                                  
    - [ ] Feature                                                                                                                                 
    - [x] Bug fix                                                                                                                                 
    - [ ] Refactor (no functional changes)                                                                                                        
    - [x] Style (formatting, naming)                                                                                                              
    - [ ] Other                                                                                                                                   
                                                                                                                                                  
    ## What Changed                                                                                                                               
                                                                                                                                                  
    - Updated `blurBackgroundColor` for Light mode to `0xF3F3F3` in `WindowBlurHelper.cs`.                                                        
    - Updated `blurBackgroundColor` for Dark mode to `0x202020` in `WindowBlurHelper.cs`.                                                         
    - Removed unnecessary empty lines around `EnableBlur` method declaration.                                                                     
    - Corrected the XML docstring default value for `blurBackgroundColor` to reflect the new default (`0x202020`).                                
                                                                                                                                                  
    ## Additional Information                                                                                                                     
                                                                                                                                                  
    *(Feel free to add any screenshots here if you want to show the before/after effect of the solid background color without blur)*              
                                                                                                                                                  
    ## Checklist                                                                                                                                  
    - [x] Code changes are manually tested and working.                                                                                           
    - [x] Formatting and naming are consistent with the project.                                                                                  
    - [x] Self-review of changes is done.                                                                                                         
    <!-- AI usage -->                                                                                                                             
    - [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).                                                        
    
