### PR TITLE
Update GetLogsPath to search directories on all versions

### DIFF
--- a/FluentFlyoutWPF/Classes/Utils/FileSystemHelper.cs
+++ b/FluentFlyoutWPF/Classes/Utils/FileSystemHelper.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2024-2026 The FluentFlyout Authors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-using FluentFlyout.Classes.Settings;
 using System.IO;
 using Windows.Storage;
 
@@ -11,48 +10,40 @@ namespace FluentFlyoutWPF.Classes.Utils
     {
         public static string GetLogsPath()
         {
-            if (SettingsManager.Current.IsStoreVersion)
+            string path;
+
+            // the way MSIX apps choose a logs path work incredibly weirdly (i haven't figured it out), so we're searching multiple possible locations
+            // first, check same path as where settings is saved
+            try
             {
-                return Path.Combine(ApplicationData.Current.LocalCacheFolder.Path, "Roaming", "FluentFlyout");
-            }
-            else
-            {
-                string path;
-
-                // non-store versions work incredibly weirdly (i haven't figured it out), so we're searching multiple possible locations
-                // first, check %appData%\FluentFlyout
-                try
-                {
-                    path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                        "FluentFlyout");
-                    if (Directory.Exists(path))
-                        return path;
-
-                }
-                catch { }
-
-                // if that doesn't exist, check same path as store version
-                try
-                {
-                    path = Path.Combine(ApplicationData.Current.LocalCacheFolder.Path,
-                        "Roaming",
-                        "FluentFlyout");
-                    if (Directory.Exists(path))
-                        return path;
-                }
-                catch { }
-
-                // if neither of those exist, return hardcoded path
-                // %localAppData%\Packages\unchihugo.FluentFlyout_69b7b6qge1ahj\LocalCache\Roaming\FluentFlyout
-                return Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                    "Packages",
-                    "unchihugo.FluentFlyout_69b7b6qge1ahj",
-                    "LocalCache",
+                path = Path.Combine(ApplicationData.Current.LocalCacheFolder.Path,
                     "Roaming",
-                    "FluentFlyout"
-                );
+                    "FluentFlyout");
+                if (Directory.Exists(path))
+                    return path;
             }
+            catch { }
+
+            // if that doesn't work, check %appData%\FluentFlyout
+            try
+            {
+                path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    "FluentFlyout");
+                if (Directory.Exists(path))
+                    return path;
+            }
+            catch { }
+
+            // if neither of those exist, return hardcoded path
+            // %localAppData%\Packages\unchihugo.FluentFlyout_69b7b6qge1ahj\LocalCache\Roaming\FluentFlyout
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Packages",
+                "unchihugo.FluentFlyout_69b7b6qge1ahj",
+                "LocalCache",
+                "Roaming",
+                "FluentFlyout"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->

Update GetLogsPath to search directories on all versions instead of sideload only. Store versions sometimes also didn't return the logs directory.

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other