### PR TITLE
Add taskbar widget cover position setting

### DIFF
--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
@@ -97,21 +97,64 @@ public partial class TaskbarWidgetControl : UserControl
     public void ReorderControls()
     {
         // Remove ControlsStackPanel from MainStackPanel
+        // Remove media elements too before rebuilding the order
         MainStackPanel.Children.Remove(ControlsStackPanel);
+        MainStackPanel.Children.Remove(SongImageBorder);
+        MainStackPanel.Children.Remove(SongInfoStackPanel);
+
+        bool controlsOnLeft = SettingsManager.Current.TaskbarWidgetControlsPosition == 0;
+        bool coverOnRight = IsCoverOnRight();
 
         // Reorder based on position setting
-        if (SettingsManager.Current.TaskbarWidgetControlsPosition == 0)
+        if (controlsOnLeft)
         {
-            // Left: Controls, Image, Info
-            MainStackPanel.Children.Insert(0, ControlsStackPanel);
+            // Left: Controls, Image/Info content
+            MainStackPanel.Children.Add(ControlsStackPanel);
             ControlsStackPanel.Margin = new Thickness(2, 0, 6, 0); // for some reason margins are weird on left side
+        }
+
+        if (coverOnRight)
+        {
+            // Right cover: Info, Image
+            MainStackPanel.Children.Add(SongInfoStackPanel);
+            MainStackPanel.Children.Add(SongImageBorder);
         }
         else
         {
-            // Right: Image, Info, Controls
+            // Left cover: Image, Info
+            MainStackPanel.Children.Add(SongImageBorder);
+            MainStackPanel.Children.Add(SongInfoStackPanel);
+        }
+
+        if (!controlsOnLeft)
+        {
+            // Right: Image/Info content, Controls
             MainStackPanel.Children.Add(ControlsStackPanel);
             ControlsStackPanel.Margin = new Thickness(8, 0, 0, 0);
         }
+
+        ApplyCoverPositionLayout(coverOnRight);
+        UpdateMarquees();
+    }
+
+    private static bool IsCoverOnRight()
+    {
+        return SettingsManager.Current.TaskbarWidgetCoverPosition switch
+        {
+            1 => false,
+            2 => true,
+            _ => SettingsManager.Current.TaskbarWidgetPosition == 2
+        };
+    }
+
+    private void ApplyCoverPositionLayout(bool coverOnRight)
+    {
+        SongInfoStackPanel.Margin = coverOnRight
+            ? new Thickness(0, 0, 8, 0)
+            : new Thickness(8, 0, 0, 0);
+
+        SongTitle.TextAlignment = coverOnRight ? TextAlignment.Right : TextAlignment.Left;
+        SongArtist.TextAlignment = coverOnRight ? TextAlignment.Right : TextAlignment.Left;
     }
 
     public void SetVerticalMode(bool isVertical)
@@ -364,8 +407,10 @@ public partial class TaskbarWidgetControl : UserControl
 
         int speed = SettingsManager.Current.TaskbarWidgetScrollingTextSpeed;
         bool loopForever = SettingsManager.Current.TaskbarWidgetScrollingTextLoopForever;
+        bool isRightAligned = IsCoverOnRight();
         bool isTitle = textBlock == SongTitle;
         double containerWidth = container.Width;
+        textBlock.TextAlignment = isRightAligned ? TextAlignment.Right : TextAlignment.Left;
 
         // references moved outside so they may be called in the else block later
         ref double cachedMaskWidth = ref (isTitle ? ref _cachedTitleOpacityMaskWidth : ref _cachedArtistOpacityMaskWidth);
@@ -416,12 +461,13 @@ public partial class TaskbarWidgetControl : UserControl
 
                 double spacerWidth = StringWidth.GetStringWidth(spacer, 400);
                 double scrollDistance = textWidth + spacerWidth;
+                double startOffset = isRightAligned ? containerWidth - textWidth : 0;
 
                 double durationToScroll = scrollDistance / speed;
                 var animation = new DoubleAnimation
                 {
-                    From = 0,
-                    To = -scrollDistance,
+                    From = startOffset,
+                    To = startOffset - scrollDistance,
                     Duration = TimeSpan.FromSeconds(durationToScroll),
                     RepeatBehavior = RepeatBehavior.Forever
                 };
@@ -434,6 +480,8 @@ public partial class TaskbarWidgetControl : UserControl
                 // resetting or reversing; this prevents abrupt cutoffs
                 double scrollDistance = textWidth - containerWidth + 10;
                 textBlock.Text = origText;
+                double startOffset = isRightAligned ? containerWidth - textWidth : 0;
+                double endOffset = isRightAligned ? 10 : -scrollDistance;
 
                 double durationSeconds = scrollDistance / speed;
                 double pauseDuration = 2.0; // wait 2 seconds at the start and end of the scroll
@@ -444,12 +492,12 @@ public partial class TaskbarWidgetControl : UserControl
                 double tTotalCycle = tScrollBackEnd + pauseDuration;
 
                 var animation = new DoubleAnimationUsingKeyFrames { RepeatBehavior = RepeatBehavior.Forever };
