### PR TITLE
Add clickable, draggable progress bar to taskbar widget

### DIFF
--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml
@@ -19,7 +19,7 @@
                 </Image.Effect>
             </Image>
             <Border Name="TopBorder" BorderThickness="0,1.25,0,0" CornerRadius="5" Margin="0,0,0,1.25">
-                <Grid Name="MainGrid" HorizontalAlignment="Left" VerticalAlignment="Center" RenderTransformOrigin="0,0.5">
+                <Grid Name="MainGrid" HorizontalAlignment="Left" VerticalAlignment="Top" RenderTransformOrigin="0,0.5">
                     <Grid.RenderTransform>
                         <ScaleTransform ScaleX="0.9" ScaleY="0.9" />
                     </Grid.RenderTransform>
@@ -72,6 +72,38 @@
                     </StackPanel>
                 </Grid>
             </Border>
+
+            <Grid Name="SeekBarTrack" HorizontalAlignment="Left" VerticalAlignment="Bottom"
+                  Width="{Binding ActualWidth, ElementName=TopBorder}" Height="12" Margin="0,0,0,0"
+                  Background="Transparent" Cursor="Hand" Panel.ZIndex="3"
+                  MouseLeftButtonDown="SeekBarTrack_MouseLeftButtonDown"
+                  MouseMove="SeekBarTrack_MouseMove"
+                  MouseLeftButtonUp="SeekBarTrack_MouseLeftButtonUp">
+                <Grid.Style>
+                    <Style TargetType="Grid">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding TaskbarWidgetSeekbarEnabled}" Value="True">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Grid.Style>
+                <Grid VerticalAlignment="Center" Height="6" IsHitTestVisible="False">
+                    <Border Background="#33FFFFFF" CornerRadius="3" />
+                    <Rectangle Name="SeekBarFill" HorizontalAlignment="Left" Width="0" RadiusX="3" RadiusY="3"
+                               Fill="{DynamicResource MicaWPF.Brushes.SystemAccentColorTertiary}" />
+                </Grid>
+                <Ellipse Name="SeekBarThumb" Width="12" Height="12" HorizontalAlignment="Left" VerticalAlignment="Center"
+                         Fill="{DynamicResource MicaWPF.Brushes.SystemAccentColorTertiary}" IsHitTestVisible="False">
+                    <Ellipse.Effect>
+                        <DropShadowEffect BlurRadius="4" ShadowDepth="0" Opacity="0.5" Color="Black" />
+                    </Ellipse.Effect>
+                    <Ellipse.RenderTransform>
+                        <TranslateTransform x:Name="SeekBarThumbTransform" X="-6" />
+                    </Ellipse.RenderTransform>
+                </Ellipse>
+            </Grid>
         </Grid>
     </Border>
 </UserControl>

--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
@@ -25,6 +25,7 @@ public partial class TaskbarWidgetControl : UserControl
     // Constants for default and small taskbar widget sizes
     private const double DefaultTaskbarWidgetHeight = 40;
     private const double SmallTaskbarWidgetHeight = 28;
+    private const double SeekBarExtraHeight = 12; // extra vertical space reserved for the progress bar row
 
     // Constants for cover image and control button sizes
     private const double DefaultCoverImageSize = 36;
@@ -62,9 +63,16 @@ public partial class TaskbarWidgetControl : UserControl
     private bool _isVertical;
     private bool _isSmallTaskbar;
 
+    // seek/progress bar
+    private System.Threading.Timer? _seekBarTimer;
+    private DateTime _lastSeekBarInteraction = DateTime.MinValue;
+    private bool _isSeekBarDragging;
+
     public TaskbarWidgetControl()
     {
         InitializeComponent();
+
+        _seekBarTimer = new System.Threading.Timer(SeekBarTimerTick, null, 0, 1000);
 
         // Apply Windows theme colors (independent of the app theme setting)
         ApplyWindowsTheme();
@@ -330,6 +338,11 @@ public partial class TaskbarWidgetControl : UserControl
 
         double logicalHeight = _isSmallTaskbar ? SmallTaskbarWidgetHeight : DefaultTaskbarWidgetHeight;
 
+        // reserve dedicated space below the cover/text row for the draggable progress bar,
+        // instead of overlapping the song title/artist text
+        if (SettingsManager.Current.TaskbarWidgetSeekbarEnabled)
+            logicalHeight += SeekBarExtraHeight;
+
         return (logicalWidth, logicalHeight);
     }
 
