### PR TITLE
Add volume flyout sync toggle

### DIFF
--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
@@ -251,7 +251,7 @@ public partial class TaskbarWidgetControl : UserControl
         if (_mainWindow == null) return;
 
         // toggle main flyout when clicked
-        _mainWindow.ShowMediaFlyout(toggleMode: true, forceShow: true);
+        _mainWindow.ShowMediaFlyoutWithVolume(toggleMode: true, forceShow: true);
     }
 
     private void MainBorder_MouseWheel(object sender, MouseWheelEventArgs e)

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -921,11 +921,7 @@ public partial class MainWindow : MicaWindow
                 if (mediaKeysPressed || (!SettingsManager.Current.MediaFlyoutVolumeKeysExcluded && volumeKeysPressed))
                     result = TryShowMediaFlyoutDebounced();
 
-                if (SettingsManager.Current.VolumeControlEnabled)
-                {
-                    volumeMixerWindow?.ViewModel.SyncMasterFromDevice();
-                    volumeMixerWindow?.ShowFlyout();
-                }
+                ShowVolumeFlyoutIfEnabled();
 
                 if (!result)
                 {
@@ -974,6 +970,33 @@ public partial class MainWindow : MicaWindow
         _lastFlyoutTime = currentTime;
         ShowMediaFlyout();
         return true;
+    }
+
+    private void ShowVolumeFlyoutIfEnabled()
+    {
+        if (!SettingsManager.Current.VolumeControlEnabled)
+            return;
+
+        volumeMixerWindow?.ViewModel.SyncMasterFromDevice();
+        volumeMixerWindow?.ShowFlyout();
+    }
+
+    public void ShowMediaFlyoutWithVolume(bool toggleMode = false, bool forceShow = false)
+    {
+        bool shouldShowVolumeFlyoutWithMedia = GetActiveMediaSession() != null
+            && (forceShow || SettingsManager.Current.MediaFlyoutEnabled)
+            && !FullscreenDetector.IsFullscreenApplicationRunning()
+            && SettingsManager.Current.VolumeControlEnabled
+            && SettingsManager.Current.VolumeControlSyncWithMediaFlyout;
+        bool isToggleClose = toggleMode && Visibility == Visibility.Visible && !_isHiding;
+
+        if (shouldShowVolumeFlyoutWithMedia && isToggleClose)
+            volumeMixerWindow?.HideFlyout();
+
+        ShowMediaFlyout(toggleMode, forceShow);
+
+        if (shouldShowVolumeFlyoutWithMedia && !isToggleClose)
+            ShowVolumeFlyoutIfEnabled();
     }
 
     public async void ShowMediaFlyout(bool toggleMode = false, bool forceShow = false)
@@ -1958,7 +1981,7 @@ public partial class MainWindow : MicaWindow
             //ThemeService themeService = new ThemeService();
             //themeService.ChangeTheme(MicaWPF.Core.Enums.WindowsTheme.Light);
         }
-        else if (SettingsManager.Current.NIconLeftClick == 1) ShowMediaFlyout();
+        else if (SettingsManager.Current.NIconLeftClick == 1) ShowMediaFlyoutWithVolume();
     }
 
     private Task PauseOtherSessions(MediaSession currentMediaSession)

--- a/FluentFlyoutWPF/Pages/VolumeMixerPage.xaml
+++ b/FluentFlyoutWPF/Pages/VolumeMixerPage.xaml
@@ -71,6 +71,16 @@
                 <ui:ToggleSwitch IsChecked="{Binding VolumeControlAboveMediaFlyout, Mode=TwoWay}" />
             </ui:CardControl>
 
+            <ui:CardControl x:Name="VolumeSyncWithMediaFlyoutTitleCard" Tag="Indexable" Icon="{ui:SymbolIcon ArrowSync24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource VolumeSyncWithMediaFlyoutTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource VolumeSyncWithMediaFlyoutDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <ui:ToggleSwitch IsChecked="{Binding VolumeControlSyncWithMediaFlyout, Mode=TwoWay}" />
+            </ui:CardControl>
+
             <ui:CardControl x:Name="VolumeFlyoutStayDurationTitleCard" Tag="Indexable" Grid.Row="3" Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,12">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ar.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ar.xaml
