### PR TITLE
Update media flyout's media id section to clickable button style

### DIFF
--- a/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
+++ b/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Media;
@@ -74,6 +73,7 @@ public static class MediaPlayerData
             {
                 try
                 {
+                    // pre-filter processes without a main window handle unless they are an exact match to the media player id
                     bool isExactMatch = variants.Contains(p.ProcessName, StringComparer.OrdinalIgnoreCase);
                     if (!isExactMatch && p.MainWindowHandle == IntPtr.Zero)
                     {

--- a/FluentFlyoutWPF/MainWindow.xaml
+++ b/FluentFlyoutWPF/MainWindow.xaml
@@ -155,10 +155,15 @@
                             Style="{StaticResource MicaWPF.Styles.TransparentButton}" VerticalAlignment="Center">
                                 <ui:SymbolIcon Name="SymbolShuffle" Symbol="ArrowShuffleOff24" Filled="false" Opacity="0.5" FontSize="18"/>
                             </controls:Button>
-                            <StackPanel Name="MediaIdStackPanel" Orientation="Horizontal" Width="72" MouseLeftButtonUp="MediaIdStackPanel_MouseLeftButtonUp">
-                                <Image x:Name="MediaIdIcon" Width="14" Height="14"/>
-                                <TextBlock Name="MediaId" VerticalAlignment="Center" FontSize="10" Width="50" Margin="6,0,0,0" FontWeight="Regular" Opacity="0.25" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
-                            </StackPanel>
+
+                            <controls:Button Name="MediaIdButton" Padding="0" Height="28" Width="70"
+                                             Style="{StaticResource MicaWPF.Styles.TransparentButton}"
+                                             Click="MediaIdButton_Click">
+                                <StackPanel Orientation="Horizontal" Margin="2,0">
+                                    <Image x:Name="MediaIdIcon" Width="14" Height="14"/>
+                                    <TextBlock Name="MediaId" VerticalAlignment="Center" FontSize="10" Width="50" Margin="6,0,0,0" FontWeight="Regular" Opacity="0.25" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
+                                </StackPanel>
+                            </controls:Button>
 
                         </StackPanel>
                     </StackPanel>

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1074,7 +1074,7 @@ public partial class MainWindow : MicaWindow
 
                 if (SettingsManager.Current.PlayerInfoEnabled && !SettingsManager.Current.CompactLayout)
                 {
-                    MediaIdStackPanel.Visibility = Visibility.Visible;
+                    MediaIdButton.Visibility = Visibility.Visible;
                     (string title, ImageSource? Icon) = MediaPlayerData.GetAndCacheMediaPlayerData(mediaSession.Id);
                     MediaId.Text = title;
                     if (Icon != null)
@@ -1087,7 +1087,7 @@ public partial class MainWindow : MicaWindow
                         MediaIdIcon.Visibility = Visibility.Collapsed;
                     }
                 }
-                else MediaIdStackPanel.Visibility = Visibility.Collapsed;
+                else MediaIdButton.Visibility = Visibility.Collapsed;
 
                 // background blurred image visibility setting
                 BackgroundImageStyle1.Visibility = SettingsManager.Current.MediaFlyoutBackgroundBlur == 1 ? Visibility.Visible : Visibility.Collapsed;
@@ -1195,7 +1195,7 @@ public partial class MainWindow : MicaWindow
                 BodyStackPanel.Width = 300;
                 ControlsStackPanel.Margin = new Thickness(0);
                 ControlsStackPanel.Width = 104;
-                MediaIdStackPanel.Visibility = Visibility.Collapsed;
+                MediaIdButton.Visibility = Visibility.Collapsed;
                 SongImageBorder.Margin = new Thickness(0);
                 SongImageBorder.Height = 36;
                 SongInfoStackPanel.Margin = new Thickness(8, 0, 0, 0);
@@ -1214,7 +1214,7 @@ public partial class MainWindow : MicaWindow
                 BodyStackPanel.Width = 194 - 72 + extraWidth;
                 ControlsStackPanel.Margin = Margin = new Thickness(12, 8, 0, 0);
                 ControlsStackPanel.Width = 184 - 72 + extraWidth;
-                MediaIdStackPanel.Visibility = Visibility.Visible;
+                MediaIdButton.Visibility = Visibility.Visible;
                 SongImageBorder.Margin = new Thickness(6);
                 SongImageBorder.Height = 78;
                 SongInfoStackPanel.Margin = new Thickness(12, 0, 0, 0);
@@ -1236,8 +1236,6 @@ public partial class MainWindow : MicaWindow
                 SeekbarWrapper.Visibility = Visibility.Visible;
             else
                 SeekbarWrapper.Visibility = Visibility.Collapsed;
-
-            MediaIdStackPanel.Cursor = SettingsManager.Current.PlayerInfoEnabled && !SettingsManager.Current.CompactLayout ? Cursors.Hand : Cursors.Arrow;
         });
 
         _layout = SettingsManager.Current.CompactLayout;
@@ -1249,7 +1247,7 @@ public partial class MainWindow : MicaWindow
         _alwaysDisplay = SettingsManager.Current.MediaFlyoutAlwaysDisplay;
     }
 
-    private async void MediaIdStackPanel_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    private async void MediaIdButton_Click(object sender, RoutedEventArgs e)
     {
         if (!SettingsManager.Current.PlayerInfoEnabled || SettingsManager.Current.CompactLayout) return;
         e.Handled = true;


### PR DESCRIPTION
## Summary
Updates the media flyout’s “Show Media Player Name” feature to be styled as a clickable button.
Example:
  
<img width="126" height="46" alt="image" src="https://github.com/user-attachments/assets/cf76b45a-c7db-4c9b-b218-b90ef54ebf1a" />

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other
