### PR TITLE
Discord Rich presence MVP

### DIFF
--- a/FluentFlyoutWPF/Classes/Services/DiscordRpcService.cs
+++ b/FluentFlyoutWPF/Classes/Services/DiscordRpcService.cs
@@ -1,0 +1,123 @@
+using DiscordRPC;
+using DiscordRPC.Logging;
+using FluentFlyout.Classes.Settings;
+using System;
+
+namespace FluentFlyoutWPF.Classes.Services
+{
+    public static class DiscordRpcService
+    {
+        private static DiscordRpcClient? _client;
+        private static bool _isInitialized;
+        private static readonly object _lock = new object();
+        private const string AppId = "1521650050600796262";
+
+        public static void Initialize()
+        {
+            lock (_lock)
+            {
+                if (_isInitialized || !SettingsManager.Current.DiscordRpcEnabled)
+                    return;
+
+                _client = new DiscordRpcClient(AppId)
+                {
+                    Logger = new ConsoleLogger { Level = LogLevel.Warning }
+                };
+
+                _client.Initialize();
+                _isInitialized = true;
+            }
+        }
+
+        public static void UpdatePresence(string title, string artist, bool isPlaying, TimeSpan? position = null, TimeSpan? endTime = null)
+        {
+            lock (_lock)
+            {
+                if (!SettingsManager.Current.DiscordRpcEnabled)
+                {
+                    if (_isInitialized)
+                        DisposeInternal();
+                    return;
+                }
+
+                if (!_isInitialized)
+                {
+                    Initialize();
+                }
+
+                if (_client == null || !_client.IsInitialized) return;
+
+                if (string.IsNullOrWhiteSpace(title))
+                {
+                    _client.ClearPresence();
+                    return;
+                }
+
+                var presence = new RichPresence()
+                {
+                    Details = Truncate(title, 128),
+                    State = Truncate(string.IsNullOrWhiteSpace(artist) ? "Unknown Artist" : artist, 128),
+                    Assets = new Assets()
+                    {
+                        LargeImageKey = "fluentflyout_logo",
+                        LargeImageText = "FluentFlyout"
+                    }
+                };
+
+                if (isPlaying)
+                {
+                    if (position.HasValue)
+                    {
+                        var startDateTime = DateTime.UtcNow - position.Value;
+                        presence.Timestamps = new Timestamps(startDateTime);
+                    }
+                    else
+                    {
+                        presence.Timestamps = Timestamps.Now;
+                    }
+                }
+
+                _client.SetPresence(presence);
+            }
+        }
+
+        public static void ClearPresence()
+        {
+            lock (_lock)
+            {
+                if (_isInitialized && _client != null)
+                {
+                    _client.ClearPresence();
+                }
+            }
+        }
+
+        public static void Dispose()
+        {
+            lock (_lock)
+            {
+                DisposeInternal();
+            }
+        }
+
+        private static void DisposeInternal()
+        {
+            if (!_isInitialized) return;
+
+            if (_client != null)
+            {
+                _client.ClearPresence();
+                _client.Dispose();
+                _client = null;
+            }
+
+            _isInitialized = false;
+        }
+
+        private static string Truncate(string value, int maxChars)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+            return value.Length <= maxChars ? value : value.Substring(0, Math.Max(0, maxChars - 3)) + "...";
+        }
+    }
+}

--- a/FluentFlyoutWPF/FluentFlyout.csproj
+++ b/FluentFlyoutWPF/FluentFlyout.csproj
@@ -41,6 +41,7 @@
     <None Remove="Resources\Onboarding\Taskbar.png" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="DiscordRichPresence" Version="1.6.1.70" />
     <PackageReference Include="Dubya.WindowsMediaController" Version="2.5.6" />
     <PackageReference Include="MicaWPF" Version="6.3.2" />
 	<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -636,6 +636,15 @@ public partial class MainWindow : MicaWindow
         }
     }
 
+    private void UpdateDiscordPresence(MediaSession session)
+    {
+        var songInfo = TryGetMediaProperties(session.ControlSession);
+        if (songInfo == null) return;
+        var playbackInfo = session.ControlSession.GetPlaybackInfo();
+        var timeline = session.ControlSession.GetTimelineProperties();
+        DiscordRpcService.UpdatePresence(songInfo.Title, songInfo.Artist, playbackInfo?.PlaybackStatus == GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing, timeline?.Position, timeline?.EndTime);
+    }
+
     private void CurrentSession_OnPlaybackStateChanged(MediaSession mediaSession, GlobalSystemMediaTransportControlsSessionPlaybackInfo? playbackInfo = null)
     {
 #if DEBUG
@@ -658,6 +667,7 @@ public partial class MainWindow : MicaWindow
             var tbPlayback = focusedSession.ControlSession.GetPlaybackInfo();
 
             taskbarWindow?.UpdateUi(tbSongInfo.Title, tbSongInfo.Artist, tbThumbnail, tbPlayback?.PlaybackStatus, tbPlayback?.Controls);
+            UpdateDiscordPresence(focusedSession);
         }
 
         if (IsVisible)
@@ -709,6 +719,7 @@ public partial class MainWindow : MicaWindow
         BitmapHelper.GetDominantColors(1);
 
         taskbarWindow?.UpdateUi(songInfo.Title, songInfo.Artist, thumbnail, playbackInfo.PlaybackStatus, playbackInfo.Controls);
+        UpdateDiscordPresence(currentActiveSession);
 
         pauseOtherMediaSessionsIfNeeded(mediaSession);
 
