### PR TITLE
Fix race condition causing NullReferenceException in taskbar auto-hide timer

### DIFF
--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
@@ -691,15 +691,16 @@ on_error:
                 // Start delayed hide
                 if (_autoHideTimer == null)
                 {
-                    _autoHideTimer = new DispatcherTimer
+                    var localTimer = new DispatcherTimer
                     {
                         Interval = TimeSpan.FromMilliseconds(750)
                     };
 
-                    _autoHideTimer.Tick += (s, e) =>
+                    localTimer.Tick += (s, e) =>
                     {
-                        _autoHideTimer.Stop();
-                        _autoHideTimer = null;
+                        localTimer.Stop();
+                        if (_autoHideTimer == localTimer)
+                            _autoHideTimer = null;
 
                         if (_lastPlaybackStatus != GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing)
                         {
@@ -710,7 +711,8 @@ on_error:
                         }
                     };
 
-                    _autoHideTimer.Start();
+                    _autoHideTimer = localTimer;
+                    localTimer.Start();
                 }
             }
         }


### PR DESCRIPTION
Fixes #994

## Summary
Fixes a race condition in the taskbar auto-hide timer that could crash the app with a NullReferenceException.

## Motivation
`_autoHideTimer` was a shared field read and written from potentially different threads. If `UpdateUi()` cleared the field on one thread right as the delayed tick fired on another, the tick handler's `_autoHideTimer.Stop()` call dereferenced a null reference.

## What Changed
- Captured the timer instance locally (`localTimer`) before starting it.
- Tick handler now stops and null-checks against `localTimer` directly instead of the shared field, eliminating the race.

## Testing
- Built successfully.
- Ran the app with TaskbarWidgetAutoHide enabled, rapidly toggled media playback pause/resume repeatedly — no crash observed. Previously this would intermittently trigger the NullReferenceException from issue #994.

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).