@@ -288,4 +288,6 @@
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">سرعة التمرير</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">سرعة تمرير النصوص (بكسل/ثانية). الإفتراضي هو 20.</system:String>
     <system:String x:Key="SearchSettings">إعدادات البحث</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">إظهار وإخفاء قائمة الصوت دائمًا مع قائمة الوسائط المنبثقة</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">إظهار أو إخفاء قائمة الصوت المنبثقة مع قائمة الوسائط عند فتحها من أيقونة شريط المهام أو أداة شريط المهام.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ca.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ca.xaml
@@ -284,4 +284,6 @@ Pots ajudar a contribuir amb les traduccions a</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextLoopForeverDescription">Repetir el text en un bucle infinit en una direcció en comptes de desplaçar-se endavant i endarrere.</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">Velocitat de Desplaçament</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">Velocitat a la qual es desplaça el text (píxels/segon). El valor per defecte és 20.</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Mostra i amaga sempre amb el desplegable multimèdia</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Mostra o amaga el desplegable de volum juntament amb el desplegable multimèdia quan s&apos;obre des de la icona de la safata o el giny de la barra de tasques.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-cs.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-cs.xaml
@@ -231,4 +231,6 @@ Poznámka: Jelikož se jedná o open-source projekt, jsou tyto funkce k dispozic
     <system:String x:Key="MonitorWithFocusedWindow">Monitor s aktivním oknem</system:String>
     <system:String x:Key="LegacyTaskbarWidthTitle">Starší systém šířky na hlavním panelu</system:String>
     <system:String x:Key="LegacyTaskbarWidthDescription">Použije starší sytém pro šířku na hlavním panelu pro panelové Widgety</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Vždy zobrazit a skrýt společně s plovoucím oknem médií</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Zobrazit nebo skrýt plovoucí okno hlasitosti společně s plovoucím oknem médií při otevření z ikony v oznamovací oblasti nebo widgetu hlavního panelu.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-de.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-de.xaml
@@ -288,4 +288,6 @@ Du kannst helfen, die App zu übersetzen auf</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextLoopForeverDescription">Lassen Sie den Text in einer Richtung endlos durchlaufen, anstatt ihn hin und her scrollen zu lassen.</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">Scrollgeschwindigkeit</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">Geschwindigkeit, mit der der Text scrollt (Pixel/Sekunde). Der Standardwert ist 20.</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Immer zusammen mit dem Medien-Flyout ein- und ausblenden</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Blendet das Lautstärke-Flyout zusammen mit dem Medien-Flyout ein oder aus, wenn es über das Taskleistensymbol oder das Taskleisten-Widget geöffnet wird.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -292,4 +292,6 @@ You can help contribute translations on</System:String>
     <System:String x:Key="VolumeMixerHighlightDescription">See which apps are currently outputting audio</System:String>
     <System:String x:Key="MasterVolumeText">Master volume</System:String>
     <System:String x:Key="OpenMediaPlayerText">Open media player</System:String>
+    <System:String x:Key="VolumeSyncWithMediaFlyoutTitle">Always show and hide with Media Flyout</System:String>
+    <System:String x:Key="VolumeSyncWithMediaFlyoutDescription">Show or hide the volume flyout together with the media flyout when opened from the tray icon or taskbar widget.</System:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-es.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-es.xaml
@@ -288,4 +288,6 @@ Nota: Como proyecto de código abierto, estas opciones también están disponibl
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">Velocidad del Scroll</system:String>
     <system:String x:Key="SearchSettings">Ajustes de búsqueda</system:String>
     <system:String x:Key="TaskbarVisualizerBaselineAutoHideDescription">Oculta automáticamente la base cuando no se reproduce audio</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Mostrar y ocultar siempre con el flyout multimedia</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Muestra u oculta el flyout de volumen junto con el flyout multimedia cuando se abre desde el icono de la bandeja o el widget de la barra de tareas.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-fi.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-fi.xaml
