### PR TITLE
Fix media flow instability/crashes

### DIFF
--- a/FluentFlyoutWPF/Classes/Utils/BitmapHelper.cs
+++ b/FluentFlyoutWPF/Classes/Utils/BitmapHelper.cs
@@ -142,16 +142,25 @@ internal static class BitmapHelper
         }
 
         BitmapImage image = new();
-        using (var imageStream = thumbnail.OpenReadAsync().GetAwaiter().GetResult().AsStreamForRead())
+
+        try
         {
-            // initialize the BitmapImage
-            image.BeginInit();
-            image.CacheOption = BitmapCacheOption.OnLoad;
-            image.DecodePixelWidth = maxThumbnailSize;
-            image.StreamSource = imageStream;
-            image.EndInit();
+            using (var imageStream = thumbnail.OpenReadAsync().GetAwaiter().GetResult().AsStreamForRead())
+            {
+                // initialize the BitmapImage
+                image.BeginInit();
+                image.CacheOption = BitmapCacheOption.OnLoad;
+                image.DecodePixelWidth = maxThumbnailSize;
+                image.StreamSource = imageStream;
+                image.EndInit();
+            }
+            image.Freeze();
         }
-        image.Freeze();
+        catch (Exception ex)
+        {
+            Logger.Info(ex, "Failed to load thumbnail image");
+            return null;
+        }
 
         // add bitmap to thumbnail cache with empty brush
         _thumbnailCache.Set(hashCode, image);

--- a/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
+++ b/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2024-2026 The FluentFlyout Authors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Automation;
@@ -20,10 +21,10 @@ public static class MediaPlayerData
         public int ProcessId { get; set; }
     }
     // cache for media player info to avoid redundant process lookups
-    private static readonly Dictionary<string, CachedMediaPlayerInfo> mediaPlayerCache = [];
+    private static readonly ConcurrentDictionary<string, CachedMediaPlayerInfo> mediaPlayerCache = [];
 
     // id variants of media players where the key is the mediaPlayerId and the value is the mediaPlayerCache key
-    private static readonly Dictionary<string, string> mediaPlayerIdVariants = [];
+    private static readonly ConcurrentDictionary<string, string> mediaPlayerIdVariants = [];
 
     private static Process[]? cachedProcesses = null;
     private static DateTime lastCacheTime = DateTime.MinValue;


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->

Fixes crashes that occur in the media flow: concurrent access to MediaPlayerData dictionaries and wrap potentially unstable code in BitmapHelper in try/catch

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Fixes #1044

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other