@@ -515,6 +528,8 @@ public partial class TaskbarWidgetControl : UserControl
                 MainBorder.Background = new SolidColorBrush(Colors.Transparent);
                 MainBorder.Background.Opacity = 0;
                 TopBorder.BorderBrush = Brushes.Transparent;
+
+                SeekBarFill.Width = 0;
 
                 Visibility = Visibility.Visible;
             });
@@ -702,5 +717,109 @@ public partial class TaskbarWidgetControl : UserControl
         if (focusedSession == null) return;
 
         await focusedSession.ControlSession.TrySkipNextAsync();
+    }
+
+    // periodically syncs the thin progress line (and its thumb) at the bottom of the widget with
+    // the active media session's playback position. Cheap no-op when disabled/hidden/dragging.
+    private void SeekBarTimerTick(object? state)
+    {
+        try
+        {
+            if (!SettingsManager.Current.TaskbarWidgetSeekbarEnabled) return;
+            if (_mainWindow == null || Visibility != Visibility.Visible) return;
+            if (_isSeekBarDragging) return;
+            // avoid fighting with the user right after they release a seek
+            if (DateTime.Now.Subtract(_lastSeekBarInteraction).TotalMilliseconds < 750) return;
+
+            var session = _mainWindow.GetActiveMediaSession();
+            if (session == null) return;
+
+            var timeline = session.ControlSession.GetTimelineProperties();
+            if (timeline.MaxSeekTime.TotalSeconds < 1.0) return; // player doesn't report a real duration/seek support
+
+            var position = timeline.Position + (DateTime.Now - timeline.LastUpdatedTime.DateTime);
+            double fraction = timeline.MaxSeekTime.TotalSeconds > 0
+                ? position.TotalSeconds / timeline.MaxSeekTime.TotalSeconds
+                : 0;
+            fraction = Math.Clamp(fraction, 0.0, 1.0);
+
+            Dispatcher.Invoke(() => SetSeekBarVisual(fraction));
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Taskbar widget error while updating seek bar");
+        }
+    }
+
+    // moves the fill rectangle and the round thumb to reflect a 0.0-1.0 position in the song
+    private void SetSeekBarVisual(double fraction)
+    {
+        fraction = Math.Clamp(fraction, 0.0, 1.0);
+        if (SeekBarTrack.ActualWidth <= 0) return;
+
+        double filledWidth = SeekBarTrack.ActualWidth * fraction;
+        SeekBarFill.Width = filledWidth;
+        SeekBarThumbTransform.X = filledWidth - (SeekBarThumb.Width / 2);
+    }
+
+    // returns the 0.0-1.0 fraction along the track for a mouse event's X position
+    private double GetSeekBarFraction(MouseEventArgs e)
+    {
+        if (SeekBarTrack.ActualWidth <= 0) return 0;
+        double fraction = e.GetPosition(SeekBarTrack).X / SeekBarTrack.ActualWidth;
+        return Math.Clamp(fraction, 0.0, 1.0);
+    }
+
+    private void SeekBarTrack_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        // swallow so the click doesn't also toggle the media flyout via the parent border
+        e.Handled = true;
+
+        if (_mainWindow == null || SeekBarTrack.ActualWidth <= 0) return;
+        if (_mainWindow.GetActiveMediaSession() == null) return;
+
+        _isSeekBarDragging = true;
+        SeekBarTrack.CaptureMouse();
+        SetSeekBarVisual(GetSeekBarFraction(e));
+    }
+
+    private void SeekBarTrack_MouseMove(object sender, MouseEventArgs e)
+    {
+        if (!_isSeekBarDragging || e.LeftButton != MouseButtonState.Pressed) return;
+
+        SetSeekBarVisual(GetSeekBarFraction(e));
+    }
+
+    private async void SeekBarTrack_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        e.Handled = true;
+
+        if (!_isSeekBarDragging) return;
+        _isSeekBarDragging = false;
+        SeekBarTrack.ReleaseMouseCapture();
+
+        if (_mainWindow == null || SeekBarTrack.ActualWidth <= 0) return;
+
+        var focusedSession = _mainWindow.GetActiveMediaSession();
+        if (focusedSession == null) return;
+
+        try
+        {
+            var timeline = focusedSession.ControlSession.GetTimelineProperties();
+            double totalSeconds = timeline.MaxSeekTime.TotalSeconds;
+            if (totalSeconds < 1.0) return; // this player/session doesn't support seeking
+
+            double fraction = GetSeekBarFraction(e);
+            var targetPosition = TimeSpan.FromSeconds(totalSeconds * fraction);
+
+            SetSeekBarVisual(fraction); // reflect the final position immediately
+            _lastSeekBarInteraction = DateTime.Now;
+
+            await focusedSession.ControlSession.TryChangePlaybackPositionAsync(targetPosition.Ticks);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Taskbar widget error while seeking");
+        }
     }
 }

