### PR TITLE
Fix bottom-center flyout offset

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -398,6 +398,11 @@ public partial class MainWindow : MicaWindow
     /// Computes the final resting position (left, top) for a window based on the current
     /// position setting and the selected monitor's work area.
     /// </summary>
+    private static double GetBottomCenterFlyoutBottomMargin()
+    {
+        return SettingsManager.Current.VolumeControlEnabled && SettingsManager.Current.VolumeControlAboveMediaFlyout ? 16 : 80;
+    }
+
     private (double left, double top) GetFinalPosition(Rect windowRect, Rect workArea)
     {
         int position = SettingsManager.Current.Position;
@@ -410,7 +415,7 @@ public partial class MainWindow : MicaWindow
         double top = position switch
         {
             0 or 2 => workArea.Top + workArea.Height - windowRect.Height - 16,
-            1 => workArea.Top + workArea.Height - windowRect.Height - 80,
+            1 => workArea.Top + workArea.Height - windowRect.Height - GetBottomCenterFlyoutBottomMargin(),
             _ => workArea.Top + 16
         };
         return (left, top);
@@ -477,12 +482,13 @@ public partial class MainWindow : MicaWindow
             }
             else if (_position == 1)
             {
+                double bottomMargin = GetBottomCenterFlyoutBottomMargin();
                 window_left = workArea.Left + workArea.Width / 2 - windowRect.Width / 2;
-                moveAnimation.To = workArea.Top + workArea.Height - windowRect.Height - 80;
+                moveAnimation.To = workArea.Top + workArea.Height - windowRect.Height - bottomMargin;
                 if (SettingsManager.Current.FlyoutAnimationSpeed == 0)
                     moveAnimation.From = moveAnimation.To;
                 else
-                    moveAnimation.From = workArea.Top + workArea.Height - windowRect.Height - 60;
+                    moveAnimation.From = moveAnimation.To + 20;
             }
             else if (_position == 2)
             {

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -398,12 +398,15 @@ public partial class MainWindow : MicaWindow
     /// Computes the final resting position (left, top) for a window based on the current
     /// position setting and the selected monitor's work area.
     /// </summary>
-    private static double GetBottomCenterFlyoutBottomMargin()
+    private static double GetBottomCenterFlyoutBottomMargin(bool reserveNativeVolumeOsdSpace)
     {
+        if (!reserveNativeVolumeOsdSpace)
+            return 16;
+
         return SettingsManager.Current.VolumeControlEnabled && SettingsManager.Current.VolumeControlAboveMediaFlyout ? 16 : 80;
     }
 
-    private (double left, double top) GetFinalPosition(Rect windowRect, Rect workArea)
+    private (double left, double top) GetFinalPosition(Rect windowRect, Rect workArea, bool reserveNativeVolumeOsdSpace = false)
     {
         int position = SettingsManager.Current.Position;
         double left = position switch
@@ -415,13 +418,13 @@ public partial class MainWindow : MicaWindow
         double top = position switch
         {
             0 or 2 => workArea.Top + workArea.Height - windowRect.Height - 16,
-            1 => workArea.Top + workArea.Height - windowRect.Height - GetBottomCenterFlyoutBottomMargin(),
+            1 => workArea.Top + workArea.Height - windowRect.Height - GetBottomCenterFlyoutBottomMargin(reserveNativeVolumeOsdSpace),
             _ => workArea.Top + 16
         };
         return (left, top);
     }
 
-    public void OpenAnimation(MicaWindow window, bool alwaysBottom = false, MonitorInfo? selectedMonitor = null, MicaWindow? aboveReference = null)
+    public void OpenAnimation(MicaWindow window, bool alwaysBottom = false, MonitorInfo? selectedMonitor = null, MicaWindow? aboveReference = null, bool reserveNativeVolumeOsdSpace = false)
     {
         var eventTriggers = window.Triggers[0] as EventTrigger;
         var beginStoryboard = eventTriggers.Actions[0] as BeginStoryboard;
@@ -447,7 +450,7 @@ public partial class MainWindow : MicaWindow
             double refWidth = aboveReference.Width * monitor.dpiX / 96.0;
             double refHeight = aboveReference.Height * monitor.dpiY / 96.0;
             var refRect = new Rect(0, 0, refWidth, refHeight);
-            var (refLeft, refTop) = GetFinalPosition(refRect, workArea);
+            var (refLeft, refTop) = GetFinalPosition(refRect, workArea, reserveNativeVolumeOsdSpace);
 
             window_left = refLeft + refWidth / 2 - windowRect.Width / 2;
             double aboveTop = refTop - windowRect.Height - 8;
@@ -482,7 +485,7 @@ public partial class MainWindow : MicaWindow
             }
             else if (_position == 1)
             {
-                double bottomMargin = GetBottomCenterFlyoutBottomMargin();
+                double bottomMargin = GetBottomCenterFlyoutBottomMargin(reserveNativeVolumeOsdSpace);
                 window_left = workArea.Left + workArea.Width / 2 - windowRect.Width / 2;
                 moveAnimation.To = workArea.Top + workArea.Height - windowRect.Height - bottomMargin;
                 if (SettingsManager.Current.FlyoutAnimationSpeed == 0)
@@ -933,7 +936,7 @@ public partial class MainWindow : MicaWindow
         if (_isHiding == true)
         {
             _isHiding = false;
-            OpenAnimation(this);
+            OpenAnimation(this, reserveNativeVolumeOsdSpace: true);
         }
         cts.Cancel();
         cts = new CancellationTokenSource();

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -485,13 +485,14 @@ public partial class MainWindow : MicaWindow
             }
             else if (_position == 1)
             {
-                double bottomMargin = GetBottomCenterFlyoutBottomMargin(reserveNativeVolumeOsdSpace);
                 window_left = workArea.Left + workArea.Width / 2 - windowRect.Width / 2;
-                moveAnimation.To = workArea.Top + workArea.Height - windowRect.Height - bottomMargin;
+                double bottomMargin = GetBottomCenterFlyoutBottomMargin(reserveNativeVolumeOsdSpace);
+                double moveTo = workArea.Top + workArea.Height - windowRect.Height - bottomMargin;
+                moveAnimation.To = moveTo;
                 if (SettingsManager.Current.FlyoutAnimationSpeed == 0)
-                    moveAnimation.From = moveAnimation.To;
+                    moveAnimation.From = moveTo;
                 else
-                    moveAnimation.From = moveAnimation.To + 20;
+                    moveAnimation.From = moveTo + 20;
             }
             else if (_position == 2)
             {

--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
@@ -98,7 +98,7 @@ public partial class VolumeMixerWindow : MicaWindow
             if (aboveMedia)
             {
                 Width = _mainWindow.Width;
-                _mainWindow.OpenAnimation(this, aboveReference: _mainWindow);
+                _mainWindow.OpenAnimation(this, aboveReference: _mainWindow, reserveNativeVolumeOsdSpace: true);
             }
             else
             {


### PR DESCRIPTION
## Summary

Fix the extra bottom-center offset for media flyouts when FluentFlyout's custom volume flyout is stacked above them.

## Motivation

The 80px offset is only needed when the media flyout has to leave room for the native Windows volume OSD. The previous implementation put that decision in the shared flyout positioning path, so other flyouts such as Next Up could inherit media-only spacing.

## Type of Change

- [x] Bug fix

## What Changed

- Added an explicit `reserveNativeVolumeOsdSpace` positioning flag.
- Enabled that flag only for the media flyout and for the custom volume flyout when it calculates the media flyout reference position.
- Left other flyouts, including Next Up, on the normal 16px bottom-center margin.

## Screenshots

<img width="2560" height="1440" alt="10323b9f-ad13-45b1-a175-e990eb9fe47e" src="https://github.com/user-attachments/assets/87d53a26-2dfd-440c-abfc-65903f0aaa85" />

<img width="2560" height="1440" alt="6c6ae9a3-14e9-4061-b8f8-6cb73caf591c" src="https://github.com/user-attachments/assets/5e174bbb-86fc-49ea-94bd-704c3928660b" />

works fine with auto hide taskbar disabled:

<img width="2560" height="1438" alt="image" src="https://github.com/user-attachments/assets/1742cd5c-9249-4f91-9e81-d10e021b536d" />


## Additional Information

Validated with `dotnet build FluentFlyoutWPF\FluentFlyout.csproj -p:UseAppHost=false`.

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).