@@ -63,4 +63,6 @@ Huomaa: Koska kyseessä on avoimen lähdekoodin projekti, nämä toiminnot ovat 
     <system:String x:Key="PremiumPurchaseCancelled">Osto peruttu.</system:String>
     <system:String x:Key="HomeTitle">Koti</system:String>
     <system:String x:Key="Enabled">Käytössä</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Näytä ja piilota aina mediaikkunan kanssa</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Näytä tai piilota äänenvoimakkuusikkuna mediaikkunan mukana, kun se avataan ilmaisinalueen kuvakkeesta tai tehtäväpalkin widgetistä.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-fr.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-fr.xaml
@@ -288,4 +288,6 @@ Vous pouvez contribuer aux traductions sur</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextLoopForeverDescription">Faire défiler le texte indéfiniment dans une seule direction au lieu d'un défilement aller-retour.</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">Vitesse de défilement</system:String>
     <system:String x:Key="SearchSettings">Rechercher les paramètres</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Toujours afficher et masquer avec le menu déroulant Média</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Affiche ou masque le menu déroulant du volume avec le menu déroulant Média lorsqu&apos;il est ouvert depuis l&apos;icône de la zone de notification ou le widget de la barre des tâches.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-he.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-he.xaml
@@ -248,4 +248,6 @@
     <system:String x:Key="VolumeMixerHighlightTitle">הדגשת אפליקציות המשמיעות שמע</system:String>
     <system:String x:Key="VolumeMixerHighlightDescription">הצג אילו אפליקציות מפיקות שמע כרגע</system:String>
     <system:String x:Key="MasterVolumeText">עוצמת קול כללית</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">הצג והסתר תמיד יחד עם חלונית המדיה</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">הצג או הסתר את חלונית עוצמת הקול יחד עם חלונית המדיה כאשר היא נפתחת מסמל המגש או מווידג&apos;ט שורת המשימות.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-hi.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-hi.xaml
@@ -286,4 +286,6 @@
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">लेख ऊपर-नीचे करनो की गति (पिक्सेल/सेकंड)। प्रीसेट 20 है।</system:String>
     <system:String x:Key="OnboardingStepsCounter">{1} में से {0} चरण</system:String>
     <system:String x:Key="TaskbarVisualizerBaselineAutoHideDescription">जब कोई ऑडियो नहीं चल रहा हो, तो बेसलाइन को अपने-आप छिपा दो</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">मीडिया फ़्लाईआउट के साथ हमेशा दिखाएँ और छिपाएँ</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">ट्रे आइकन या टास्कबार विजेट से खोलने पर वॉल्यूम फ़्लाईआउट को मीडिया फ़्लाईआउट के साथ दिखाएँ या छिपाएँ।</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-hr.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-hr.xaml
@@ -60,4 +60,6 @@ nasumičnu reprodukciju i informacije o mediju</system:String>
     <system:String x:Key="TaskbarWidgetBackgroundBlurTitle">Pozadinsko Zamućenje</system:String>
     <system:String x:Key="TaskbarWidgetBackgroundBlurDescription">Dodaj efekt pozadinskog zamućenja widgetu za traku</system:String>
     <system:String x:Key="TaskbarWidgetHideCompletelyTitle">Kompletno Sakrij Kada Nema Nikakvog Medija</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Uvijek prikaži i sakrij s medijskim skočnim prozorom</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Prikaži ili sakrij skočni prozor glasnoće zajedno s medijskim skočnim prozorom kada se otvori iz ikone u traci ili widgeta programske trake.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-hu.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-hu.xaml
@@ -268,4 +268,6 @@ Segíts te is a fordításban a(z)</system:String>
     <system:String x:Key="MasterVolumeText">Fő hangerő</system:String>
     <system:String x:Key="TaskbarWidgetFixedWidthTitle">Widget szélességének rögzítése</system:String>
     <system:String x:Key="TaskbarWidgetFixedWidthDescription">A widget szélességét tartsa állandóan, ne pedig a címhez és az előadó nevéhez igazítsa</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Mindig a média flyouttal együtt jelenjen meg és tűnjön el</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">A hangerő flyout megjelenítése vagy elrejtése a média flyouttal együtt, amikor a tálcaikonról vagy a tálcawidgetről nyitja meg.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-id.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-id.xaml