-                animation.KeyFrames.Add(new LinearDoubleKeyFrame(0, KeyTime.FromTimeSpan(TimeSpan.Zero)));
-                animation.KeyFrames.Add(new LinearDoubleKeyFrame(0, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tWaitStart))));
-                animation.KeyFrames.Add(new LinearDoubleKeyFrame(-scrollDistance, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tScrollEnd))));
-                animation.KeyFrames.Add(new LinearDoubleKeyFrame(-scrollDistance, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tWaitEnd))));
-                animation.KeyFrames.Add(new LinearDoubleKeyFrame(0, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tScrollBackEnd))));
-                animation.KeyFrames.Add(new LinearDoubleKeyFrame(0, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tTotalCycle))));
+                animation.KeyFrames.Add(new LinearDoubleKeyFrame(startOffset, KeyTime.FromTimeSpan(TimeSpan.Zero)));
+                animation.KeyFrames.Add(new LinearDoubleKeyFrame(startOffset, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tWaitStart))));
+                animation.KeyFrames.Add(new LinearDoubleKeyFrame(endOffset, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tScrollEnd))));
+                animation.KeyFrames.Add(new LinearDoubleKeyFrame(endOffset, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tWaitEnd))));
+                animation.KeyFrames.Add(new LinearDoubleKeyFrame(startOffset, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tScrollBackEnd))));
+                animation.KeyFrames.Add(new LinearDoubleKeyFrame(startOffset, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tTotalCycle))));
 
                 // sync fades with the "ping pong" movement
                 Color transparentWhite = Color.FromArgb(0, 255, 255, 255);
@@ -460,20 +508,20 @@ public partial class TaskbarWidgetControl : UserControl
                 TimeSpan fadeTime = TimeSpan.FromMilliseconds(Math.Min(300, durationSeconds * 1000 / 2.0));
 
                 var leftColorAnim = new ColorAnimationUsingKeyFrames { RepeatBehavior = RepeatBehavior.Forever };
-                leftColorAnim.KeyFrames.Add(new DiscreteColorKeyFrame(solidWhite, KeyTime.FromTimeSpan(TimeSpan.Zero)));
-                leftColorAnim.KeyFrames.Add(new LinearColorKeyFrame(solidWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tWaitStart))));
-                leftColorAnim.KeyFrames.Add(new LinearColorKeyFrame(transparentWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tWaitStart) + fadeTime)));
-                leftColorAnim.KeyFrames.Add(new LinearColorKeyFrame(transparentWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tScrollBackEnd) - fadeTime)));
-                leftColorAnim.KeyFrames.Add(new LinearColorKeyFrame(solidWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tScrollBackEnd))));
-                leftColorAnim.KeyFrames.Add(new LinearColorKeyFrame(solidWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tTotalCycle))));
+                leftColorAnim.KeyFrames.Add(new DiscreteColorKeyFrame(isRightAligned ? transparentWhite : solidWhite, KeyTime.FromTimeSpan(TimeSpan.Zero)));
+                leftColorAnim.KeyFrames.Add(new LinearColorKeyFrame(isRightAligned ? transparentWhite : solidWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tWaitStart))));
+                leftColorAnim.KeyFrames.Add(new LinearColorKeyFrame(isRightAligned ? solidWhite : transparentWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tWaitStart) + fadeTime)));
+                leftColorAnim.KeyFrames.Add(new LinearColorKeyFrame(isRightAligned ? solidWhite : transparentWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tScrollBackEnd) - fadeTime)));
+                leftColorAnim.KeyFrames.Add(new LinearColorKeyFrame(isRightAligned ? transparentWhite : solidWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tScrollBackEnd))));
+                leftColorAnim.KeyFrames.Add(new LinearColorKeyFrame(isRightAligned ? transparentWhite : solidWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tTotalCycle))));
 
                 var rightColorAnim = new ColorAnimationUsingKeyFrames { RepeatBehavior = RepeatBehavior.Forever };
-                rightColorAnim.KeyFrames.Add(new DiscreteColorKeyFrame(transparentWhite, KeyTime.FromTimeSpan(TimeSpan.Zero)));
-                rightColorAnim.KeyFrames.Add(new LinearColorKeyFrame(transparentWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tScrollEnd) - fadeTime)));
-                rightColorAnim.KeyFrames.Add(new LinearColorKeyFrame(solidWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tScrollEnd))));
-                rightColorAnim.KeyFrames.Add(new LinearColorKeyFrame(solidWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tWaitEnd))));
-                rightColorAnim.KeyFrames.Add(new LinearColorKeyFrame(transparentWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tWaitEnd) + fadeTime)));
-                rightColorAnim.KeyFrames.Add(new LinearColorKeyFrame(transparentWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tTotalCycle))));
+                rightColorAnim.KeyFrames.Add(new DiscreteColorKeyFrame(isRightAligned ? solidWhite : transparentWhite, KeyTime.FromTimeSpan(TimeSpan.Zero)));
+                rightColorAnim.KeyFrames.Add(new LinearColorKeyFrame(isRightAligned ? solidWhite : transparentWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tScrollEnd) - fadeTime)));
+                rightColorAnim.KeyFrames.Add(new LinearColorKeyFrame(isRightAligned ? transparentWhite : solidWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tScrollEnd))));
+                rightColorAnim.KeyFrames.Add(new LinearColorKeyFrame(isRightAligned ? transparentWhite : solidWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tWaitEnd))));
+                rightColorAnim.KeyFrames.Add(new LinearColorKeyFrame(isRightAligned ? solidWhite : transparentWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tWaitEnd) + fadeTime)));
+                rightColorAnim.KeyFrames.Add(new LinearColorKeyFrame(isRightAligned ? solidWhite : transparentWhite, KeyTime.FromTimeSpan(TimeSpan.FromSeconds(tTotalCycle))));
 
                 cachedMask.GradientStops[0].BeginAnimation(GradientStop.ColorProperty, leftColorAnim);
                 cachedMask.GradientStops[3].BeginAnimation(GradientStop.ColorProperty, rightColorAnim);