@@ -769,6 +780,8 @@ public partial class MainWindow : MicaWindow
 
         if (GetActiveMediaSession() is not { } session || session.Id != mediaSession.Id) return;
 
+        UpdateDiscordPresence(session);
+
         if (_seekBarEnabled)
         {
             Dispatcher.Invoke(() =>
@@ -787,6 +800,11 @@ public partial class MainWindow : MicaWindow
         Logger.Debug("Session closed: " + (mediaSession.Id).ToString());
 #endif
         UpdateTaskbar();
+        var activeSession = GetActiveMediaSession();
+        if (activeSession == null)
+        {
+            DiscordRpcService.ClearPresence();
+        }
     }
 
     private static IntPtr SetHook(LowLevelKeyboardProc proc) // set the keyboard hook
@@ -1424,6 +1442,7 @@ public partial class MainWindow : MicaWindow
             cts?.Dispose();
 
             TaskbarVisualizerControl.DisposeVisualizer();
+            DiscordRpcService.Dispose();
 
             // unhook hooks
             if (_hookId != IntPtr.Zero)

--- a/FluentFlyoutWPF/Pages/MediaFlyoutPage.xaml
+++ b/FluentFlyoutWPF/Pages/MediaFlyoutPage.xaml
@@ -33,6 +33,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,24">
                 <Border CornerRadius="10" ClipToBounds="True" Width="164" Height="98">
@@ -166,7 +167,7 @@
                 </ui:CardControl.Header>
                 <ui:ToggleSwitch Name="PauseOtherSessionsEnabledSwitch" IsChecked="{Binding PauseOtherSessionsEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl x:Name="MediaFlyoutExcludeVolumeTitleCard" Tag="Indexable" Grid.Row="15" Icon="{ui:SymbolIcon SpeakerOff24}" Margin="0,0,0,76">
+            <ui:CardControl x:Name="MediaFlyoutExcludeVolumeTitleCard" Tag="Indexable" Grid.Row="15" Icon="{ui:SymbolIcon SpeakerOff24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource MediaFlyoutExcludeVolumeTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -174,6 +175,15 @@
                     </StackPanel>
                 </ui:CardControl.Header>
                 <ui:ToggleSwitch Name="MediaFlyoutVolumeKeysExcludedSwitch" IsChecked="{Binding MediaFlyoutVolumeKeysExcluded, Mode=TwoWay}" />
+            </ui:CardControl>
+            <ui:CardControl x:Name="DiscordRpcTitleCard" Tag="Indexable" Grid.Row="16" Icon="{ui:SymbolIcon XboxController24}" Margin="0,0,0,76">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource DiscordRpcEnabledTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource DiscordRpcEnabledDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <ui:ToggleSwitch Name="DiscordRpcSwitch" IsChecked="{Binding DiscordRpcEnabled, Mode=TwoWay}" />
             </ui:CardControl>
         </Grid>
     </StackPanel>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -13,6 +13,8 @@
     <System:String x:Key="TextBlockText3">Display a flyout when you press a media key</System:String>
     <System:String x:Key="MediaFlyoutExcludeVolumeTitle">Exclude Volume Keys</System:String>
     <System:String x:Key="MediaFlyoutExcludeVolumeDescription">Do not display the flyout when pressing volume up/down/mute</System:String>
+    <System:String x:Key="DiscordRpcEnabledTitle">Discord Rich Presence</System:String>
+    <System:String x:Key="DiscordRpcEnabledDescription">Show currently playing media on your Discord profile.</System:String>
     <System:String x:Key="TextBlockText2">Choose from a preset of modern background blur styles</System:String>
     <System:String x:Key="BackgroundBlurOption1" xml:space="preserve"> None</System:String>
     <System:String x:Key="BackgroundBlurOption2" xml:space="preserve"> Style 1 (Cover Glow)</System:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -682,6 +682,9 @@ public partial class UserSettings : ObservableObject
     [ObservableProperty]
     public partial bool AnonymousTelemetryAllowed { get; set; }
 
+    [ObservableProperty]
+    public partial bool DiscordRpcEnabled { get; set; }
+
     [XmlIgnore]
     private bool _initializing = true;
 
@@ -773,6 +776,7 @@ public partial class UserSettings : ObservableObject
         AnonymousTelemetryAllowed = true;
         AllowedApps = [];
         BlockedApps = [];
+        DiscordRpcEnabled = false;
 
         PropertyChanged += OnPropertyChangedSaveSettings;
     }
@@ -838,6 +842,20 @@ public partial class UserSettings : ObservableObject
     {
         if (oldValue == newValue) return;
         SelectedLanguage = LanguageOptions.First(l => l.Tag == newValue);
+    }
+
+    partial void OnDiscordRpcEnabledChanged(bool oldValue, bool newValue)
+    {
+        if (oldValue == newValue || _initializing) return;
+
+        if (!newValue)
+        {
+            FluentFlyoutWPF.Classes.Services.DiscordRpcService.Dispose();
+        }
+        else
+        {
+            FluentFlyoutWPF.Classes.Services.DiscordRpcService.Initialize();
+        }
     }
 
     partial void OnSelectedLanguageChanged(LanguageOption oldValue, LanguageOption newValue)


### PR DESCRIPTION
Fixes #312

Adds a thread-safe Discord Rich Presence service (`DiscordRpcService`) to broadcast currently playing Windows SMTC media metadata to Discord profiles in real-time.
Includes a dedicated settings toggle in `MediaFlyoutPage` (indexed for search) and elapsed playback timestamp tracking.