@@ -288,4 +288,6 @@ Anda dapat membantu berkontribusi dalam menerjemahkan di</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">Kecepatan Gulir</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextLoopForeverDescription">Gulirkan teks terus-menerus ke satu arah, bukan bolak-balik.</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">Kecepatan gulir teks (piksel/detik). Nilai bawaan adalah 20.</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Selalu tampil dan sembunyi bersama flyout media</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Tampilkan atau sembunyikan flyout volume bersama flyout media saat dibuka dari ikon baki atau widget bilah tugas.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-it.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-it.xaml
@@ -288,4 +288,6 @@ Puoi contribuire alla traduzione su</system:String>
     <system:String x:Key="SearchSettings">Cerca impostazioni</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextTitle">Testo Scorrevole</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">Velocità di scorrimento</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Mostra e nascondi sempre con il flyout multimediale</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Mostra o nasconde il flyout del volume insieme al flyout multimediale quando viene aperto dall&apos;icona dell&apos;area di notifica o dal widget della barra delle applicazioni.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ja.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ja.xaml
@@ -286,4 +286,6 @@
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">テキストがスクロールする速度 (ピクセル/秒)。既定値は 20。</system:String>
     <system:String x:Key="TaskbarVisualizerBaselineAutoHideDescription">オーディオが再生されていないときは、ベースラインを自動的に非表示にします</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTitle">スクロールを有効化</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">メディア フライアウトと常に一緒に表示/非表示</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">トレイ アイコンまたはタスクバー ウィジェットから開いたときに、音量フライアウトをメディア フライアウトと一緒に表示または非表示にします。</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ko.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ko.xaml
@@ -288,4 +288,6 @@
     <system:String x:Key="TaskbarWidgetScrollingTextLoopForeverDescription">텍스트를 한 방향으로 계속 스크롤하기.</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">스크롤 속도</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">텍스트 스크롤 속도 설정(픽셀/초). 기본값은 20.</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">미디어 플라이아웃과 항상 함께 표시 및 숨기기</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">트레이 아이콘 또는 작업 표시줄 위젯에서 열 때 볼륨 플라이아웃을 미디어 플라이아웃과 함께 표시하거나 숨깁니다.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-nl.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-nl.xaml
@@ -170,4 +170,6 @@ verbergt herhalen, shuffle en spelerinfo</system:String>
     <system:String x:Key="UpdateAvailableNotificationTitle">Update Verkrijgbaar!</system:String>
     <system:String x:Key="UpdateAvailableNotificationMessage">Een niewe versie ({0}) is verkrijgbaar.</system:String>
     <system:String x:Key="UpdateAvailableNotificationButton">Download Update</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Altijd samen met de mediaflyout tonen en verbergen</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Toon of verberg de volumeflyout samen met de mediaflyout wanneer deze wordt geopend via het systeemvakpictogram of de taakbalkwidget.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-pl.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-pl.xaml
@@ -288,4 +288,6 @@ Możesz pomóc w tworzeniu tłumaczeń na stronie</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextLoopForeverDescription">Przewijaj tekst nieskończenie w jedną stronę zamiast przewijania w przód i w tył.</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">Prędkość Przewijania</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">Prędkość przewijania tekstu (pikseli na sekundę). Domyślna wartość to 20.</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Zawsze pokazuj i ukrywaj razem z panelem multimediów</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Pokazuj lub ukrywaj panel głośności razem z panelem multimediów po otwarciu z ikony zasobnika lub widżetu paska zadań.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-pt-BR.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-pt-BR.xaml
@@ -288,4 +288,6 @@ Nota: Como um projeto de código aberto, esses recursos também estão disponív
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">Velocidade de rolagem</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">Velocidade em que o texto rola (pixels/segundo). O padrão é 20.</system:String>
     <system:String x:Key="SearchSettings">Pesquisar configurações</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Sempre mostrar e ocultar com o flyout de mídia</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Mostra ou oculta o flyout de volume junto com o flyout de mídia ao abrir pelo ícone da bandeja ou pelo widget da barra de tarefas.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ru.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ru.xaml
@@ -288,4 +288,6 @@
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">Скорость прокрутки</system:String>
     <system:String x:Key="Back">Назад</system:String>
     <system:String x:Key="OnboardingStepsCounter">Шаг {0} из {1}</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Всегда показывать и скрывать вместе с панелью мультимедиа</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Показывает или скрывает панель громкости вместе с панелью мультимедиа при открытии из значка в трее или виджета панели задач.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-si.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-si.xaml