--- a/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
@@ -127,6 +127,19 @@
                     <ComboBoxItem Content="{DynamicResource PositionBottomRight}" />
                 </ComboBox>
             </ui:CardControl>
+            <ui:CardControl x:Name="TaskbarWidgetCoverPositionTitleCard" Tag="Indexable" Icon="{ui:SymbolIcon ArrowMove24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource TaskbarWidgetCoverPositionTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource TaskbarWidgetCoverPositionDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <ComboBox SelectedIndex="{Binding TaskbarWidgetCoverPosition}" IsEnabled="{Binding IsPremiumUnlocked}">
+                    <ComboBoxItem Content="{DynamicResource PositionDefault}" />
+                    <ComboBoxItem Content="{DynamicResource PositionLeft}" />
+                    <ComboBoxItem Content="{DynamicResource PositionRight}" />
+                </ComboBox>
+            </ui:CardControl>
             <ui:CardControl x:Name="TaskbarWidgetSelectedMonitorTitleCard" Tag="Indexable" Grid.Row="5" Icon="{ui:SymbolIcon ProjectionScreen24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ar.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ar.xaml
@@ -215,6 +215,9 @@
     <system:String x:Key="TaskbarVisualizerAudioPeakLevelTitle">حد ذروة الصوت</system:String>
     <system:String x:Key="PositionLeft">اليسار</system:String>
     <system:String x:Key="PositionRight">اليمين</system:String>
+    <system:String x:Key="PositionDefault">الافتراضي</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">موضع صورة الألبوم</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">الافتراضي إلى اليسار. إذا تم تعيين موضع الأداة إلى أسفل اليمين، يكون الافتراضي إلى اليمين.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">موقع أزرار التحكم بالوسائط</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">اختر مكان عرض أزرار التحكم في الوسائط</system:String>
     <system:String x:Key="TaskbarVisualizerClickableTitle">إضغط لفتح الإعدادات</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ca.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ca.xaml
@@ -66,6 +66,9 @@ Oculta els botons de repetició, aleatori i la informació del reproductor</syst
     <system:String x:Key="TaskbarWidgetAutoHideDescription">Oculta automàticament el widget quan la reproducció es pausa</system:String>
     <system:String x:Key="TaskbarWidgetControlsTitle">Controls Multimèdia del Widget</system:String>
     <system:String x:Key="TaskbarWidgetControlsDescription">Mostra controls multimèdia al widget</system:String>
+    <system:String x:Key="PositionDefault">Predeterminat</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Posició de la caràtula</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Per defecte és a l'esquerra. Si la posició del widget està configurada a baix a la dreta, per defecte és a la dreta.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Posició de Controls Multimèdia</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Tria on vols mostrar els controls multimèdia</system:String>
     <system:String x:Key="PositionLeft">Esquerra</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-cs.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-cs.xaml
@@ -200,6 +200,9 @@ Poznámka: Jelikož se jedná o open-source projekt, jsou tyto funkce k dispozic
     <system:String x:Key="PositionRight">Vpravo</system:String>
     <system:String x:Key="TaskbarVisualizerOutputDeviceTitle">Výstupní zařízení</system:String>
     <system:String x:Key="TaskbarWidgetAutoHideTitle">Autoskrytí widgetu</system:String>
+    <system:String x:Key="PositionDefault">Výchozí</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Pozice obalu alba</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Výchozí hodnota je vlevo. Pokud je pozice widgetu nastavena vpravo dole, výchozí hodnota je vpravo.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Pozice média tlačítek</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Vybrat, kde zobrazovat média tlačítka</system:String>
     <system:String x:Key="LockKeysCursorUIDescription" xml:space="preserve">Vybrat monitor na kterém se bude zobrazovat flyout.</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-de.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-de.xaml
@@ -216,6 +216,9 @@ Du kannst helfen, die App zu übersetzen auf</system:String>
     <system:String x:Key="FailedToImportSettings">Einstellungen konnten nicht importiert werden. Prüfe das Dateiformat.</system:String>
     <system:String x:Key="PositionLeft">Links</system:String>
     <system:String x:Key="PositionRight">Rechts</system:String>
