### PR TITLE
Fix visualizer high-frequency bar saturation

### DIFF
--- a/FluentFlyoutWPF/Classes/Visualizer.cs
+++ b/FluentFlyoutWPF/Classes/Visualizer.cs
@@ -394,7 +394,7 @@ namespace FluentFlyoutWPF.Classes
                 }
 
                 float progress = (float)i / BarCount;
-                float linearBoost = 1.0f + (progress * 75.0f);
+                float linearBoost = 1.0f + (progress * 6.0f);
                 maxAmplitude *= linearBoost;
 
                 if (maxAmplitude < 0.001f) maxAmplitude = 0.001f;


### PR DESCRIPTION
## Summary
High-frequency bars in the taskbar audio visualizer were pinning to max height regardless of actual audio content, rendering as solid static blocks instead of reactive bars.

## Root Cause
In `ProcessFftData()`, the linear frequency boost scaled up to 76x for the highest-index (high-frequency) bars:

```csharp
float linearBoost = 1.0f + (progress * 75.0f);
```

Combined with the amplitude noise floor, this amplified residual noise enough to saturate `intensity` to 1.0 almost constantly for high-frequency bins, regardless of real signal.

## Fix
Reduced the boost ceiling from 75x to 6x:

```csharp
float linearBoost = 1.0f + (progress * 6.0f);
```

## Testing
- Built successfully.
- Played tracks with bass and treble content, TaskbarVisualizerEnabled on.
- High-frequency bars now rise and fall with content instead of pinning at max height.

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).