@@ -14,4 +14,6 @@
     <system:String x:Key="BackgroundBlurOption2" xml:space="preserve"> Cover එක දිලිසෙන (Style 1)</system:String>
     <system:String x:Key="BackgroundBlurOption3" xml:space="preserve"> ඉර පායනවා වගේ දිලිසෙන (Style 2)</system:String>
     <system:String x:Key="BackgroundBlurOption4" xml:space="preserve"> බොඳ වුන (Style 3)</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Media flyout එකත් සමඟ සෑමවිටම පෙන්වන්න සහ සඟවන්න</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Tray icon එකෙන් හෝ taskbar widget එකෙන් විවෘත කළ විට volume flyout එක media flyout එක සමඟ පෙන්වන්න හෝ සඟවන්න.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-sk.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-sk.xaml
@@ -284,4 +284,6 @@ Môžete pomôcť s prekladmi na</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextLoopForeverDescription">Nekonečná slučka textu jedným smerom namiesto posúvania tam a späť.</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">Rýchlosť Posúvania</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">Rýchlosť, ktorou sa text posúva (pixel za sekundu). Predvolené: 20.</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Vždy zobraziť a skryť spolu s plávajúcim oknom médií</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Zobrazí alebo skryje plávajúce okno hlasitosti spolu s plávajúcim oknom médií pri otvorení z ikony v systémovej lište alebo widgetu panela úloh.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ta.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ta.xaml
@@ -42,4 +42,6 @@
     <system:String x:Key="LockWindow_NumLock">நம் லாக்</system:String>
     <system:String x:Key="LockWindow_ScrollLock">ஸ்க்ரோல் லாக்</system:String>
     <system:String x:Key="LockWindow_InsertPressed">இன்சர்ட் அழுத்தப்பட்டது</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">மீடியா ஃப்ளையவுட்டுடன் எப்போதும் காட்டவும் மறைக்கவும்</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Tray icon அல்லது taskbar widget இலிருந்து திறக்கும் போது volume flyout-ஐ media flyout உடன் காட்டவும் அல்லது மறைக்கவும்.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-th.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-th.xaml
@@ -50,4 +50,6 @@
     <system:String x:Key="PauseOtherMediaTitle">หยุดสื่อที่เล่นอยู่ก่อนหน้านี้อัตโนมัติ</system:String>
     <system:String x:Key="PauseOtherMediaDescription">เมื่อคุณเล่นสื่อตัวใหม่ สื่ออื่นๆที่เคยเล่นอยู่จะถูกหยุดโดยอัตโนมัติ</system:String>
     <system:String x:Key="TaskbarWidgetCustomizationTitle">Widget ของ Taskbar</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">แสดงและซ่อนพร้อมกับ Media Flyout เสมอ</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">แสดงหรือซ่อน flyout ระดับเสียงพร้อมกับ media flyout เมื่อเปิดจากไอคอนถาดระบบหรือวิดเจ็ตแถบงาน</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-tr.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-tr.xaml
@@ -288,4 +288,6 @@ Not: Açık kaynaklı bir proje olduğundan, bu özellikler GitHub'daki manuel y
     <system:String x:Key="TaskbarWidgetScrollingTextLoopForeverDescription">Metni ileri geri kaydırmak yerine tek yönde sonsuz döngüye al.</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">Kaydırma Hızı</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">Metnin kayma hızı (piksel/saniye). Varsayılan: 20.</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Medya açılır penceresiyle her zaman birlikte göster ve gizle</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Tepsi simgesinden veya görev çubuğu widget&apos;ından açıldığında ses açılır penceresini medya açılır penceresiyle birlikte gösterir ya da gizler.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-uk.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-uk.xaml
@@ -241,4 +241,6 @@
     <system:String x:Key="Back">Назад</system:String>
     <system:String x:Key="Next">Далі</system:String>
     <system:String x:Key="Finish">Закінчити</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Завжди показувати й приховувати разом зі спливним вікном медіа</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Показує або приховує спливне вікно гучності разом зі спливним вікном медіа під час відкриття з піктограми в треї або віджета панелі завдань.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-vi.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-vi.xaml