+    <system:String x:Key="PositionDefault">Standard</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Position des Albumcovers</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Standardmäßig links. Wenn die Widget-Position auf unten rechts eingestellt ist, ist die Standardeinstellung rechts.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Position der Mediensteuerung</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Wähle aus, wo die Mediensteuerung-Buttons angezeigt werden sollen</system:String>
     <system:String x:Key="TaskbarVisualizerClickableDescription">Beim klicken des Visualisierers wird die Einstellungsseite geöffnet</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -75,6 +75,9 @@ hides repeat, shuffle and player info</System:String>
     <System:String x:Key="TaskbarWidgetShowPauseOverlayDescription">When media is paused, display a pause icon over the album art</System:String>
     <System:String x:Key="TaskbarWidgetControlsTitle">Widget Media Controls</System:String>
     <System:String x:Key="TaskbarWidgetControlsDescription">Show media control buttons on the widget</System:String>
+    <System:String x:Key="PositionDefault">Default</System:String>
+    <System:String x:Key="TaskbarWidgetCoverPositionTitle">Album Art Position</System:String>
+    <System:String x:Key="TaskbarWidgetCoverPositionDescription">Default is left. If the widget position is set to bottom-right, default is right.</System:String>
     <System:String x:Key="TaskbarWidgetControlsPositionTitle">Media Controls Position</System:String>
     <System:String x:Key="TaskbarWidgetControlsPositionDescription">Choose where to display the media control buttons</System:String>
     <System:String x:Key="PositionLeft">Left</System:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-es.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-es.xaml
@@ -214,6 +214,9 @@ Nota: Como proyecto de código abierto, estas opciones también están disponibl
     <system:String x:Key="TaskbarVisualizerAudioPeakLevelDescription">Como de alto debe de ser el volumen para que las barras alcancen su altura máxima</system:String>
     <system:String x:Key="BackupRestoreSectionTitle">Copias de seguridad y restauración</system:String>
     <system:String x:Key="PositionRight">Derecha</system:String>
+    <system:String x:Key="PositionDefault">Predeterminado</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Posición de la carátula</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">De forma predeterminada queda a la izquierda. Si la posición del widget está configurada abajo a la derecha, queda a la derecha de forma predeterminada.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Posición de Controles Multimedia</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Elige donde quieres mostrar los controles multimedia</system:String>
     <system:String x:Key="PositionLeft">Izquierda</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-fi.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-fi.xaml
@@ -63,4 +63,7 @@ Huomaa: Koska kyseessä on avoimen lähdekoodin projekti, nämä toiminnot ovat 
     <system:String x:Key="PremiumPurchaseCancelled">Osto peruttu.</system:String>
     <system:String x:Key="HomeTitle">Koti</system:String>
     <system:String x:Key="Enabled">Käytössä</system:String>
+    <system:String x:Key="PositionDefault">Oletus</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Kansikuvan sijainti</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Oletus on vasemmalla. Jos widgetin sijainniksi on asetettu oikea alakulma, oletus on oikealla.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-fr.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-fr.xaml
@@ -197,6 +197,9 @@ Vous pouvez contribuer aux traductions sur</system:String>
     <system:String x:Key="TaskbarVisualizerOutputDeviceTitle">Périphérique de sortie</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutTitle">Fermer le menu déroulant au deuxième clique</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutDescription">Fermer le menu déroulant s'il est déjà ouvert lors du clique sur le widget dans la barre des tâches</system:String>
+    <system:String x:Key="PositionDefault">Par défaut</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Position de la pochette</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Par défaut, elle est à gauche. Si la position du widget est définie en bas à droite, elle est à droite par défaut.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Contrôle de la position des médias</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Choisir où afficher le bouton de contrôle des médias</system:String>
     <system:String x:Key="PositionLeft">Gauche</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-he.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-he.xaml
@@ -171,6 +171,9 @@
     <system:String x:Key="MediaFlyoutExcludeVolumeDescription">אל תציג את החלון הקופץ בעת לחיצה על הגברת/הנמכת עוצמה או השתקה</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutTitle">סגור את החלון הקופץ בלחיצה שנייה</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutDescription">סגור את החלון הקופץ אם הוא כבר פתוח בעת לחיצה על הווידג'ט בשורת המשימות</system:String>
+    <system:String x:Key="PositionDefault">ברירת מחדל</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">מיקום עטיפת האלבום</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">ברירת המחדל היא שמאלה. אם מיקום הווידג׳ט מוגדר לימין למטה, ברירת המחדל היא ימינה.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">מיקום פקדי המדיה</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">בחר היכן יוצגו פקדי המדיה</system:String>
     <system:String x:Key="PositionLeft">שמאל</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-hi.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-hi.xaml
@@ -209,6 +209,9 @@
     <system:String x:Key="FailedToImportSettings">सेटिंग्स आयात करने में विफल. विवरण के लिए लॉग जांचें।</system:String>
     <system:String x:Key="BackupRestoreSectionTitle">बैकअप लें और पुनर्स्थापित करें</system:String>
     <system:String x:Key="BackupRestoreCardTitle">बैकअप लें और अपनी सेटिंग्स पुनर्स्थापित करें</system:String>
