### PR TITLE
Improve taskbar widgets layouts and fix flyout jumping up bug

### DIFF
--- a/FluentFlyoutWPF/Classes/WindowHelper.cs
+++ b/FluentFlyoutWPF/Classes/WindowHelper.cs
@@ -13,20 +13,6 @@ public static class WindowHelper
 {
     private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
-    [StructLayout(LayoutKind.Sequential)]
-    public struct RECT
-    {
-        public int left;
-        public int top;
-        public int right;
-        public int bottom;
-
-        public static implicit operator Rect(RECT rect)
-        {
-            return new Rect(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
-        }
-    }
-
     public static void SetTopmost(Window window) // workaround to set window even more topmost
     {
         var handle = new WindowInteropHelper(window).Handle;
@@ -41,14 +27,13 @@ public static class WindowHelper
 
     public static Rect GetPlacement(Window window) // get the window position, ignoring WPF
     {
-        var wp = new NativeMethods.WINDOWPLACEMENT { length = Marshal.SizeOf<NativeMethods.WINDOWPLACEMENT>() };
-
         var handle = new WindowInteropHelper(window).Handle;
-        GetWindowPlacement(handle, ref wp);
-
-        return new Rect(wp.rcNormalPosition.Left, wp.rcNormalPosition.Top,
-            wp.rcNormalPosition.Right - wp.rcNormalPosition.Left,
-            wp.rcNormalPosition.Bottom - wp.rcNormalPosition.Top);
+        GetWindowRect(handle, out RECT windowRect);
+        return new Rect(
+            windowRect.Left,
+            windowRect.Top,
+            windowRect.Right - windowRect.Left,
+            windowRect.Bottom - windowRect.Top);
     }
 
     public static void SetPosition(Window window, double x, double y, bool async = false) // set the position of the window, ignoring WPF
@@ -83,7 +68,7 @@ public static class WindowHelper
             return false;
 
         var hwnd = new WindowInteropHelper(window).Handle;
-        if (!GetWindowRect(hwnd, out NativeMethods.RECT rect))
+        if (!GetWindowRect(hwnd, out RECT rect))
             return false;
 
         return cursor.X >= rect.Left && cursor.X <= rect.Right &&

--- a/FluentFlyoutWPF/Controls/TaskbarVisualizerControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarVisualizerControl.xaml.cs
@@ -4,8 +4,6 @@
 using FluentFlyout.Classes.Settings;
 using FluentFlyoutWPF;
 using FluentFlyoutWPF.Classes;
-using MicaWPF.Core.Enums;
-using MicaWPF.Core.Helpers;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -18,6 +16,9 @@ namespace FluentFlyout.Controls;
 /// </summary>
 public partial class TaskbarVisualizerControl : UserControl
 {
+    private const double DefaultTaskbarVisualizerHeight = 40;
+    private const double SmallTaskbarVisualizerHeight = 28;
+
     // reference to main window for flyout functions
     private static readonly Visualizer visualizer = new();
 
@@ -43,6 +44,11 @@ public partial class TaskbarVisualizerControl : UserControl
         }
 
         Background = new SolidColorBrush(Color.FromArgb(1, 0, 0, 0));
+    }
+
+    public void SetSmallTaskbarMode(bool isSmallTaskbar)
+    {
+        Height = isSmallTaskbar ? SmallTaskbarVisualizerHeight : DefaultTaskbarVisualizerHeight;
     }
 
     public static void OnTaskbarVisualizerEnabledChanged(bool value)

--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
@@ -22,10 +22,22 @@ public partial class TaskbarWidgetControl : UserControl
 {
     private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
+    // Constants for default and small taskbar widget sizes
+    private const double DefaultTaskbarWidgetHeight = 40;
+    private const double SmallTaskbarWidgetHeight = 28;
+
+    // Constants for cover image and control button sizes
+    private const double DefaultCoverImageSize = 36;
+    private const double SmallCoverImageSize = 24;
+    private const double DefaultCoverImageMargin = 55;
+    private const double SmallCoverImageMargin = 43;
+    private const double DefaultPlaceholderIconSize = 24;
+    private const double SmallPlaceholderIconSize = 18;
+    private const double DefaultControlButtonSize = 32;
+    private const double SmallControlButtonSize = 24;
+
     private readonly double _scale = 0.9;
     private readonly int _nativeWidgetsPadding = 216;
-
-    private readonly int _coverImageMargin = 55;
 
     // Cached width calculations
     private string _cachedTitleText = string.Empty;
@@ -48,6 +60,7 @@ public partial class TaskbarWidgetControl : UserControl
     private MainWindow? _mainWindow;
     private bool _isPaused;
     private bool _isVertical;
+    private bool _isSmallTaskbar;
 
     public TaskbarWidgetControl()
     {
@@ -102,6 +115,9 @@ public partial class TaskbarWidgetControl : UserControl
     {
         _isVertical = isVertical;
         SongInfoStackPanel.Visibility = isVertical ? Visibility.Collapsed : Visibility.Visible;
+        SongArtistContainer.Visibility = !_isSmallTaskbar && !isVertical && !string.IsNullOrEmpty(_actualArtist)
+            ? Visibility.Visible
+            : Visibility.Collapsed;
 
         var counterRotate = isVertical ? new RotateTransform(-90) : null;
 
@@ -112,6 +128,26 @@ public partial class TaskbarWidgetControl : UserControl
         {
             button.RenderTransformOrigin = new System.Windows.Point(0.5, 0.5);
             button.RenderTransform = (Transform?)counterRotate ?? Transform.Identity;
+        }
+    }
+
+    public void SetSmallTaskbarMode(bool isSmallTaskbar)
+    {
+        _isSmallTaskbar = isSmallTaskbar;
+        SongArtistContainer.Visibility = !isSmallTaskbar && !_isVertical && !string.IsNullOrEmpty(_actualArtist)
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
+        double coverImageSize = isSmallTaskbar ? SmallCoverImageSize : DefaultCoverImageSize;
+        SongImageBorder.Width = coverImageSize;
+        SongImageBorder.Height = coverImageSize;
+        SongImagePlaceholder.FontSize = isSmallTaskbar ? SmallPlaceholderIconSize : DefaultPlaceholderIconSize;
+
+        double controlButtonSize = isSmallTaskbar ? SmallControlButtonSize : DefaultControlButtonSize;
+        foreach (var button in new Wpf.Ui.Controls.Button[] { PreviousButton, PlayPauseButton, NextButton })
+        {
+            button.Width = controlButtonSize;
+            button.Height = controlButtonSize;
         }
     }
 
@@ -217,6 +253,8 @@ public partial class TaskbarWidgetControl : UserControl
 
     public (double logicalWidth, double logicalHeight) CalculateSize(double dpiScale)
     {
+        double coverImageMargin = _isSmallTaskbar ? SmallCoverImageMargin : DefaultCoverImageMargin;
+
         // calculate widget width - use cached values if text hasn't changed
         string currentTitle = _actualTitle;
         string currentArtist = _actualArtist;
@@ -242,7 +280,7 @@ public partial class TaskbarWidgetControl : UserControl
 
         if (_isVertical)
         {
-            logicalWidth = _coverImageMargin;
+            logicalWidth = coverImageMargin;
         }
         else if (SettingsManager.Current.TaskbarWidgetFixedWidth)
         {
@@ -251,12 +289,13 @@ public partial class TaskbarWidgetControl : UserControl
         }
         else
         {
-            logicalWidth = Math.Max(_cachedTitleWidth, _cachedArtistWidth) + _coverImageMargin + _extraMarginForText; // add margin for cover image
+            double contentWidth = _isSmallTaskbar ? _cachedTitleWidth : Math.Max(_cachedTitleWidth, _cachedArtistWidth);
+            logicalWidth = contentWidth + coverImageMargin + _extraMarginForText; // add margin for cover image
             logicalWidth = Math.Min(logicalWidth, maxLogicalWidth);
         }
 
-        double newTitleContainerWidth = Math.Max(logicalWidth - _coverImageMargin, 0);
-        double newArtistContainerWidth = Math.Max(logicalWidth - _coverImageMargin, 0);
+        double newTitleContainerWidth = Math.Max(logicalWidth - coverImageMargin, 0);
+        double newArtistContainerWidth = Math.Max(logicalWidth - coverImageMargin, 0);
         bool widthChanged = false;
 
         if (_cachedTitleContainerWidth != newTitleContainerWidth)
@@ -282,13 +321,14 @@ public partial class TaskbarWidgetControl : UserControl
         // add space for playback controls if enabled and visible
         if (SettingsManager.Current.TaskbarWidgetControlsEnabled && ControlsStackPanel.Visibility == Visibility.Visible)
         {
+            double controlsWidth = PreviousButton.Width + PlayPauseButton.Width + NextButton.Width;
             if (!_isVertical)
-                logicalWidth += 104;
-            else
-                logicalWidth += 96; // vertical widget has no text, so remove 8px of text spacing
+                controlsWidth += ControlsStackPanel.Margin.Left + ControlsStackPanel.Margin.Right;
+
+            logicalWidth += controlsWidth;
         }
 
-        double logicalHeight = 40; // default height
+        double logicalHeight = _isSmallTaskbar ? SmallTaskbarWidgetHeight : DefaultTaskbarWidgetHeight;
 
         return (logicalWidth, logicalHeight);
     }
@@ -574,7 +614,9 @@ public partial class TaskbarWidgetControl : UserControl
             }
 
             SongTitle.Visibility = Visibility.Visible;
-            SongArtist.Visibility = !string.IsNullOrEmpty(artist) ? Visibility.Visible : Visibility.Collapsed; // hide artist if it's not available
+            SongArtistContainer.Visibility = !_isSmallTaskbar && !_isVertical && !string.IsNullOrEmpty(artist)
+                ? Visibility.Visible
+                : Visibility.Collapsed;
             SongInfoStackPanel.Visibility = _isVertical ? Visibility.Collapsed : Visibility.Visible;
             BackgroundImage.Visibility = SettingsManager.Current.TaskbarWidgetBackgroundBlur ? Visibility.Visible : Visibility.Collapsed;
 

--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
@@ -47,6 +47,7 @@ public partial class TaskbarWidgetControl : UserControl
     // reference to main window for flyout functions
     private MainWindow? _mainWindow;
     private bool _isPaused;
+    private bool _isVertical;
 
     public TaskbarWidgetControl()
     {
@@ -99,6 +100,9 @@ public partial class TaskbarWidgetControl : UserControl
 
     public void SetVerticalMode(bool isVertical)
     {
+        _isVertical = isVertical;
+        SongInfoStackPanel.Visibility = isVertical ? Visibility.Collapsed : Visibility.Visible;
+
         var counterRotate = isVertical ? new RotateTransform(-90) : null;
 
         SongImageBorder.RenderTransformOrigin = new System.Windows.Point(0.5, 0.5);
@@ -236,7 +240,11 @@ public partial class TaskbarWidgetControl : UserControl
         double maxLogicalWidth = _nativeWidgetsPadding / _scale;
         double logicalWidth;
 
-        if (SettingsManager.Current.TaskbarWidgetFixedWidth)
+        if (_isVertical)
+        {
+            logicalWidth = _coverImageMargin;
+        }
+        else if (SettingsManager.Current.TaskbarWidgetFixedWidth)
         {
             // pin to maximum width so right-aligned controls don't shift between songs
             logicalWidth = maxLogicalWidth;
@@ -274,7 +282,10 @@ public partial class TaskbarWidgetControl : UserControl
         // add space for playback controls if enabled and visible
         if (SettingsManager.Current.TaskbarWidgetControlsEnabled && ControlsStackPanel.Visibility == Visibility.Visible)
         {
-            logicalWidth += 104;
+            if (!_isVertical)
+                logicalWidth += 104;
+            else
+                logicalWidth += 96; // vertical widget has no text, so remove 8px of text spacing
         }
 
         double logicalHeight = 40; // default height
@@ -564,7 +575,7 @@ public partial class TaskbarWidgetControl : UserControl
 
             SongTitle.Visibility = Visibility.Visible;
             SongArtist.Visibility = !string.IsNullOrEmpty(artist) ? Visibility.Visible : Visibility.Collapsed; // hide artist if it's not available
-            SongInfoStackPanel.Visibility = Visibility.Visible;
+            SongInfoStackPanel.Visibility = _isVertical ? Visibility.Collapsed : Visibility.Visible;
             BackgroundImage.Visibility = SettingsManager.Current.TaskbarWidgetBackgroundBlur ? Visibility.Visible : Visibility.Collapsed;
 
             // on top of XAML visibility binding (XAML binding only hides when disabled in settings)

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -554,7 +554,7 @@ public partial class MainWindow : MicaWindow
         DoubleAnimation moveAnimation = (DoubleAnimation)storyboard.Children[0];
         var monitor = selectedMonitor != null ? selectedMonitor.Value : getSelectedMonitor();
         var workArea = monitor.workArea;
-        var windowRect = WindowHelper.GetPlacement(window);
+        Rect windowRect = WindowHelper.GetPlacement(window);
 
         // Use the window's actual current position as the animation start
         moveAnimation.From = windowRect.Top;

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
@@ -25,6 +25,8 @@ public partial class TaskbarWindow : Window
 {
     private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
+    private const double SmallTaskbarDetectionThreshold = 40;
+
     private readonly DispatcherTimer _timer;
     private readonly int _nativeWidgetsPadding = 216;
     private readonly double _scale = 0.9;
@@ -385,8 +387,13 @@ on_error:
 
             // Vertical taskbar support: rotate and reposition widget when taskbar is taller than wide
             bool isVertical = taskbarHeight > taskbarWidth;
+            double taskbarCrossSize = (isVertical ? taskbarWidth : taskbarHeight) / dpiScale;
+            bool isSmallTaskbar = taskbarCrossSize < SmallTaskbarDetectionThreshold;
             int containerWidth = taskbarWidth;
             int containerHeight = taskbarHeight;
+
+            Widget.SetSmallTaskbarMode(isSmallTaskbar);
+            TaskbarVisualizer.SetSmallTaskbarMode(isSmallTaskbar);
 
             // Following SetWindowPos will set the position relative to the parent window,
             // so those coordinates need to be converted.

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
@@ -416,6 +416,8 @@ on_error:
         if (!SettingsManager.Current.TaskbarWidgetEnabled)
             return Rect.Empty;
 
+        Widget.SetVerticalMode(isVertical);
+
         // Calculate widget size
         var (logicalWidth, logicalHeight) = Widget.CalculateSize(dpiScale);
 
@@ -428,7 +430,6 @@ on_error:
         // Apply orientation transform
         Widget.LayoutTransform = isVertical ? new System.Windows.Media.RotateTransform(90) : null;
         Widget.RenderTransform = System.Windows.Media.Transform.Identity;
-        Widget.SetVerticalMode(isVertical);
 
         // On a vertical taskbar the widget is rotated 90°, so the axes flip:
         //   primarySize = taskbarHeight, positioning runs along Y


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->
1. Hide taskbar media widget's `SongInfoStackPanel` in "vertical" mode and adjust layout slightly: this goes hand in hand with what Windows natively does with its native widget - the text is removed and only icons/symbols remain.
2. When the taskbar is in "small" mode, the taskbar widgets will now shrink and adjust their layouts accordingly. The media widget's artist hides to provide space for the title. This behavior replicates native Windows where the taskbar date hides to give space for the clock.
2.1. Additionally, fixed an issue where if the artist is hidden (e.g., when there’s no artist), the title now centers itself vertically again. This behavior had been broken in a few recent updates.
3. Refactored [WindowHelper](https://github.com/unchihugo/FluentFlyout/commit/d222db2d7810a7587c52a26bb9c0321ac219ea0a) and the `GetPlacement` method to stop flyouts from jumping up when `CloseAnimation` runs and the taskbar is positioned at the top.

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Fixes #871, fixes #831, partially #848

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [x] Bug fix
- [x] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
<!-- AI usage -->
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).