### PR TITLE
Update unchihugo.WPF-UI attribution in About licenses

### DIFF
--- a/FluentFlyoutWPF/ViewModels/AboutViewModel.cs
+++ b/FluentFlyoutWPF/ViewModels/AboutViewModel.cs
@@ -103,6 +103,9 @@ public partial class AboutViewModel : ObservableObject
         public string Url { get; set; } = string.Empty;
     }
 
+    /// <summary>
+    /// Gets the license notices displayed in Settings > About > Open Source Licenses.
+    /// </summary>
     public ObservableCollection<LicenseInfo> Licenses { get; } =
     [
         new LicenseInfo
@@ -160,10 +163,10 @@ public partial class AboutViewModel : ObservableObject
         },
         new LicenseInfo
         {
-            Name = "WPF-UI",
-            Version = "4.3.0",
+            Name = "unchihugo.WPF-UI",
+            Version = "4.4.1",
             License = "MIT",
-            Url = "https://github.com/lepoco/wpfui"
+            Url = "https://github.com/unchihugo/wpfui"
         },
         new LicenseInfo
         {

--- a/tests/test_about_licenses.py
+++ b/tests/test_about_licenses.py
@@ -1,0 +1,28 @@
+"""Regression coverage for the licenses shown in the About page."""
+
+import re
+from pathlib import Path
+
+
+ABOUT_VIEW_MODEL = (
+    Path(__file__).parents[1] / "FluentFlyoutWPF" / "ViewModels" / "AboutViewModel.cs"
+)
+LICENSE_ENTRY = re.compile(r"new LicenseInfo\s*\{(?P<body>.*?)\n\s*\},", re.DOTALL)
+FIELD = re.compile(r'(?P<name>Name|Version|License|Url)\s*=\s*"(?P<value>[^"]*)"')
+
+
+def about_licenses() -> list[dict[str, str]]:
+    source = ABOUT_VIEW_MODEL.read_text(encoding="utf-8")
+    return [dict(FIELD.findall(match.group("body"))) for match in LICENSE_ENTRY.finditer(source)]
+
+
+def test_about_lists_the_forked_wpf_ui_package() -> None:
+    licenses = about_licenses()
+
+    assert {
+        "Name": "unchihugo.WPF-UI",
+        "Version": "4.4.1",
+        "License": "MIT",
+        "Url": "https://github.com/unchihugo/wpfui",
+    } in licenses
+    assert not any(license_info.get("Name") == "WPF-UI" for license_info in licenses)


### PR DESCRIPTION
## Summary

Update the WPF-UI entry shown under Settings > About > Open Source Licenses to identify the unchihugo fork and its correct version and repository.

## Motivation

The About page still attributed the removed upstream WPF-UI 4.3.0 package after FluentFlyout switched to unchihugo.WPF-UI 4.4.1.

Closes #1021

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

- Replace the WPF-UI 4.3.0 license notice with unchihugo.WPF-UI 4.4.1 and the fork repository URL.
- Document that the license collection backs the About page’s Open Source Licenses section.
- Add regression coverage for the complete replacement entry and removal of the old package name.

## Additional Information

The existing README dependency list already links to the unchihugo fork, so no separate README correction was needed.

## Checklist
- [ ] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).

Validation observed for this change:
- `pytest -q tests/test_about_licenses.py`
- `docker run --rm -e EnableWindowsTargeting=true -v /workspace/repository:/src -w /src mcr.microsoft.com/dotnet/sdk:10.0.100 sh -lc 'dotnet restore FluentFlyoutWPF/FluentFlyout.csproj && dotnet format FluentFlyoutWPF/FluentFlyout.csproj --no-restore --include ViewModels/AboutViewModel.cs --verify-no-changes --verbosity diagnostic'`

Fixes #1021

<!-- repo-agent-case:91cda2f7-40a2-4b95-8af8-b608954e1896 -->