+    <system:String x:Key="PositionDefault">डिफ़ॉल्ट</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">एल्बम आर्ट की स्थिति</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">डिफ़ॉल्ट बाईं ओर है। यदि विजेट की स्थिति नीचे-दाईं ओर सेट है, तो डिफ़ॉल्ट दाईं ओर है।</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">मीडिया नियंत्रण स्थिति</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">चुनें कि मीडिया नियंत्रण बटन कहाँ प्रदर्शित करना है</system:String>
     <system:String x:Key="PositionLeft">बाएं</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-hr.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-hr.xaml
@@ -51,6 +51,9 @@ nasumičnu reprodukciju i informacije o mediju</system:String>
     <system:String x:Key="TaskbarWidgetVisualIssuesWarning">Konfigurirajte postavke ispod ako Vam se pojavljuju vizualne poteškoće.</system:String>
     <system:String x:Key="TaskbarWidgetSelectedMonitorTitle">Target Zaslon za Widget</system:String>
     <system:String x:Key="TaskbarWidgetPosition">Pozicija Widgeta</system:String>
+    <system:String x:Key="PositionDefault">Zadano</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Položaj omota albuma</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Zadano je lijevo. Ako je položaj widgeta postavljen dolje desno, zadano je desno.</system:String>
     <system:String x:Key="TaskbarWidgetPaddingSettingsTitle">Postavke za Ispunjenje Widgeta</system:String>
     <system:String x:Key="TaskbarWidgetPaddingSettingsDescription">Prilagodi ispunjenje oko widgeta kako bi stalo Vašem stilu trake</system:String>
     <system:String x:Key="TaskbarWidgetPaddingTitle">Automatsko Ispunjenje za tipku za Windows Widgets</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-hu.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-hu.xaml
@@ -66,6 +66,9 @@ elrejti az ismétlés, keverés és lejátszó információkat</system:String>
     <system:String x:Key="TaskbarWidgetAutoHideDescription">Automatikusan elrejti a widgetet, amikor a média szünetel</system:String>
     <system:String x:Key="TaskbarWidgetControlsTitle">Widget Médiavezérlők</system:String>
     <system:String x:Key="TaskbarWidgetControlsDescription">Mutassa a médiavezérlő gombokat a widgeten</system:String>
+    <system:String x:Key="PositionDefault">Alapértelmezett</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Albumborító pozíciója</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Az alapértelmezett bal oldalt van. Ha a widget pozíciója jobb alsóra van állítva, az alapértelmezett jobb oldalt van.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Médiavezérlők pozíciója</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Válassza ki, hol jelenjenek meg a médiavezérlő gombok</system:String>
     <system:String x:Key="PositionLeft">Bal</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-id.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-id.xaml
@@ -181,6 +181,9 @@ Anda dapat membantu berkontribusi dalam menerjemahkan di</system:String>
     <system:String x:Key="TaskbarVisualizerBaselineTitle">Perlihatkan garis dasar</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutTitle">Tutup Flyout dalam Klik Detik</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutDescription">Tutup flyout jika sudah siap membuka ketika mengklik widget bilah tugas</system:String>
+    <system:String x:Key="PositionDefault">Default</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Posisi Sampul Album</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Default berada di kiri. Jika posisi widget diatur ke kanan bawah, default berada di kanan.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Posisi Kontrol Media</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Pilih dimana untuk menampilkan tombol kontrol media</system:String>
     <system:String x:Key="PositionLeft">Kiri</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-it.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-it.xaml
@@ -213,6 +213,9 @@ Puoi contribuire alla traduzione su</system:String>
     <system:String x:Key="SettingsImportedSuccessfully">Impostazioni importate con successo! L'applicazione si riavvierà per applicare i cambiamenti.</system:String>
     <system:String x:Key="ImportSettingsWarning">Questo sostituirà tutte le impostazioni attuali. Continuare?</system:String>
     <system:String x:Key="FailedToImportSettings">Importazione delle impostazioni fallita. Controlla i log per dettagli.</system:String>
+    <system:String x:Key="PositionDefault">Predefinito</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Posizione copertina album</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Il valore predefinito è a sinistra. Se la posizione del widget è impostata in basso a destra, il valore predefinito è a destra.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Posizione Controlli Multimediali</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Scegli dove mostrare i pulsanti di controllo multimediale</system:String>
     <system:String x:Key="PositionLeft">A sinistra</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ja.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ja.xaml
@@ -205,6 +205,9 @@
     <system:String x:Key="TaskbarWidgetAutoHideDescription">メディアが停止している間はウィジェットを非表示にします</system:String>
     <system:String x:Key="TaskbarWidgetShowPauseOverlayDescription">メディアが停止されたときに、アルバムアートの上に一時停止ボタンを表示します</system:String>
     <system:String x:Key="TaskbarWidgetShowPauseOverlayTitle">一時停止アイコンオーバーレイを表示</system:String>
+    <system:String x:Key="PositionDefault">既定</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">アルバムアートの位置</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">既定では左側です。ウィジェットの位置が右下に設定されている場合、既定では右側になります。</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">メディア操作位置</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">メディア操作ボタンを表示する位置を選択</system:String>
     <system:String x:Key="PositionLeft">左</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ko.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ko.xaml
