### PR TITLE
Customize Next Up flyout

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -482,9 +482,14 @@ public partial class MainWindow : MicaWindow
         return SettingsManager.Current.VolumeControlEnabled && SettingsManager.Current.VolumeControlAboveMediaFlyout ? 16 : 80;
     }
 
-    private (double left, double top) GetFinalPosition(Rect windowRect, Rect workArea, bool reserveNativeVolumeOsdSpace = false)
+    private static int NormalizeFlyoutPosition(int position)
     {
-        int position = SettingsManager.Current.Position;
+        return position is >= 0 and <= 5 ? position : 0;
+    }
+
+    private (double left, double top) GetFinalPosition(Rect windowRect, Rect workArea, bool reserveNativeVolumeOsdSpace = false, int? positionOverride = null)
+    {
+        int position = NormalizeFlyoutPosition(positionOverride ?? SettingsManager.Current.Position);
         double left = position switch
         {
             0 or 3 => workArea.Left + 16,
@@ -500,7 +505,7 @@ public partial class MainWindow : MicaWindow
         return (left, top);
     }
 
-    public void OpenAnimation(MicaWindow window, bool alwaysBottom = false, MonitorInfo? selectedMonitor = null, MicaWindow? aboveReference = null, bool reserveNativeVolumeOsdSpace = false)
+    public void OpenAnimation(MicaWindow window, bool alwaysBottom = false, MonitorInfo? selectedMonitor = null, MicaWindow? aboveReference = null, bool reserveNativeVolumeOsdSpace = false, int? positionOverride = null)
     {
         var eventTriggers = window.Triggers[0] as EventTrigger;
         var beginStoryboard = eventTriggers.Actions[0] as BeginStoryboard;
@@ -509,6 +514,7 @@ public partial class MainWindow : MicaWindow
         DoubleAnimation moveAnimation = (DoubleAnimation)storyboard.Children[0];
         var monitor = selectedMonitor != null ? selectedMonitor.Value : getSelectedMonitor();
         var workArea = monitor.workArea;
+        int position = NormalizeFlyoutPosition(positionOverride ?? SettingsManager.Current.Position);
 
         // prevent flickering
         WindowHelper.SetVisibility(window, false); // window.Visibility = Visibility.Hidden works with some delay
@@ -526,11 +532,11 @@ public partial class MainWindow : MicaWindow
             double refWidth = aboveReference.Width * monitor.dpiX / 96.0;
             double refHeight = aboveReference.Height * monitor.dpiY / 96.0;
             var refRect = new Rect(0, 0, refWidth, refHeight);
-            var (refLeft, refTop) = GetFinalPosition(refRect, workArea, reserveNativeVolumeOsdSpace);
+            var (refLeft, refTop) = GetFinalPosition(refRect, workArea, reserveNativeVolumeOsdSpace, position);
 
             window_left = refLeft + refWidth / 2 - windowRect.Width / 2;
             double aboveTop = refTop - windowRect.Height - 8;
-            bool isTop = SettingsManager.Current.Position switch
+            bool isTop = position switch
             {
                 3 or 4 or 5 => true,
                 _ => false
@@ -549,7 +555,7 @@ public partial class MainWindow : MicaWindow
         // default behavior: position the flyout based on the user's settings
         else if (alwaysBottom == false)
         {
-            _position = SettingsManager.Current.Position;
+            _position = position;
             if (_position == 0)
             {
                 window_left = workArea.Left + 16;

--- a/FluentFlyoutWPF/Pages/NextUpPage.xaml
+++ b/FluentFlyoutWPF/Pages/NextUpPage.xaml
@@ -21,6 +21,8 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <StackPanel Orientation="Horizontal" Margin="0,0,0,24">
                 <Border CornerRadius="10" ClipToBounds="True" Width="164" Height="98">
@@ -39,7 +41,22 @@
                 </ui:CardControl.Header>
                 <ui:ToggleSwitch Name="NextUpSwitch" IsChecked="{Binding NextUpEnabled, Mode=TwoWay}" />
             </ui:CardControl>
-            <ui:CardControl x:Name="NextUpStayDurationTitleCard" Tag="Indexable" Grid.Row="3" Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,76">
+            <ui:CardControl x:Name="NextUpPositionTitleCard" Tag="Indexable" Grid.Row="2" Icon="{ui:SymbolIcon ArrowMove24}" Margin="0,0,0,12">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource NextUpPositionTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <ComboBox Name="NextUpPositionComboBox" SelectedIndex="{Binding NextUpPosition, Mode=TwoWay}">
+                    <ComboBoxItem Content="{DynamicResource PositionBottomLeft}" />
+                    <ComboBoxItem Content="{DynamicResource PositionBottomCenter}" />
+                    <ComboBoxItem Content="{DynamicResource PositionBottomRight}" />
+                    <ComboBoxItem Content="{DynamicResource PositionTopLeft}" />
+                    <ComboBoxItem Content="{DynamicResource PositionTopCenter}" />
+                    <ComboBoxItem Content="{DynamicResource PositionTopRight}" />
+                </ComboBox>
+            </ui:CardControl>
+            <ui:CardControl x:Name="NextUpStayDurationTitleCard" Tag="Indexable" Grid.Row="3" Icon="{ui:SymbolIcon Timer24}" Margin="0,0,0,3">
                 <ui:CardControl.Header>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{DynamicResource NextUpStayDurationTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
@@ -50,6 +67,23 @@
                     <ui:TextBox Name="NextUpDurationTextBox" Width="60" ClearButtonEnabled="False" Text="{Binding NextUpDurationText, Mode=TwoWay}" />
                     <TextBlock Text="{DynamicResource MillisecondsUnit}" FontSize="14" FontWeight="Regular" Margin="10,0,0,0" VerticalAlignment="Center" />
                 </StackPanel>
+            </ui:CardControl>
+            <ui:CardControl x:Name="NextUpCenterTitleArtistTitleCard" Tag="Indexable" Grid.Row="4" Icon="{ui:SymbolIcon AlignLeft24}" Margin="0,0,0,3">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource NextUpCenterTitleArtistTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <ui:ToggleSwitch Name="NextUpCenterTitleArtistSwitch" IsChecked="{Binding NextUpCenterTitleArtist, Mode=TwoWay}" />
+            </ui:CardControl>
+            <ui:CardControl x:Name="NextUpShowUpNextTextTitleCard" Tag="Indexable" Grid.Row="5" Icon="{ui:SymbolIcon Subtitles24}" Margin="0,0,0,76">
+                <ui:CardControl.Header>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{DynamicResource NextUpShowUpNextTextTitle}" FontSize="14" FontWeight="Regular" VerticalAlignment="Center" />
+                        <TextBlock Text="{DynamicResource NextUpShowUpNextTextDescription}" FontSize="12" Opacity="0.5" />
+                    </StackPanel>
+                </ui:CardControl.Header>
+                <ui:ToggleSwitch Name="NextUpShowUpNextTextSwitch" IsChecked="{Binding NextUpShowUpNextText, Mode=TwoWay}" />
             </ui:CardControl>
         </Grid>
     </StackPanel>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ar.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ar.xaml
@@ -44,6 +44,10 @@
     <system:String x:Key="EnableNextUpDescription">يُظهر ما التالي بعد انتهاء الأغنية/الفيديو</system:String>
     <system:String x:Key="NextUpStayDurationTitle">مدة ظهور إشعار الوسائط التالية</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(الافتراضي: 2000 مللي ثانية)</system:String>
+    <system:String x:Key="NextUpPositionTitle">موقع أداة التحكم</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">توسيط العنوان والفنان</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">إظهار التسمية</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">يعرض تسمية التالي قبل معلومات الأغنية</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">إشعار مفاتيح القفل</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">تحقق من حالة مفتاح القفل بنظرة واحدة. يظهر بعد الضغط على Caps Lock أو Num Lock أو Scroll Lock. مناسب لأجهزة الكمبيوتر المحمولة/لوحات المفاتيح التي لا تحتوي على مؤشرات مفاتيح القفل.</system:String>
     <system:String x:Key="EnableLockKeysTitle">تفعيل مفاتيح القفل المنبثقة</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ca.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ca.xaml
@@ -113,6 +113,10 @@ Nota: Com a projecte de codi obert, aquestes opcions també estan disponibles de
     <system:String x:Key="EnableNextUpDescription">Mostra el que ve quan s'acaba una cançó/vídeo</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Duració de Següent</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(per defecte: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Posició del Flyout</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Centrar títol i artista</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Mostra l&apos;etiqueta</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Mostra l&apos;etiqueta Següent abans de la informació de la cançó</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">Flyout de Tecles de Bloqueig</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">Revisa l'estat de les tecles de bloqueig d'una ullada. Apareix en prémer Bloq Maj, Bloq Num o Bloq Despl. Útil per a portàtils/teclats sense indicadors de tecles de bloqueig.</system:String>
     <system:String x:Key="EnableLockKeysTitle">Activar Flyout de Tecles de Bloqueig</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-cs.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-cs.xaml
@@ -46,6 +46,10 @@ skryje opakování,náhodné přehrávání a informace přehrávače</system:St
     <system:String x:Key="EnableNextUpDescription">Ukáže, jaká skladba následuje po konci písničky/videa</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Zmizení Další skladby</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(výchozí: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Pozice plovoucího přehrávače</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Vycentrovat název písničky a autora</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Zobrazit štítek</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Zobrazí štítek Další na řadě před informacemi o skladbě</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">Okno Lock Keys</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">Zkontrolujte stav Lock key na první pohled. Zobrazí se po stisknutí klávesy Caps Lock, Num Lock nebo Scroll Lock. Praktické pro notebooky/klávesnice bez indikátorů klávesy Lock.</system:String>
     <system:String x:Key="EnableLockKeysTitle">Povolit plovoucí okno Lock Keys</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-de.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-de.xaml
@@ -75,6 +75,10 @@ Anmerkung: Als Open-Source-Projekt sind diese Funktionen auch kostenlos verfügb
     <system:String x:Key="EnableNextUpDescription">Zeigt, welcher Song/Video als nächste abgespielt wird, wenn ein Song/Video endet</system:String>
     <system:String x:Key="NextUpStayDurationTitle">"Als nächstes" Anzeigedauer</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(standardmäßig: 3000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Position des Flyouts</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Titel und Künstler zentrieren</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Label anzeigen</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Zeigt das Label Als Nächstes vor den Songinformationen an</system:String>
     <system:String x:Key="EnableLockKeysDescription">Zeigt an, wenn eine bestimmte Tastensperre aktiv ist oder nicht</system:String>
     <system:String x:Key="LockKeysStayDurationTitle">Tastensperre Anzeigedauer</system:String>
     <system:String x:Key="LockKeysStayDurationDescription">(standardmäßig: 3000 ms)</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -126,6 +126,10 @@ Note: As an open-source project, these features are also available for free via 
     <System:String x:Key="EnableNextUpDescription">Shows what's next when a song/video ends</System:String>
     <System:String x:Key="NextUpStayDurationTitle">Next Up Stay Duration</System:String>
     <System:String x:Key="NextUpStayDurationDescription">(default: 2000 ms)</System:String>
+    <System:String x:Key="NextUpPositionTitle">Flyout Position</System:String>
+    <System:String x:Key="NextUpCenterTitleArtistTitle">Center Title and Artist</System:String>
+    <System:String x:Key="NextUpShowUpNextTextTitle">Show Label</System:String>
+    <System:String x:Key="NextUpShowUpNextTextDescription">Show the Up next label before the song info</System:String>
     <System:String x:Key="LockKeysCustomizationTitle">Lock Keys Flyout</System:String>
     <System:String x:Key="LockKeysDescription" xml:space="preserve">Check your lock key status at a glance. Appears after pressing Caps Lock, Num Lock or Scroll Lock. Convenient for laptops/keyboards without lock key indicators.</System:String>
     <System:String x:Key="EnableLockKeysTitle">Enable Lock Keys Flyout</System:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-es.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-es.xaml
@@ -41,6 +41,10 @@ oculta los botones de repetir y aleatorio y la información del reproductor</sys
     <system:String x:Key="EnableNextUpDescription">Muestra lo que viene cuando acaba una canción/video</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Duración de Siguiente</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(por defecto: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Posición del Flyout</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Centrar Título y Artista</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Mostrar etiqueta</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Muestra la etiqueta A continuación antes de la información de la canción</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">Flyout de Teclas de Bloqueo</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">Revisa el estado de las teclas de bloqueo de un vistazo. Aparece al pulsar Bloq Mayús, Bloq Num o Bloq Despl. Útil para portátiles/teclados sin indicadores de teclas de bloqueo.</system:String>
     <system:String x:Key="EnableLockKeysTitle">Activar Flyout de Teclas de Bloqueo</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-fi.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-fi.xaml
@@ -63,4 +63,8 @@ Huomaa: Koska kyseessä on avoimen lähdekoodin projekti, nämä toiminnot ovat 
     <system:String x:Key="PremiumPurchaseCancelled">Osto peruttu.</system:String>
     <system:String x:Key="HomeTitle">Koti</system:String>
     <system:String x:Key="Enabled">Käytössä</system:String>
+    <system:String x:Key="NextUpPositionTitle">Flyoutin Sijainti</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Keskitä Kappaleen Nimi ja Artisti</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Näytä tunniste</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Näyttää Seuraavaksi-tunnisteen kappaletietojen edessä</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-fr.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-fr.xaml
@@ -69,6 +69,10 @@ Note : En tant que projet open source, ces fonctionnalités sont également dis
     <system:String x:Key="EnableNextUpDescription">Affiche ce qui suit la fin d'une chanson/vidéo</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Prochaine étape Durée du séjour</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(par défaut : 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Position du volet</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Centrer le titre et l&apos;artiste</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Afficher le libellé</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Affiche le libellé À suivre avant les informations du morceau</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">Volet des touches de verrouillage</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">Vérifiez en un coup d'œil l'état de vos touches de verrouillage. S'affiche après avoir appuyé sur Verr. Maj., Verr. Num. ou Arrêt défil. Pratique pour les ordinateurs portables et les claviers sans indicateur de verrouillage.</system:String>
     <system:String x:Key="EnableLockKeysTitle">Activer le menu déroulant des touches de verrouillage</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-he.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-he.xaml
@@ -105,6 +105,10 @@
     <system:String x:Key="NextUpCustomizationTitle">חלון נשלף הבא</system:String>
     <system:String x:Key="NextUpStayDurationTitle">משך הצגה הבאה</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(ברירת מחדל: 2000 מילישניות.)</system:String>
+    <system:String x:Key="NextUpPositionTitle">מיקום החלון הנשלף</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">מרכז את הכותרת והאמן</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">הצג תווית</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">מציג את תווית הבא בתור לפני פרטי השיר</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">חלון נשלף של מקשי נעילה</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">בדוק את מצב מקשי הנעילה במבט חטוף. מופיע לאחר לחיצה על Caps Lock, Num Lock או Scroll Lock. נוח למחשבים ניידים ומקלדות ללא מנורות מצב למקשי הנעילה.</system:String>
     <system:String x:Key="EnableLockKeysTitle">הפעל את חלון נשלף של נעילת מקשים</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-hi.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-hi.xaml
@@ -53,6 +53,10 @@
     <system:String x:Key="EnableNextUpDescription">जब कोई गीत/वीडियो समाप्त होता है तो दिखाता है कि आगे क्या है</system:String>
     <system:String x:Key="NextUpStayDurationTitle">अगले ऊपर रहने की अवधि</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(डिफ़ॉल्ट: 2000 एमएस)</system:String>
+    <system:String x:Key="NextUpPositionTitle">फ्लाईआउट स्थिति</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">केंद्र शीर्षक और कलाकार</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">लेबल दिखाएँ</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">गीत की जानकारी से पहले नेक्स्ट अप लेबल दिखाता है</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">लॉक कीज़ फ़्लाईआउट</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">एक नज़र में अपने ताले की कुंजी की स्थिति जांचें। कैप्स लॉक, न्यूम लॉक या स्क्रॉल लॉक दबाने के बाद दिखाई देता है। बिना लॉक कुंजी संकेतक वाले लैपटॉप/कीबोर्ड के लिए सुविधाजनक।</system:String>
     <system:String x:Key="EnableLockKeysTitle">लॉक कुंजी फ़्लाईआउट सक्षम करें</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-hr.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-hr.xaml
@@ -60,4 +60,8 @@ nasumičnu reprodukciju i informacije o mediju</system:String>
     <system:String x:Key="TaskbarWidgetBackgroundBlurTitle">Pozadinsko Zamućenje</system:String>
     <system:String x:Key="TaskbarWidgetBackgroundBlurDescription">Dodaj efekt pozadinskog zamućenja widgetu za traku</system:String>
     <system:String x:Key="TaskbarWidgetHideCompletelyTitle">Kompletno Sakrij Kada Nema Nikakvog Medija</system:String>
+    <system:String x:Key="NextUpPositionTitle">Pozicija iskočnog prozora</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Centriraj naslov i izvođača</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Prikaži oznaku</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Prikazuje oznaku Sljedeće prije informacija o pjesmi</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-hu.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-hu.xaml
@@ -113,6 +113,10 @@ Megjegyzés: Mivel ez egy nyílt forráskódú projekt, ezek a funkciók ingyene
     <system:String x:Key="EnableNextUpDescription">Megmutatja, mi következik, amikor egy dal/videó véget ér</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Következő Flyout ablak megjelenítési ideje</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(alapértelmezett: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Flyout pozíció</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Cím és előadó középre igazítása</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Címke megjelenítése</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Megjeleníti a Következő címkét a dal adatai előtt</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">Billentyűzár Flyout</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">Ellenőrizze a billentyűzárak állapotát egy pillantással. A Caps Lock, Num Lock vagy Scroll Lock megnyomása után jelenik meg. Kényelmes laptopokhoz/billentyűzetekhez, amelyek nem rendelkeznek zárjelzőkkel.</system:String>
     <system:String x:Key="EnableLockKeysTitle">Billentyűzár Flyout engedélyezése</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-id.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-id.xaml
@@ -68,6 +68,10 @@ Catatan: Sebagai proyek open-source, fitur-fitur ini juga tersedia secara gratis
     <system:String x:Key="EnableNextUpDescription">Tampilkan apa selanjutnya apabila lagu/video berakhir</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Durasi Flyout Berikutnya</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(default: 2000 milidetik)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Posisi Flyout</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Judul dengan Nama Artis ditengah</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Tampilkan label</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Menampilkan label Berikutnya sebelum info lagu</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">Tombol Kunci Flyout</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">Periksa status kunci pengunci Anda sekilas pandang. Tampil setelah menekan Caps Lock, Num Lock, atau Scroll Lock. Praktis untuk laptop/keyboard yang tidak dilengkapi indikator lampu kunci pengunci.</system:String>
     <system:String x:Key="EnableLockKeysTitle">Aktifkan Tombol Kunci untuk Flyout</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-it.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-it.xaml
@@ -75,6 +75,10 @@ Nota: essendo un progetto open-source, queste funzionalità sono comunque dispon
     <system:String x:Key="EnableNextUpDescription">Mostra cosa verrà riprodotto dopo la fine di una canzone o di un video</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Durata Prossimo Elemento</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(predefinito: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Posizione del Flyout</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Centra Titolo e Artista</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Mostra etichetta</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Mostra l&apos;etichetta Prossimo prima delle informazioni del brano</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">Flyout Tasti di Blocco</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">Controlla lo stato dei tasti Bloc Maiusc, Bloc Num e Bloc Scorr a colpo d’occhio. Compare dopo aver premuto uno di questi tasti. Utile per laptop o tastiere senza indicatori dei tasti di blocco.</system:String>
     <system:String x:Key="EnableLockKeysTitle">Attiva Flyout Pulsanti di Blocco</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ja.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ja.xaml
@@ -66,6 +66,10 @@
     <system:String x:Key="EnableNextUpDescription">曲や動画の終了時に次の曲を表示します</system:String>
     <system:String x:Key="NextUpStayDurationTitle">次に再生ポップアップの表示時間</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(既定値: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">ポップアップ表示の位置</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">タイトルとアーティストを中央揃え</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">ラベルを表示</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">曲情報の前に次に再生ラベルを表示します</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">ロックキー</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">ロックキーの状態を一目で確認できます。Caps Lock、Num Lock、またはScroll Lockを押すと表示されます。ロックキーインジケーターがないノートPCやキーボードに便利です。</system:String>
     <system:String x:Key="EnableLockKeysTitle">ロックキーのポップアップを有効化</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ko.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ko.xaml
@@ -44,6 +44,10 @@
     <system:String x:Key="EnableNextUpDescription">음악/영상이 끝날 때 현재 미디어 정보를 표시</system:String>
     <system:String x:Key="NextUpStayDurationTitle">현재 재생 정보 표시 지속 시간</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(기본값: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Flyout 위치</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">제목 및 아티스트 가운데 정렬</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">레이블 표시</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">곡 정보 앞에 다음 항목 레이블을 표시합니다</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">토글 키 Flyout</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">토글 키 상태를 한눈에 확인하세요. Caps Lock, Num Lock 또는 Scroll Lock을 누르면 나타납니다. 토글 키 표시등이 없는 노트북/키보드에 편리합니다.</system:String>
     <system:String x:Key="EnableLockKeysTitle">토글 키 Flyout 활성화</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-nl.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-nl.xaml
@@ -123,6 +123,10 @@ verbergt herhalen, shuffle en spelerinfo</system:String>
     <system:String x:Key="AllFuturePremiumFeatures">Alle premium-functies</system:String>
     <system:String x:Key="NextUpCustomizationTitle">Volgende Video/Nummer Flyout</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(standaard: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Flyoutpositie</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Titel en artiest centreren</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Label tonen</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Toont het label Volgende voor de nummerinformatie</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">Lock-toetsen Flyout</system:String>
     <system:String x:Key="EnableLockKeysTitle">Lock-toetsen Flyout inschakelen</system:String>
     <system:String x:Key="LockKeysStayDurationDescription">(standaard: 2000 ms)</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-pl.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-pl.xaml
@@ -64,6 +64,10 @@ Uwaga: Jako projekt open-source, te funkcje są również dostępne za darmo pop
     <system:String x:Key="EnableNextUpDescription">Pokazuje co następne, gdy utwór lub wideo się zakończy</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Czas wyświetlania panelu "Następne w kolejce"</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(domyślnie: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Pozycja Panelu</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Wyśrodkuj Tytuł oraz Artystę</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Pokaż etykietę</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Pokazuje etykietę Następne przed informacjami o utworze</system:String>
     <system:String x:Key="SystemSettingsTitle">Ustawienia systemowe</system:String>
     <system:String x:Key="LaunchOnStartupTitle">Uruchom przy starcie systemu</system:String>
     <system:String x:Key="LaunchOnStartupDescription">Uruchom zminimalizowany do zasobnika systemowego po zalogowaniu do Windows</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-pt-BR.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-pt-BR.xaml
@@ -20,6 +20,10 @@
     <system:String x:Key="EnableNextUpTitle">Ativar flyout A seguir</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Duração do "Próximo"</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(padrão: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Posição do Submenu</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Centralizar título e artista</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Mostrar rótulo</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Mostra o rótulo A seguir antes das informações da música</system:String>
     <system:String x:Key="BackgroundBlurOption1" xml:space="preserve"> Nenhum</system:String>
     <system:String x:Key="BackgroundBlurTitle">Blur de fundo</system:String>
     <system:String x:Key="CompactLayoutTitle">Layout compacto</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ru.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ru.xaml
@@ -56,6 +56,10 @@
     <system:String x:Key="EnableNextUpDescription">Отображает, что будет дальше после окончания текущего медиа</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Длительность отображения окна</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(по умолчанию: 2000 мс)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Расположение всплывающего плеера</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Центрировать название трека и имя исполнителя</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Показывать метку</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Показывает метку Далее перед информацией о треке</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">Клавиши-переключатели</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">Уведомление о смене состояния клавиш-переключателей. Появляется после нажатия Caps Lock, Num Lock или Scroll Lock. Удобно для ноутбуков и клавиатур без индикаторов клавиш-переключателей.</system:String>
     <system:String x:Key="EnableLockKeysTitle">Включить всплывающие клавиши-переключатели</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-si.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-si.xaml
@@ -14,4 +14,8 @@
     <system:String x:Key="BackgroundBlurOption2" xml:space="preserve"> Cover එක දිලිසෙන (Style 1)</system:String>
     <system:String x:Key="BackgroundBlurOption3" xml:space="preserve"> ඉර පායනවා වගේ දිලිසෙන (Style 2)</system:String>
     <system:String x:Key="BackgroundBlurOption4" xml:space="preserve"> බොඳ වුන (Style 3)</system:String>
+    <system:String x:Key="NextUpPositionTitle">ඊළඟ Flyout ස්ථානය</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">මාතෘකාව සහ කලාකරුවා මධ්‍යයට පෙළගස්වන්න</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">ලේබලය පෙන්වන්න</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">ගීත තොරතුරුට පෙර ඊළඟ ලේබලය පෙන්වයි</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-sk.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-sk.xaml
@@ -111,6 +111,10 @@ Poznámka: Keďže ide o open-source projekt, tieto funkcie sú k dispozícii aj
     <system:String x:Key="EnableNextUpDescription">Zobrazuje, čo nasleduje po skončení skladby/videa</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Doba Zotrvania Ďalšia Skladba</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(predvolené: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Pozícia Plávajúceho okna</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Vycentrovať Názov a Autora</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Zobraziť štítok</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Zobrazí štítok Ďalej pred informáciami o skladbe</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">Plávajúce okno Lock Klávesy</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">Skontrolujte si stav Lock kláves jedným pohľadom. Zobrazí sa po stlačení klávesy Caps Lock, Num Lock alebo Scroll Lock. Vhodné pre notebooky/klávesnice bez indikátorov Lock kláves.</system:String>
     <system:String x:Key="EnableLockKeysTitle">Povoliť Plávajúce okno Lock Klávesy</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-ta.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-ta.xaml
@@ -42,4 +42,8 @@
     <system:String x:Key="LockWindow_NumLock">நம் லாக்</system:String>
     <system:String x:Key="LockWindow_ScrollLock">ஸ்க்ரோல் லாக்</system:String>
     <system:String x:Key="LockWindow_InsertPressed">இன்சர்ட் அழுத்தப்பட்டது</system:String>
+    <system:String x:Key="NextUpPositionTitle">ஃப்ளையவுட் தோன்றும் இடம்</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">தலைப்பு மற்றும் கலைஞரை மையப்படுத்து</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">லேபிளைக் காட்டு</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">பாடல் தகவலுக்கு முன் அடுத்து லேபிளைக் காட்டுகிறது</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-th.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-th.xaml
@@ -50,4 +50,8 @@
     <system:String x:Key="PauseOtherMediaTitle">หยุดสื่อที่เล่นอยู่ก่อนหน้านี้อัตโนมัติ</system:String>
     <system:String x:Key="PauseOtherMediaDescription">เมื่อคุณเล่นสื่อตัวใหม่ สื่ออื่นๆที่เคยเล่นอยู่จะถูกหยุดโดยอัตโนมัติ</system:String>
     <system:String x:Key="TaskbarWidgetCustomizationTitle">Widget ของ Taskbar</system:String>
+    <system:String x:Key="NextUpPositionTitle">ตำแหน่ง Flyout</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">แสดงชื่อเพลงและศิลปินไว้ตรงกลาง</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">แสดงป้าย</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">แสดงป้ายถัดไปก่อนข้อมูลเพลง</system:String>
 </ResourceDictionary>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-tr.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-tr.xaml
@@ -43,6 +43,10 @@ tekrar, karıştırma ve oynatıcı bilgilerini gizler</system:String>
     <system:String x:Key="EnableNextUpDescription">Bir şarkı/video bittiğinde sırada ne olduğunu gösterir</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Sıradaki Kalış Süresi</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(varsayılan: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Açılır Pencere Pozisyonu</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Başlığı ve Sanatçıyı Ortala</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Etiketi göster</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Şarkı bilgisinden önce Sıradaki etiketini gösterir</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">Kilitleme Tuşları Açılır Penceresi</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">Caps Lock, Num Lock veya Scroll Lock tuşlarının durumunu hızlıca kontrol edin. Bu bildirim, kilitleme tuşu göstergesi olmayan dizüstü bilgisayarlarda/klavyelerde kullanışlıdır. Tuşlara basıldıktan sonra görünür.</system:String>
     <system:String x:Key="EnableLockKeysTitle">Kilitleme Tuşları Açılır Pencerelerini Etkinleştir</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-uk.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-uk.xaml
@@ -87,6 +87,10 @@
     <system:String x:Key="NextUpCustomizationTitle">Далі в черзі</system:String>
     <system:String x:Key="AnimationSettingsTitle">Налаштування анімації</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(за замовчуванням: 2000 мс)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Розташування спливаючого вікна</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Центрувати назву та виконавця</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Показувати мітку</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Показує мітку Далі перед інформацією про трек</system:String>
     <system:String x:Key="LockKeysStayDurationDescription">(за замовчуванням: 2000 мс)</system:String>
     <system:String x:Key="SystemSettingsTitle">Система</system:String>
     <system:String x:Key="HomeDashboardTitle">Інформаційна панель</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-vi.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-vi.xaml
@@ -34,6 +34,10 @@
     <system:String x:Key="EnableNextUpDescription">Hiển thị thông báo</system:String>
     <system:String x:Key="NextUpStayDurationTitle">Thời gian hiển thị</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(mặc định: 2000 ms)</system:String>
+    <system:String x:Key="NextUpPositionTitle">Vị trí giao diện</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">Căn giữa tiêu đề và tên tác giả</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">Hiển thị nhãn</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">Hiển thị nhãn Tiếp theo trước thông tin bài hát</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">Thông báo phím chuyển</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">Thông báo hiển thị khi nhấn các phím chuyển: Caps Lock, Scroll Lock, Num Lock và Insert.</system:String>
     <system:String x:Key="EnableLockKeysTitle">Hiển thị thông báo</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-zh-CN.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-zh-CN.xaml
@@ -44,6 +44,10 @@
     <system:String x:Key="EnableNextUpDescription">显示当前歌曲 / 视频结束后的下一项内容</system:String>
     <system:String x:Key="NextUpStayDurationTitle">“接下来” 浮窗停留时间</system:String>
     <system:String x:Key="NextUpStayDurationDescription">（默认：2000 毫秒）</system:String>
+    <system:String x:Key="NextUpPositionTitle">浮窗位置</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">居中显示标题和艺术家</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">显示标签</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">在歌曲信息前显示 “接下来” 标签</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">键盘锁定键浮窗</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">快速查看键盘锁定键状态。按下大写锁定键、数字锁定键或滚动锁定键后显示。对于没有锁定键指示灯的笔记本电脑 / 键盘来说很实用。</system:String>
     <system:String x:Key="EnableLockKeysTitle">启用键盘锁定键浮窗</system:String>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-zh-TW.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-zh-TW.xaml
@@ -44,6 +44,10 @@
     <system:String x:Key="EnableNextUpDescription">當歌曲/影片結束時顯示下一首</system:String>
     <system:String x:Key="NextUpStayDurationTitle">下一首停留時間</system:String>
     <system:String x:Key="NextUpStayDurationDescription">(預設 : 2000 毫秒）</system:String>
+    <system:String x:Key="NextUpPositionTitle">彈出視窗位置</system:String>
+    <system:String x:Key="NextUpCenterTitleArtistTitle">置中顯示標題及作者</system:String>
+    <system:String x:Key="NextUpShowUpNextTextTitle">顯示標籤</system:String>
+    <system:String x:Key="NextUpShowUpNextTextDescription">在歌曲資訊前顯示下一首標籤</system:String>
     <system:String x:Key="LockKeysCustomizationTitle">鎖定鍵彈出視窗</system:String>
     <system:String x:Key="LockKeysDescription" xml:space="preserve">立即查看鎖定鍵狀態。按下 Caps Lock、Num Lock 或 Scroll Lock 後出現。適合沒有鎖定鍵指示燈的筆電/鍵盤。</system:String>
     <system:String x:Key="EnableLockKeysTitle">啟用鎖定鍵彈出視窗</system:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -133,6 +133,24 @@ public partial class UserSettings : ObservableObject
     [NotifyPropertyChangedFor(nameof(NextUpDurationText))]
     public partial int NextUpDuration { get; set; }
 
+    /// <summary>
+    /// 'Next Up' flyout position on screen
+    /// </summary>
+    [ObservableProperty]
+    public partial int NextUpPosition { get; set; }
+
+    /// <summary>
+    /// Center the title and artist text in the 'Next Up' flyout
+    /// </summary>
+    [ObservableProperty]
+    public partial bool NextUpCenterTitleArtist { get; set; }
+
+    /// <summary>
+    /// Show the 'Up next' label in the 'Next Up' flyout
+    /// </summary>
+    [ObservableProperty]
+    public partial bool NextUpShowUpNextText { get; set; }
+
     [XmlIgnore]
     public string NextUpDurationText
     {
@@ -710,6 +728,9 @@ public partial class UserSettings : ObservableObject
         Duration = 3000;
         NextUpEnabled = false;
         NextUpDuration = 2000;
+        NextUpPosition = -1;
+        NextUpCenterTitleArtist = false;
+        NextUpShowUpNextText = true;
         NIconLeftClick = 0;
         CenterTitleArtist = false;
         FlyoutAnimationEasingStyle = 2;
@@ -839,7 +860,21 @@ public partial class UserSettings : ObservableObject
     /// </summary>
     internal void CompleteInitialization()
     {
+        bool settingsChanged = NormalizeDeserializedSettings();
         _initializing = false;
+
+        if (settingsChanged)
+        {
+            SettingsManager.SaveSettings();
+        }
+    }
+
+    private bool NormalizeDeserializedSettings()
+    {
+        if (NextUpPosition is >= 0 and <= 5) return false;
+
+        NextUpPosition = Position is >= 0 and <= 5 ? Position : 0;
+        return true;
     }
 
     partial void OnAppLanguageChanged(string oldValue, string newValue)

--- a/FluentFlyoutWPF/Windows/NextUpWindow.xaml
+++ b/FluentFlyoutWPF/Windows/NextUpWindow.xaml
@@ -39,7 +39,7 @@
     </Window.Triggers>
 
     <Grid Margin="12,0,12,0" ColumnDefinitions="Auto, Auto, *">
-        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+        <StackPanel x:Name="UpNextStackPanel" Orientation="Horizontal" VerticalAlignment="Center">
             <ui:SymbolIcon Symbol="MusicNote120" Filled="True" Width="14" Height="14" FontSize="14" VerticalAlignment="Center" Margin="0,0,2,0"/>
             <TextBlock x:Name="UpNextTextBlock" Text="{DynamicResource NextUpWindow_UpNextText}" FontSize="12" VerticalAlignment="Center" FontWeight="Medium"/>
         </StackPanel>
@@ -50,8 +50,8 @@
             </Border.Background>
         </Border>
         <StackPanel Grid.Column="2" Name="SongInfoStackPanel" Margin="6,0,0,0" Orientation="Vertical" VerticalAlignment="Center">
-            <TextBlock Name="SongTitle" Text="Song Title" FontSize="14" FontWeight="Medium" TextTrimming="CharacterEllipsis"/>
-            <TextBlock Name="SongArtist" Text="Artist Name" FontSize="14" FontWeight="Medium" Opacity="0.5" TextTrimming="CharacterEllipsis"/>
+            <TextBlock Name="SongTitle" Text="Song Title" FontSize="14" FontWeight="Medium" TextTrimming="CharacterEllipsis" HorizontalAlignment="Stretch"/>
+            <TextBlock Name="SongArtist" Text="Artist Name" FontSize="14" FontWeight="Medium" Opacity="0.5" TextTrimming="CharacterEllipsis" HorizontalAlignment="Stretch"/>
         </StackPanel>
     </Grid>
 </controls:MicaWindow>

--- a/FluentFlyoutWPF/Windows/NextUpWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/NextUpWindow.xaml.cs
@@ -16,6 +16,10 @@ namespace FluentFlyoutWPF.Windows;
 /// </summary>
 public partial class NextUpWindow : MicaWindow
 {
+    private const double MaxWindowWidth = 400;
+    private const double MinWindowWidth = 160;
+    private const int TextPadding = 8;
+
     MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
     public NextUpWindow(string title, string artist, BitmapImage thumbnail)
     {
@@ -37,19 +41,14 @@ public partial class NextUpWindow : MicaWindow
             WindowBlurHelper.DisableBlur(this);
         }
 
-        int additionalMargin = 8; // additional margin to avoid text clipping
-        var upNextWidth = StringWidth.GetStringWidth(UpNextTextBlock.Text) + additionalMargin;
-        var titleWidth = StringWidth.GetStringWidth(title) + additionalMargin;
-        var artistWidth = StringWidth.GetStringWidth(artist) + additionalMargin;
-
-        Width = titleWidth > artistWidth ? titleWidth + 76 + upNextWidth : artistWidth + 76 + upNextWidth;
-        if (Width > 400) Width = 400; // max width to prevent window from being too wide
+        ApplyCustomization();
+        Width = GetWindowWidth(title, artist);
         SongTitle.Text = title;
         SongArtist.Text = artist;
         UpdateThumbnail(thumbnail);
         Show();
 
-        mainWindow.OpenAnimation(this);
+        mainWindow.OpenAnimation(this, positionOverride: SettingsManager.Current.NextUpPosition);
 
         async void wait()
         {
@@ -60,6 +59,45 @@ public partial class NextUpWindow : MicaWindow
         }
 
         wait();
+    }
+
+    private void ApplyCustomization()
+    {
+        var settings = SettingsManager.Current;
+
+        UpNextStackPanel.Visibility = settings.NextUpShowUpNextText ? Visibility.Visible : Visibility.Collapsed;
+        SongImageBorder.Margin = settings.NextUpShowUpNextText
+            ? new Thickness(12, 1, 0, 0)
+            : new Thickness(0, 1, 0, 0);
+
+        var textAlignment = settings.NextUpCenterTitleArtist ? TextAlignment.Center : TextAlignment.Left;
+        SongTitle.TextAlignment = textAlignment;
+        SongArtist.TextAlignment = textAlignment;
+    }
+
+    private double GetWindowWidth(string title, string artist)
+    {
+        double leadingWidth = 0;
+
+        if (SettingsManager.Current.NextUpShowUpNextText)
+        {
+            const double iconWidth = 14;
+            const double iconRightMargin = 2;
+            const double thumbnailLeftMargin = 12;
+            leadingWidth = iconWidth
+                + iconRightMargin
+                + StringWidth.GetStringWidth(UpNextTextBlock.Text, fontSize: 12)
+                + thumbnailLeftMargin;
+        }
+
+        const double windowHorizontalMargin = 24;
+        const double thumbnailWidth = 38;
+        const double songInfoLeftMargin = 6;
+
+        double songTextWidth = Math.Max(StringWidth.GetStringWidth(title), StringWidth.GetStringWidth(artist)) + TextPadding;
+        double width = windowHorizontalMargin + leadingWidth + thumbnailWidth + songInfoLeftMargin + songTextWidth;
+
+        return Math.Min(Math.Max(width, MinWindowWidth), MaxWindowWidth);
     }
 
     public void UpdateThumbnail(BitmapImage thumbnail)


### PR DESCRIPTION
Adds independent Next Up flyout controls for position, title/artist alignment, and the Up next label.

Closes #457

<img width="900" height="700" alt="image" src="https://github.com/user-attachments/assets/771552aa-0b5b-45ef-abaa-8566636bd377" />

samples:

<img width="298" height="154" alt="image" src="https://github.com/user-attachments/assets/b11f68c4-6c81-44c5-ac43-2b741ac675cd" />

<img width="418" height="261" alt="image" src="https://github.com/user-attachments/assets/c5b9389f-b3ea-4130-bcae-88436b4de541" />

AI tools were used.