### PR TITLE
Fix app filtering matching display names by substring

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -272,22 +272,30 @@ public partial class MainWindow : MicaWindow
 
         if (SettingsManager.Current.AppFilteringMode == 0) // Blacklist mode
         {
-            if (SettingsManager.Current.BlockedApps != null && SettingsManager.Current.BlockedApps.Any(b =>
-                    appName.Contains(b, StringComparison.OrdinalIgnoreCase) ||
-                    appId.Contains(b, StringComparison.OrdinalIgnoreCase)))
+            if (SettingsManager.Current.BlockedApps != null &&
+                SettingsManager.Current.BlockedApps.Any(b => MatchesFilterEntry(b, appName, appId)))
                 return false;
 
             return true;
         }
         else // Whitelist mode
         {
-            if (SettingsManager.Current.AllowedApps != null && SettingsManager.Current.AllowedApps.Any(a =>
-                    appName.Contains(a, StringComparison.OrdinalIgnoreCase) ||
-                    appId.Contains(a, StringComparison.OrdinalIgnoreCase)))
+            if (SettingsManager.Current.AllowedApps != null &&
+                SettingsManager.Current.AllowedApps.Any(a => MatchesFilterEntry(a, appName, appId)))
                 return true;
 
             return false;
         }
+    }
+
+    // display names are matched in full: entries always hold a whole app name, and a substring match let one entry
+    // swallow others (blocking "Amazon Music" also blocked "Amazon Music SMTC Bridge"). the session id keeps substring
+    // matching so an entry can still target a whole package or publisher
+    private static bool MatchesFilterEntry(string entry, string appName, string appId)
+    {
+        if (string.IsNullOrWhiteSpace(entry)) return false; // an empty entry would match every session
+
+        return appName.Equals(entry, StringComparison.OrdinalIgnoreCase) || appId.Contains(entry, StringComparison.OrdinalIgnoreCase);
     }
 
     public MediaSession? GetActiveMediaSession()


### PR DESCRIPTION
## Summary

App filtering compared list entries against the session's **display name** with `Contains`, so a single entry also filtered every other app whose display name contained it as a substring. This makes the display name comparison exact, and leaves the session id on substring matching.

## Motivation

Closes #1024

`IsSessionAllowed()` ran the same predicate in both modes:

```csharp
appName.Contains(b, StringComparison.OrdinalIgnoreCase) ||
appId.Contains(b, StringComparison.OrdinalIgnoreCase)
```

`appName` is the user-facing name from `GetAndCacheMediaPlayerData()`, so blocking one app silently blocked unrelated apps whose name happened to contain it — I hit this with `Amazon Music` on the blocklist also hiding `AmazonMusic SMTC Bridge`, but the same holds for any pair like `Spotify` / `Spotify Widget`. Allowlist mode has the mirrored problem, letting unlisted apps through.

Matching the display name in full is what the rest of the feature already assumes. Only two things write these entries, and both store a complete app name:

- the `AppFilteringPage` ComboBox stores the `GetAndCacheMediaPlayerData()` return value verbatim
- the manual text box runs `NormalizeAppName()`, which resolves what was typed to a real session name first

So the stored value is a whole name by construction; the `Contains` on the matching side was the half that disagreed.

The session id deliberately keeps substring matching. Entries added before the display name became resolvable can hold a fragment like `chrome` or `spotify` that only lines up with the AUMID, and that is also the way an entry can target a whole package or publisher rather than one display name. Tightening both sides would be more uniform but would silently break those existing settings, so it is left alone.

Blank entries are now skipped as well — an empty string is a substring of everything, so it previously hid every session in blocklist mode and allowed every session in allowlist mode.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

- `MainWindow.IsSessionAllowed()` — the predicate duplicated across the blocklist and allowlist branches is extracted into a new `MatchesFilterEntry()` helper, so both modes stay in step.
- `MatchesFilterEntry()` compares the display name with `Equals` instead of `Contains`, keeps `Contains` for the session id, and returns false for null/whitespace entries.
- One file touched, `FluentFlyoutWPF/MainWindow.xaml.cs`. No settings, UI or localization changes, so no resource dictionary updates are needed.

## Additional Information

Behaviour for the two apps I reproduced with (`Amazon Music` → `AmazonMobileLLC.AmazonMusic_kc6t79cpj4tp0!…`, `AmazonMusic SMTC Bridge` → `AmazonMusicSmtc_f91r0mcej9kn8!App`):

| Blocklist entry | Session | Before | After |
|---|---|---|---|
| `AmazonMusic SMTC` | `AmazonMusic SMTC Bridge` | blocked | **allowed** — partial display name, and the AUMID has no space so the id does not match either |
| `Amazon Music` | `Amazon Music` | blocked | blocked (exact match, unchanged) |
| `Amazon Music` | `AmazonMusic SMTC Bridge` | allowed | allowed |
| `AmazonMobileLLC` | `Amazon Music` | blocked | blocked — the id substring path still works |
| `AmazonMobileLLC` | `AmazonMusic SMTC Bridge` | allowed | allowed |
| `` (blank) | any | blocked | **allowed** |

I kept the diff confined to `IsSessionAllowed()` and its new helper, so if #1023 lands first this should only need the `BlockedApps` / `AllowedApps` / `AppFilteringMode` property renames applied to the two call sites.

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
<!-- AI usage -->
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).