@@ -141,6 +141,9 @@
     <system:String x:Key="TaskbarVisualizerBarCountDescription">비주얼라이저에 표시되는 바의 개수 설정</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutTitle">두 번 클릭하여 Flyout 닫기</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutDescription">Flyout이 열려 있을 때 작업 표시줄 위젯을 클릭하여 닫기</system:String>
+    <system:String x:Key="PositionDefault">기본값</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">앨범 아트 위치</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">기본값은 왼쪽입니다. 위젯 위치가 오른쪽 아래로 설정되어 있으면 기본값은 오른쪽입니다.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">미디어 컨트롤 위치</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">미디어 컨트롤 버튼을 표시할 위치를 선택</system:String>
     <system:String x:Key="PositionLeft">왼쪽</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-nl.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-nl.xaml
@@ -91,6 +91,9 @@ verbergt herhalen, shuffle en spelerinfo</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Weergaveduur van ‘Volgende’</system:String>
     <system:String x:Key="TaskbarWidgetManualPaddingTitle">Aangepaste Opvulling</system:String>
     <system:String x:Key="TaskbarWidgetManualPaddingDescription">Voeg extra opvulling toe (standaard: 0px)</system:String>
+    <system:String x:Key="PositionDefault">Standaard</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Positie albumhoes</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Standaard links. Als de widgetpositie is ingesteld op rechtsonder, is standaard rechts.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Mediaknoppen positie</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Bepaal waar de mediaknoppen worden weergegeven</system:String>
     <system:String x:Key="PositionLeft">Links</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-pl.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-pl.xaml
@@ -210,6 +210,9 @@ Możesz pomóc w tworzeniu tłumaczeń na stronie</system:String>
     <system:String x:Key="FailedToImportSettings">Nie udało się zaimportować ustawień. Sprawdź dziennik zdarzeń, aby zobaczyć szczegóły.</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutTitle">Zamknij Flyout klikając dwa razy</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutDescription">Zamknij flyout jeżeli jest już otwarty po kliknięciu w widget na pasku zadań</system:String>
+    <system:String x:Key="PositionDefault">Domyślne</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Pozycja okładki albumu</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Domyślnie po lewej. Jeśli pozycja widżetu jest ustawiona na prawy dolny róg, domyślnie jest po prawej.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Pozycja Kontroli Mediów</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Wybierz gdzie wyświetlać przyciski kontroli mediów</system:String>
     <system:String x:Key="PositionLeft">Lewo</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-pt-BR.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-pt-BR.xaml
@@ -213,6 +213,9 @@ Nota: Como um projeto de código aberto, esses recursos também estão disponív
     <system:String x:Key="SettingsImportedSuccessfully">Configurações importadas com sucesso! O aplicativo será reiniciado agora para aplicar as alterações.</system:String>
     <system:String x:Key="ImportSettingsWarning">Isso substituirá todas as suas configurações atuais. Continuar?</system:String>
     <system:String x:Key="FailedToImportSettings">Falha ao importar as configurações. Verifique os logs para mais detalhes.</system:String>
+    <system:String x:Key="PositionDefault">Padrão</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Posição da capa do álbum</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">O padrão fica à esquerda. Se a posição do widget estiver definida como canto inferior direito, o padrão fica à direita.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Posição dos controles de mídia</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Escolha onde mostrar os botões de controle de mídia</system:String>
     <system:String x:Key="PositionLeft">Esquerda</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ru.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ru.xaml
@@ -213,6 +213,9 @@
     <system:String x:Key="SettingsImportedSuccessfully">Настройки успешно импортированы! Приложение перезапустится для применения изменений.</system:String>
     <system:String x:Key="ImportSettingsWarning">Это заменит все ваши текущие настройки. Продолжить?</system:String>
     <system:String x:Key="FailedToImportSettings">Не удалось импортировать настройки. Подробнее в журнале.</system:String>
+    <system:String x:Key="PositionDefault">По умолчанию</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Положение обложки альбома</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">По умолчанию слева. Если положение виджета задано как внизу справа, по умолчанию будет справа.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Позиция медиакнопок</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Выберите, где отображать медиакнопки</system:String>
     <system:String x:Key="PositionLeft">Слева</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-si.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-si.xaml
@@ -14,4 +14,7 @@
     <system:String x:Key="BackgroundBlurOption2" xml:space="preserve"> Cover එක දිලිසෙන (Style 1)</system:String>
     <system:String x:Key="BackgroundBlurOption3" xml:space="preserve"> ඉර පායනවා වගේ දිලිසෙන (Style 2)</system:String>
     <system:String x:Key="BackgroundBlurOption4" xml:space="preserve"> බොඳ වුන (Style 3)</system:String>
+    <system:String x:Key="PositionDefault">පෙරනිමි</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">ඇල්බම කවරයේ ස්ථානය</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">පෙරනිමිය වම් පැත්තේය. විජට් ස්ථානය පහළ දකුණ ලෙස සකසා ඇත්නම්, පෙරනිමිය දකුණේය.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-sk.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-sk.xaml
@@ -86,6 +86,9 @@ skrýva informácie o opakovaní, náhodnom prehrávaní a prehrávači</system:
     <system:String x:Key="TaskbarVisualizerAudioPeakLevelDescription">Aký hlasný musí byť zvuk, aby stĺpce dosiahli svoju maximálnu výšku</system:String>
     <system:String x:Key="TaskbarVisualizerOutputDeviceTitle">Výstupné Zariadenie</system:String>
     <system:String x:Key="TaskbarVisualizerOutputDeviceDescription">Zmeňte, čo vizualizér počúva, prepnutím výstupného zariadenia FluentFlyout.</system:String>
