### PR TITLE
Keep media seekbar updating when volume flyout opens

### DIFF
--- a/FluentFlyoutWPF/Classes/WindowHelper.cs
+++ b/FluentFlyoutWPF/Classes/WindowHelper.cs
@@ -22,7 +22,7 @@ public static class WindowHelper
     public static void SetVisibility(Window window, bool visible) // workaround to set window even more topmost
     {
         var handle = new WindowInteropHelper(window).Handle;
-        SetWindowPos(handle, 0, 0, 0, 0, 0, (uint)(SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | (visible ? SWP_SHOWWINDOW : SWP_HIDEWINDOW)));
+        SetWindowPos(handle, 0, 0, 0, 0, 0, (uint)(SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | (visible ? SWP_SHOWWINDOW : SWP_HIDEWINDOW)));
     }
 
     public static Rect GetPlacement(Window window) // get the window position, ignoring WPF
@@ -39,7 +39,7 @@ public static class WindowHelper
     public static void SetPosition(Window window, double x, double y, bool async = false) // set the position of the window, ignoring WPF
     {
         var handle = new WindowInteropHelper(window).Handle;
-        uint flags = SWP_NOSIZE | SWP_NOZORDER | (async ? SWP_ASYNCWINDOWPOS : (uint)0);
+        uint flags = SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | (async ? SWP_ASYNCWINDOWPOS : (uint)0);
         bool result = SetWindowPos(handle, 0, (int)x, (int)y, 0, 0, flags);
 
         if (!result)
@@ -53,11 +53,19 @@ public static class WindowHelper
 
     public static void SetNoActivate(Window window) // prevent window from stealing focus
     {
-        window.SourceInitialized += (sender, e) =>
+        window.ShowActivated = false;
+
+        void ApplyNoActivateStyle()
         {
             var helper = new WindowInteropHelper(window);
+            if (helper.Handle == IntPtr.Zero)
+                return;
+
             SetWindowLong(helper.Handle, GWL_EXSTYLE, GetWindowLong(helper.Handle, GWL_EXSTYLE) | WS_EX_NOACTIVATE);
-        };
+        }
+
+        window.SourceInitialized += (sender, e) => ApplyNoActivateStyle();
+        ApplyNoActivateStyle();
     }
 
     // Check if the mouse cursor is currently over the specified window

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -784,16 +784,15 @@ public partial class MainWindow : MicaWindow
 
     private void MediaManager_OnAnyTimelinePropertyChanged(MediaSession mediaSession, GlobalSystemMediaTransportControlsSessionTimelineProperties timelineProperties)
     {
-        _lastSelfUpdateTimestamp = DateTime.Now;
-
         if (GetActiveMediaSession() is not { } session || session.Id != mediaSession.Id) return;
 
         if (_seekBarEnabled)
         {
             Dispatcher.Invoke(() =>
             {
-                if (!IsActive || _isDragging) return;
+                if (Visibility != Visibility.Visible || _isHiding || _isDragging) return;
 
+                _lastSelfUpdateTimestamp = DateTime.Now;
                 UpdateSeekbarCurrentDuration(session.ControlSession.GetTimelineProperties().Position);
                 HandlePlayBackState(session.ControlSession.GetPlaybackInfo().PlaybackStatus);
             });


### PR DESCRIPTION
## Why

When the volume flyout is enabled, showing it can take window activation away from the media flyout. The media timeline handler treated WPF `IsActive` as a requirement for applying seekbar updates, so timeline events were ignored while focus sat on the volume flyout. The fallback timer then stayed suppressed by `_lastSelfUpdateTimestamp`, making the media progress bar update slowly.

## Change in behavior

Before this PR, the media flyout itself could become the active/focused window. This change makes the shared flyout window helpers more consistently no-activate, so flyouts shown through those helpers should avoid taking focus in general.

That is intentionally broader than only fixing the volume flyout. It keeps media progress updates independent from whichever transient flyout happens to be focused, and it reduces the chance that media, volume, lock-key, or next-up flyouts steal focus from the user's current app.

## Changes

- Set `ShowActivated = false` in `WindowHelper.SetNoActivate`, and apply `WS_EX_NOACTIVATE` immediately when an HWND already exists.
- Add `SWP_NOACTIVATE` to helper show/move calls so native visibility and positioning operations do not activate flyout windows.
- Stop using media flyout focus as the condition for timeline seekbar updates. Timeline updates now apply when the media flyout is visible, not hiding, and the user is not dragging the seekbar.
- Update `_lastSelfUpdateTimestamp` only after a timeline update is actually applied, so skipped events no longer suppress the timer path.

## Alternative

If making every helper-driven flyout no-activate is too aggressive, the narrower fix is to keep the previous behavior where the media flyout may take focus, but make the volume flyout explicitly no-activate. In that version, seekbar updates should still stop depending on `IsActive`, or the media flyout should be reactivated after showing the volume flyout so focus stays on media instead of moving to volume.