@@ -287,4 +287,6 @@ Lưu ý: Vì đây là một dự án mã nguồn mở, các tính năng này c�
     <system:String x:Key="TaskbarWidgetScrollingTextLoopForeverDescription">Lặp lại văn bản vô hạn theo một hướng thay vì cuộn qua lại.</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">Tốc độ cuộn</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">Tốc độ cuộn văn bản (pixel/giây). Mặc định là 20.</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">Luôn hiển thị và ẩn cùng flyout media</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">Hiển thị hoặc ẩn flyout âm lượng cùng với flyout media khi mở từ biểu tượng khay hoặc tiện ích trên thanh tác vụ.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-zh-CN.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-zh-CN.xaml
@@ -288,4 +288,7 @@
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedTitle">滚动速度</system:String>
     <system:String x:Key="TaskbarWidgetScrollingTextSpeedDescription">文本滚动速度（像素/秒），默认值为 20。</system:String>
     <system:String x:Key="SearchSettings">搜索设置</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">随媒体浮窗显示</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription" xml:space="preserve">从任务栏小组件唤起或收起媒体浮窗时一同显隐音量浮窗
+如“单击托盘图标时行为”设为“显示媒体浮窗”，触发时音量浮窗也将一同显示</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-zh-TW.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-zh-TW.xaml
@@ -250,4 +250,6 @@
     <system:String x:Key="Finish">結束</system:String>
     <system:String x:Key="TaskbarWidgetFixedWidthTitle">固定小工具寬度</system:String>
     <system:String x:Key="EnableScrollTitle">啟用 Scroll Lock 指示符</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutTitle">始終隨媒體彈出視窗一同顯示或隱藏</system:String>
+    <system:String x:Key="VolumeSyncWithMediaFlyoutDescription">從系統匣圖示或工作列小工具開啟或關閉媒體彈出視窗時，一併顯示或隱藏音量彈出視窗。</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -595,6 +595,9 @@ public partial class UserSettings : ObservableObject
     public partial bool VolumeControlAboveMediaFlyout { get; set; }
 
     [ObservableProperty]
+    public partial bool VolumeControlSyncWithMediaFlyout { get; set; }
+
+    [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(VolumeControlDurationText))]
     public partial int VolumeControlDuration { get; set; }
 
@@ -769,6 +772,7 @@ public partial class UserSettings : ObservableObject
         TaskbarVisualizerBaselineAutoHide = false;
         VolumeControlEnabled = false;
         VolumeControlAboveMediaFlyout = false;
+        VolumeControlSyncWithMediaFlyout = false;
         VolumeControlDuration = 3000;
         VolumeMixerEnabled = false;
         VolumeMixerHighlightActiveApps = false;

--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
@@ -171,6 +171,24 @@ public partial class VolumeMixerWindow : MicaWindow
         }
     }
 
+    public async void HideFlyout()
+    {
+        if (_isHiding)
+            return;
+
+        _cts.Cancel();
+        _mainWindow.CloseAnimation(this);
+        _isHiding = true;
+        _lastFlyoutTime = 0;
+        await Task.Delay(MainWindow.getDuration());
+
+        if (!_isHiding)
+            return;
+
+        WindowHelper.SetVisibility(this, false);
+        ViewModel.IsExpanded = false;
+    }
+
     private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(VolumeMixerViewModel.IsExpanded))


### PR DESCRIPTION
## Summary

Adds a volume setting above the volume flyout stay-duration control for linking manual media flyout triggers with the volume flyout.

Taskbar widget and tray "show media flyout" entries now go through a wrapper that:
- shows media first, then volume, when opening
- starts the volume hide animation before the media hide animation on toggle-close, without waiting between them

These popups are visually syncing when open btw

Media-key and volume-key paths keep their existing direct calls. Auto stay-duration behavior is still timer-driven, so matching media/volume durations naturally collapse together without extra close synchronization.

<img width="900" height="700" alt="image" src="https://github.com/user-attachments/assets/e3cbcb19-bc12-4d13-a1f3-e6840a9eec78" />

## Motivation

closes #1050

## Type of Change

- [x] Feature

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).