+    <system:String x:Key="PositionDefault">Predvolené</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Pozícia obalu albumu</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Predvolene je vľavo. Ak je pozícia widgetu nastavená vpravo dole, predvolene je vpravo.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Pozícia Ovládania Médií</system:String>
     <system:String x:Key="TaskbarVisualizerClickableTitle">Kliknutím otvoríte Nastavenia</system:String>
     <system:String x:Key="TaskbarVisualizerClickableDescription">Kliknutím na vizualizér sa otvorí jeho stránka s nastaveniami</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ta.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ta.xaml
@@ -42,4 +42,7 @@
     <system:String x:Key="LockWindow_NumLock">நம் லாக்</system:String>
     <system:String x:Key="LockWindow_ScrollLock">ஸ்க்ரோல் லாக்</system:String>
     <system:String x:Key="LockWindow_InsertPressed">இன்சர்ட் அழுத்தப்பட்டது</system:String>
+    <system:String x:Key="PositionDefault">இயல்பு</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">ஆல்பம் அட்டையின் நிலை</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">இயல்பாக இடப்புறம். விட்ஜெட் நிலை கீழ் வலப்புறமாக அமைக்கப்பட்டிருந்தால், இயல்பாக வலப்புறம் இருக்கும்.</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-th.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-th.xaml
@@ -50,4 +50,7 @@
     <system:String x:Key="PauseOtherMediaTitle">หยุดสื่อที่เล่นอยู่ก่อนหน้านี้อัตโนมัติ</system:String>
     <system:String x:Key="PauseOtherMediaDescription">เมื่อคุณเล่นสื่อตัวใหม่ สื่ออื่นๆที่เคยเล่นอยู่จะถูกหยุดโดยอัตโนมัติ</system:String>
     <system:String x:Key="TaskbarWidgetCustomizationTitle">Widget ของ Taskbar</system:String>
+    <system:String x:Key="PositionDefault">ค่าเริ่มต้น</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">ตำแหน่งภาพปกอัลบั้ม</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">ค่าเริ่มต้นอยู่ทางซ้าย หากตั้งค่าตำแหน่งวิดเจ็ตเป็นมุมขวาล่าง ค่าเริ่มต้นจะอยู่ทางขวา</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-tr.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-tr.xaml
@@ -203,6 +203,9 @@ Not: Açık kaynaklı bir proje olduğundan, bu özellikler GitHub'daki manuel y
     <system:String x:Key="TaskbarWidgetAutoHideDescription">Medya duraklatıldığında widget'ı otomatik gizler</system:String>
     <system:String x:Key="TaskbarWidgetShowPauseOverlayTitle">Duraklatma simgesini göster</system:String>
     <system:String x:Key="TaskbarWidgetShowPauseOverlayDescription">Medya duraklatıldığında albüm kapağı üzerinde duraklat simgesini göster</system:String>
+    <system:String x:Key="PositionDefault">Varsayılan</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Albüm Kapağı Konumu</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Varsayılan soldadır. Widget konumu sağ alt olarak ayarlanırsa varsayılan sağdadır.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Medya Denetimleri Konumu</system:String>
     <system:String x:Key="TaskbarVisualizerCenteredBarsTitle">Ortalanmış Ses Çubukları</system:String>
     <system:String x:Key="TaskbarVisualizerCenteredBarsDescription">Alt kısımdan yükselmek yerine merkezden simetrik olarak genişleyen çubuklar</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-uk.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-uk.xaml
@@ -111,6 +111,9 @@
     <system:String x:Key="TaskbarWidgetCloseableFlyoutTitle">Закривати впливаючі вікна подвійним натисканням</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutDescription">Закриваи вспливаюче вікно, якщо воно вже відкрите, натисканням на панель завдань</system:String>
     <system:String x:Key="TaskbarWidgetControlsDescription">Показувати кнопки керування на віджеті</system:String>
+    <system:String x:Key="PositionDefault">За замовчуванням</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Положення обкладинки альбому</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">За замовчуванням ліворуч. Якщо положення віджета встановлено внизу праворуч, за замовчуванням буде праворуч.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Позиція кнопок керування</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Де розташувати кнопки керування</system:String>
     <system:String x:Key="PositionLeft">Зліва</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-vi.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-vi.xaml
@@ -212,6 +212,9 @@ Lưu ý: Vì đây là một dự án mã nguồn mở, các tính năng này c�
     <system:String x:Key="FailedToExportSettings">Để biết thêm chi tiết, hãy nhấn chuột phải vào biểu tượng khay hệ thống và mở folder nhật ký.</system:String>
     <system:String x:Key="ImportSettingsWarning">Sắp áp dụng thay đổi. Có tiếp tục không?</system:String>
     <system:String x:Key="FailedToImportSettings">Để biết thêm chi tiết, hãy nhấn chuột phải vào biểu tượng khay hệ thống và mở folder nhật ký.</system:String>