--- a/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
@@ -34,6 +34,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <StackPanel Orientation="Horizontal" Margin="0,0,0,24">
                 <Border CornerRadius="10" ClipToBounds="True" Width="164" Height="98">
@@ -251,7 +252,17 @@
                     <ComboBoxItem Content="{DynamicResource PositionRight}" />
                 </ComboBox>
             </ui:CardControl>
-            <ui:CardControl x:Name="TaskbarWidgetAnimatedTitleCard" Tag="Indexable" Grid.Row="13" Icon="{ui:SymbolIcon Wand24}" Margin="0,0,0,3">
+            <ui:CardControl x:Name="TaskbarWidgetSeekbarTitleCard" Tag="Indexable" Grid.Row="13" Icon="{ui:SymbolIcon SlideArrowRight24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource TaskbarWidgetSeekbarTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource TaskbarWidgetSeekbarDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <ui:ToggleSwitch IsChecked="{Binding TaskbarWidgetSeekbarEnabled, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
+            </ui:CardControl>
+
+            <ui:CardControl x:Name="TaskbarWidgetAnimatedTitleCard" Tag="Indexable" Grid.Row="14" Icon="{ui:SymbolIcon Wand24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TaskbarWidgetAnimatedTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -261,7 +272,7 @@
                 <ui:ToggleSwitch IsChecked="{Binding TaskbarWidgetAnimated, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
             </ui:CardControl>
 
-            <ui:CardExpander x:Name="TaskbarWidgetScrollingTextCard" Tag="Indexable" Grid.Row="14" Icon="{ui:SymbolIcon TextDirectionHorizontalRight24}" ContentPadding="0" Margin="0,0,0,3">
+            <ui:CardExpander x:Name="TaskbarWidgetScrollingTextCard" Tag="Indexable" Grid.Row="15" Icon="{ui:SymbolIcon TextDirectionHorizontalRight24}" ContentPadding="0" Margin="0,0,0,3">
                 <ui:CardExpander.Header>
                     <Grid ColumnDefinitions="*, Auto">
                         <StackPanel Orientation="Vertical">
@@ -298,7 +309,7 @@
                 </StackPanel>
             </ui:CardExpander>
 
-            <ui:CardControl x:Name="TaskbarWidgetShowPauseOverlayTitleCard" Tag="Indexable" Grid.Row="15" Icon="{ui:SymbolIcon Pause24}" Margin="0,0,0,76">
+            <ui:CardControl x:Name="TaskbarWidgetShowPauseOverlayTitleCard" Tag="Indexable" Grid.Row="16" Icon="{ui:SymbolIcon Pause24}" Margin="0,0,0,76">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource TaskbarWidgetShowPauseOverlayTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-de.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-de.xaml
@@ -218,6 +218,8 @@ Du kannst helfen, die App zu übersetzen auf</system:String>
     <system:String x:Key="PositionRight">Rechts</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Position der Mediensteuerung</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Wähle aus, wo die Mediensteuerung-Buttons angezeigt werden sollen</system:String>
+    <system:String x:Key="TaskbarWidgetSeekbarTitle">Fortschrittsbalken anzeigen</system:String>
+    <system:String x:Key="TaskbarWidgetSeekbarDescription">Zeigt einen dünnen, klickbaren Fortschrittsbalken am unteren Rand des Widgets an. Klicke an eine beliebige Stelle, um im Song dorthin zu springen (nicht von allen Playern unterstützt).</system:String>
     <system:String x:Key="TaskbarVisualizerClickableDescription">Beim klicken des Visualisierers wird die Einstellungsseite geöffnet</system:String>
     <system:String x:Key="TaskbarWidgetAutoHideTitle">Versteckt das Widget Automatisch</system:String>
     <system:String x:Key="TaskbarVisualizerClickableTitle">Klicke um die Einstellungen zu öffnen</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -76,6 +76,8 @@ hides repeat, shuffle and player info</System:String>
     <System:String x:Key="TaskbarWidgetControlsDescription">Show media control buttons on the widget</System:String>
     <System:String x:Key="TaskbarWidgetControlsPositionTitle">Media Controls Position</System:String>
     <System:String x:Key="TaskbarWidgetControlsPositionDescription">Choose where to display the media control buttons</System:String>
+    <System:String x:Key="TaskbarWidgetSeekbarTitle">Show Progress Bar</System:String>
+    <System:String x:Key="TaskbarWidgetSeekbarDescription">Displays a thin, clickable progress line at the bottom of the widget. Click anywhere on it to jump to that point in the song (not supported by all players).</System:String>
     <System:String x:Key="PositionLeft">Left</System:String>
     <System:String x:Key="PositionRight">Right</System:String>
     <System:String x:Key="TaskbarWidgetAnimatedTitle">Widget Animations</System:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -453,6 +453,12 @@ public partial class UserSettings : ObservableObject
     public partial int TaskbarWidgetControlsPosition { get; set; }
 
     /// <summary>
+    /// Whether a thin, clickable progress/seek bar is shown at the bottom of the taskbar widget.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool TaskbarWidgetSeekbarEnabled { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the taskbar widget should play animations.
     /// </summary>
     [ObservableProperty]
@@ -744,6 +750,7 @@ public partial class UserSettings : ObservableObject
         TaskbarWidgetShowPauseOverlay = true;
         TaskbarWidgetControlsEnabled = false;
         TaskbarWidgetControlsPosition = 1;
+        TaskbarWidgetSeekbarEnabled = false;
         TaskbarWidgetAnimated = true;
         TaskbarWidgetScrollingEnabled = false;
         TaskbarWidgetScrollingTextSpeed = 20;
@@ -921,6 +928,12 @@ public partial class UserSettings : ObservableObject
     }
 
     partial void OnTaskbarWidgetControlsEnabledChanged(bool oldValue, bool newValue)
+    {
+        if (oldValue == newValue || _initializing) return;
+        UpdateTaskbar();
+    }
+
+    partial void OnTaskbarWidgetSeekbarEnabledChanged(bool oldValue, bool newValue)
     {
         if (oldValue == newValue || _initializing) return;
         UpdateTaskbar();


### PR DESCRIPTION

## Summary
new progressbar in taskbar

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Closes #issue-number

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

- New TaskbarWidgetSeekbarEnabled setting under Widget Customization
- Thin progress line with a draggable thumb at the bottom of the compact taskbar widget; click or drag to seek, mirrors the existing seekbar logic used by the media flyout (TryChangePlaybackPositionAsync)
- Localized (en-US, de)

## Additional Information


<img width="1262" height="77" alt="Screenshot 2026-08-23 025128 - Kopie" src="https://github.com/user-attachments/assets/a00e7c53-f1f0-4f22-9413-752a0ad56860" />

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
<!-- AI usage -->
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).