+    <system:String x:Key="PositionDefault">Mặc định</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">Vị trí ảnh bìa album</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">Mặc định ở bên trái. Nếu vị trí widget được đặt ở góc dưới bên phải, mặc định ở bên phải.</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">Vị trí các nút điều khiển</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">Vị trí các nút điều khiển</system:String>
     <system:String x:Key="PositionLeft">Trái</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-zh-CN.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-zh-CN.xaml
@@ -209,6 +209,9 @@
     <system:String x:Key="ImportSuccessful">导入成功</system:String>
     <system:String x:Key="ImportFailed">导入失败</system:String>
     <system:String x:Key="SettingsExportedSuccessfully">设置导出成功！</system:String>
+    <system:String x:Key="PositionDefault">默认</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">封面位置</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">默认靠左，如果小组件位置设置为右下角，则默认靠右。</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">媒体控制按键位置</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">选择媒体控制按钮在小组件内的显示位置</system:String>
     <system:String x:Key="BackupRestoreCardTitle">将你的设置进行备份和恢复</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-zh-TW.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-zh-TW.xaml
@@ -176,6 +176,9 @@
     <system:String x:Key="TaskbarVisualizerBarCountTitle">長條數量</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutTitle">第二次點擊時關閉浮動視窗</system:String>
     <system:String x:Key="TaskbarWidgetCloseableFlyoutDescription">若在點擊工作列小工具時浮出視窗已開啟，則將其關閉</system:String>
+    <system:String x:Key="PositionDefault">預設</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionTitle">封面位置</system:String>
+    <system:String x:Key="TaskbarWidgetCoverPositionDescription">預設靠左，如果小工具位置設定為右下角，則預設靠右。</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionTitle">媒體控制項位置</system:String>
     <system:String x:Key="TaskbarWidgetControlsPositionDescription">選擇媒體控制鈕的顯示位置</system:String>
     <system:String x:Key="PositionLeft">靠左</system:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -379,6 +379,12 @@ public partial class UserSettings : ObservableObject
     public partial int TaskbarWidgetPosition { get; set; }
 
     /// <summary>
+    /// Position of the taskbar widget cover image. 0: Default, 1: Left, 2: Right
+    /// </summary>
+    [ObservableProperty]
+    public partial int TaskbarWidgetCoverPosition { get; set; }
+
+    /// <summary>
     /// Determines whether padding should be applied to the taskbar widget for the native Windows Widgets button
     /// </summary>
     [ObservableProperty]
@@ -743,6 +749,7 @@ public partial class UserSettings : ObservableObject
         TaskbarWidgetEnabled = false;
         TaskbarWidgetSelectedMonitor = 0;
         TaskbarWidgetPosition = 0;
+        TaskbarWidgetCoverPosition = 0;
         TaskbarWidgetPadding = true;
         TaskbarWidgetManualPadding = 0;
         TaskbarWidgetBackgroundBlur = false;
@@ -895,7 +902,19 @@ public partial class UserSettings : ObservableObject
     partial void OnTaskbarWidgetPositionChanged(int oldValue, int newValue)
     {
         if (oldValue == newValue || _initializing) return;
+        if (TaskbarWidgetCoverPosition == 0)
+        {
+            UpdateTaskbarWidgetLayout();
+            return;
+        }
+
         UpdateTaskbar();
+    }
+
+    partial void OnTaskbarWidgetCoverPositionChanged(int oldValue, int newValue)
+    {
+        if (oldValue == newValue || _initializing) return;
+        UpdateTaskbarWidgetLayout();
     }
 
     partial void OnTaskbarWidgetManualPaddingChanged(int oldValue, int newValue)
@@ -938,8 +957,7 @@ public partial class UserSettings : ObservableObject
     {
         if (oldValue == newValue || _initializing) return;
 
-        MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
-        mainWindow.taskbarWindow?.Widget?.ReorderControls();
+        UpdateTaskbarWidgetLayout();
     }
 
     partial void OnTaskbarVisualizerPositionChanged(int oldValue, int newValue)
@@ -957,6 +975,18 @@ public partial class UserSettings : ObservableObject
     private void UpdateTaskbar()
     {
         MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
+        mainWindow.UpdateTaskbar();
+    }
+
+    private void UpdateTaskbarWidgetLayout()
+    {
+        MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
+        var widget = mainWindow.taskbarWindow?.Widget;
+        if (widget != null)
+        {
+            widget.Dispatcher.Invoke(widget.ReorderControls);
+        }
+
         mainWindow.UpdateTaskbar();
     }
 


### PR DESCRIPTION
Adds a cover position setting for the taskbar widget: Default, Left, and Right.

Default keeps the cover on the left unless the widget position is bottom-right. When the cover is on the right, the title and artist text are right-aligned.

<img width="355" height="91" alt="image" src="https://github.com/user-attachments/assets/473c15bc-1c80-42a3-ac1d-d1c24b052912" />

<img width="900" height="700" alt="image" src="https://github.com/user-attachments/assets/4fa86366-b82b-44a9-9f36-dd37a9559086" />

AI tools were used.