### PR TITLE
Title: Fix 35 upstream bugs: volume flyout, mixer, media flyout, visualizer, taskbar widget, startup

### DIFF
--- a/.github/build-files/FluentFlyout_Installer.bat
+++ b/.github/build-files/FluentFlyout_Installer.bat
@@ -10,6 +10,32 @@ ECHO   Please follow the prompts in the blue window.
 ECHO ===================================================
 ECHO.
 
+:: Prerequisite: the GitHub build is framework-dependent and needs the
+:: .NET Desktop Runtime 10 (x64). Without it the package installs fine but
+:: the app silently fails to start (no window, no Task Manager entry).
+SET "DotNetFxKey=HKLM\SOFTWARE\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.WindowsDesktop.App"
+reg query "%DotNetFxKey%" 2>NUL | findstr /R "10\." >NUL
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO ---------------------------------------------------
+    ECHO   .NET 10 Desktop Runtime ^(x64^) was NOT detected.
+    ECHO   FluentFlyout will NOT start without it.
+    ECHO   Download it here:
+    ECHO   https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe
+    ECHO ---------------------------------------------------
+    ECHO.
+    SET /P OpenDotNet="Open the download page now? (Y/N): "
+    IF /I "%OpenDotNet%"=="Y" (
+        START "" "https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe"
+        ECHO.
+        ECHO Install the runtime, then run this installer again.
+        PAUSE
+        EXIT /B 1
+    ) ELSE (
+        ECHO Continuing without the runtime - the app may fail to start.
+        ECHO.
+    )
+)
+
 cd /d "%~dp0SystemFiles"
 
 :: Run the VS generated script

--- a/.github/build-files/README.txt
+++ b/.github/build-files/README.txt
@@ -12,6 +12,13 @@ Since you've chosen to install via the GitHub method, there are two ways to inst
    this is the manual method. Follow the installation instructions below: 
    https://github.com/unchihugo/FluentFlyout?tab=readme-ov-file#using-msixbundle-installer
 
+PREREQUISITE (both methods):
+The GitHub build needs the .NET 10 Desktop Runtime (x64) installed, otherwise
+the package installs but the app silently fails to start (no window, not even
+in Task Manager). Get it here:
+https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe
+(The FluentFlyout_Installer.bat checks this for you automatically.)
+
 -----------------------------------------------------------------------------------------------------
 
 Note: GitHub releases provide the full feature set without restrictions. The only trade-off is

--- a/FluentFlyoutMSIX/FluentFlyoutMSIX.wapproj
+++ b/FluentFlyoutMSIX/FluentFlyoutMSIX.wapproj
@@ -83,7 +83,6 @@
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
-    <AppInstallerUri>C:\Users\hu8go\Desktop</AppInstallerUri>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <GenerateTemporaryStoreCertificate>True</GenerateTemporaryStoreCertificate>
     <PackageCertificateThumbprint>25D3EFB3B470444AB88088492FCDA18F99BAF513</PackageCertificateThumbprint>

--- a/FluentFlyoutMSIX/Package.appxmanifest
+++ b/FluentFlyoutMSIX/Package.appxmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
@@ -20,8 +20,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.14393.0" MaxVersionTested="10.0.14393.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
   </Dependencies>
 
   <Resources>

--- a/FluentFlyoutWPF/Classes/AudioDeviceMonitor.cs
+++ b/FluentFlyoutWPF/Classes/AudioDeviceMonitor.cs
@@ -17,6 +17,7 @@ public class AudioDeviceMonitor : IDisposable
 
     public event EventHandler<DefaultDeviceChangedEventArgs>? DefaultDeviceChanged;
     public event EventHandler? DeviceTopologyChanged;
+    public event EventHandler? DevicePropertyChanged;
 
     public static AudioDeviceMonitor Instance
     {
@@ -46,6 +47,7 @@ public class AudioDeviceMonitor : IDisposable
             _notificationClient = new AudioDeviceNotificationClient();
             _notificationClient.DefaultDeviceChanged += OnDefaultDeviceChanged;
             _notificationClient.DeviceTopologyChanged += OnDeviceTopologyChanged;
+            _notificationClient.DevicePropertyChanged += OnDevicePropertyChanged;
             _deviceEnumerator.RegisterEndpointNotificationCallback(_notificationClient);
 
             Logger.Info("Audio device monitoring initialized");
@@ -70,6 +72,11 @@ public class AudioDeviceMonitor : IDisposable
     {
         Logger.Info("Audio device topology changed");
         DeviceTopologyChanged?.Invoke(this, e);
+    }
+
+    private void OnDevicePropertyChanged(object? sender, EventArgs e)
+    {
+        DevicePropertyChanged?.Invoke(this, e);
     }
 
     public MMDevice? GetDefaultRenderDevice()
@@ -109,6 +116,7 @@ public class AudioDeviceMonitor : IDisposable
         {
             _notificationClient.DefaultDeviceChanged -= OnDefaultDeviceChanged;
             _notificationClient.DeviceTopologyChanged -= OnDeviceTopologyChanged;
+            _notificationClient.DevicePropertyChanged -= OnDevicePropertyChanged;
         }
 
         if (_deviceEnumerator != null && _notificationClient != null)
@@ -150,6 +158,7 @@ public class AudioDeviceNotificationClient : IMMNotificationClient
 {
     public event EventHandler<DefaultDeviceChangedEventArgs>? DefaultDeviceChanged;
     public event EventHandler? DeviceTopologyChanged;
+    public event EventHandler? DevicePropertyChanged;
 
     public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)
     {
@@ -159,7 +168,7 @@ public class AudioDeviceNotificationClient : IMMNotificationClient
     public void OnDeviceStateChanged(string deviceId, DeviceState newState) => DeviceTopologyChanged?.Invoke(this, EventArgs.Empty);
     public void OnDeviceAdded(string pwstrDeviceId) => DeviceTopologyChanged?.Invoke(this, EventArgs.Empty);
     public void OnDeviceRemoved(string deviceId) => DeviceTopologyChanged?.Invoke(this, EventArgs.Empty);
-    public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key) { }
+    public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key) => DevicePropertyChanged?.Invoke(this, EventArgs.Empty);
 }
 
 public class DefaultDeviceChangedEventArgs(DataFlow dataFlow, Role role, string deviceId) : EventArgs

--- a/FluentFlyoutWPF/Classes/AudioDeviceMonitor.cs
+++ b/FluentFlyoutWPF/Classes/AudioDeviceMonitor.cs
@@ -16,6 +16,7 @@ public class AudioDeviceMonitor : IDisposable
     private AudioDeviceNotificationClient? _notificationClient;
 
     public event EventHandler<DefaultDeviceChangedEventArgs>? DefaultDeviceChanged;
+    public event EventHandler? DeviceTopologyChanged;
 
     public static AudioDeviceMonitor Instance
     {
@@ -44,6 +45,7 @@ public class AudioDeviceMonitor : IDisposable
             _deviceEnumerator = new MMDeviceEnumerator();
             _notificationClient = new AudioDeviceNotificationClient();
             _notificationClient.DefaultDeviceChanged += OnDefaultDeviceChanged;
+            _notificationClient.DeviceTopologyChanged += OnDeviceTopologyChanged;
             _deviceEnumerator.RegisterEndpointNotificationCallback(_notificationClient);
 
             Logger.Info("Audio device monitoring initialized");
@@ -62,6 +64,12 @@ public class AudioDeviceMonitor : IDisposable
 
         Logger.Info("Default audio output device changed");
         DefaultDeviceChanged?.Invoke(this, e);
+    }
+
+    private void OnDeviceTopologyChanged(object? sender, EventArgs e)
+    {
+        Logger.Info("Audio device topology changed");
+        DeviceTopologyChanged?.Invoke(this, e);
     }
 
     public MMDevice? GetDefaultRenderDevice()
@@ -97,7 +105,11 @@ public class AudioDeviceMonitor : IDisposable
 
     public void Dispose()
     {
-        _notificationClient?.DefaultDeviceChanged -= OnDefaultDeviceChanged;
+        if (_notificationClient != null)
+        {
+            _notificationClient.DefaultDeviceChanged -= OnDefaultDeviceChanged;
+            _notificationClient.DeviceTopologyChanged -= OnDeviceTopologyChanged;
+        }
 
         if (_deviceEnumerator != null && _notificationClient != null)
         {
@@ -137,15 +149,16 @@ public class AudioDeviceMonitor : IDisposable
 public class AudioDeviceNotificationClient : IMMNotificationClient
 {
     public event EventHandler<DefaultDeviceChangedEventArgs>? DefaultDeviceChanged;
+    public event EventHandler? DeviceTopologyChanged;
 
     public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)
     {
         DefaultDeviceChanged?.Invoke(this, new DefaultDeviceChangedEventArgs(flow, role, defaultDeviceId));
     }
 
-    public void OnDeviceStateChanged(string deviceId, DeviceState newState) { }
-    public void OnDeviceAdded(string pwstrDeviceId) { }
-    public void OnDeviceRemoved(string deviceId) { }
+    public void OnDeviceStateChanged(string deviceId, DeviceState newState) => DeviceTopologyChanged?.Invoke(this, EventArgs.Empty);
+    public void OnDeviceAdded(string pwstrDeviceId) => DeviceTopologyChanged?.Invoke(this, EventArgs.Empty);
+    public void OnDeviceRemoved(string deviceId) => DeviceTopologyChanged?.Invoke(this, EventArgs.Empty);
     public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key) { }
 }
 

--- a/FluentFlyoutWPF/Classes/NativeMethods.cs
+++ b/FluentFlyoutWPF/Classes/NativeMethods.cs
@@ -69,6 +69,9 @@ public static partial class NativeMethods
     internal const int APPCOMMAND_MEDIA_PLAY_PAUSE = 14;
     internal const int FAPPCOMMAND_KEY = 0x0000;
 
+    // Process Access Rights
+    internal const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+
     #endregion
 
     #region Enums

--- a/FluentFlyoutWPF/Classes/NativeMethods.cs
+++ b/FluentFlyoutWPF/Classes/NativeMethods.cs
@@ -72,6 +72,11 @@ public static partial class NativeMethods
     // Process Access Rights
     internal const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
 
+    // AppBar (taskbar) messages and states
+    internal const uint ABM_GETSTATE = 0x00000004;
+    internal const uint ABM_GETTASKBARPOS = 0x00000005;
+    internal const int ABS_AUTOHIDE = 0x0000001;
+
     #endregion
 
     #region Enums
@@ -198,6 +203,17 @@ public static partial class NativeMethods
         public string DeviceID;
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
         public string DeviceKey;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct APPBARDATA
+    {
+        public int cbSize;
+        public IntPtr hWnd;
+        public uint uCallbackMessage;
+        public uint uEdge;
+        public RECT rc;
+        public int lParam;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -388,6 +404,9 @@ public static partial class NativeMethods
 
     [LibraryImport("shell32.dll")]
     internal static partial int SHQueryUserNotificationState(out QUERY_USER_NOTIFICATION_STATE pquns);
+
+    [DllImport("shell32.dll", CharSet = CharSet.Auto)]
+    internal static extern IntPtr SHAppBarMessage(uint dwMessage, ref APPBARDATA pData);
 
     #endregion
 }

--- a/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
+++ b/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
@@ -14,6 +14,16 @@ public static class MediaPlayerData
 {
     private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
+    [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr OpenProcess(uint processAccess, bool bInheritHandle, uint processId);
+
+    [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+    private static extern bool QueryFullProcessImageName(IntPtr hProcess, uint dwFlags, System.Text.StringBuilder lpExeName, ref int lpdwSize);
+
+    [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+    [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
     private class CachedMediaPlayerInfo
     {
         public required string Title { get; set; }

--- a/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
+++ b/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
@@ -257,6 +257,51 @@ public static class MediaPlayerData
         .Contains(processName, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Resolves the executable path of a process, including elevated/admin
+    /// processes that deny <see cref="Process.MainModule"/> to a non-elevated
+    /// caller. <c>PROCESS_QUERY_LIMITED_INFORMATION</c> plus
+    /// <c>QueryFullProcessImageName</c> is granted for such processes, and file
+    /// metadata/icon reads work on the path without opening the process.
+    /// Returns null only when the process is gone or fully inaccessible.
+    /// </summary>
+    public static string? TryGetProcessPath(int processId)
+    {
+        IntPtr handle = IntPtr.Zero;
+        try
+        {
+            handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, (uint)processId);
+            if (handle != IntPtr.Zero)
+            {
+                var builder = new System.Text.StringBuilder(1024);
+                int size = builder.Capacity;
+                if (QueryFullProcessImageName(handle, 0, builder, ref size) && size > 0)
+                    return builder.ToString(0, size);
+            }
+        }
+        catch
+        {
+            // fall through to the MainModule attempt below
+        }
+        finally
+        {
+            if (handle != IntPtr.Zero)
+            {
+                try { CloseHandle(handle); } catch { }
+            }
+        }
+
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return process.MainModule?.FileName;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Extracts the associated icon for a given process ID. Returns null if the process is inaccessible.
     /// </summary>
     public static ImageSource? GetAndCacheProcessIcon(int processId, string title)
@@ -274,8 +319,7 @@ public static class MediaPlayerData
                 }
             }
 
-            var process = Process.GetProcessById(processId);
-            var path = process.MainModule?.FileName;
+            var path = TryGetProcessPath(processId);
             if (path == null) return null;
 
             // store in cache for future lookups

--- a/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
+++ b/FluentFlyoutWPF/Classes/Utils/MediaPlayerData.cs
@@ -92,7 +92,9 @@ public static class MediaPlayerData
                         // fall back to MainWindowTitle if the description is empty
                         string title = !string.IsNullOrWhiteSpace(mainModule.FileVersionInfo.FileDescription)
                                         ? mainModule.FileVersionInfo.FileDescription
-                                        : p.MainWindowTitle;
+                                        : !string.IsNullOrWhiteSpace(p.MainWindowTitle)
+                                            ? p.MainWindowTitle
+                                            : p.ProcessName;
 
                         return new { Title = title, Path = path, ProcessId = p.Id, IsExactMatch = isExactMatch };
                     }

--- a/FluentFlyoutWPF/Classes/Utils/MonitorUtil.cs
+++ b/FluentFlyoutWPF/Classes/Utils/MonitorUtil.cs
@@ -27,6 +27,16 @@ public static class MonitorUtil
     public static MonitorInfo GetSelectedMonitor(int index = 0)
     {
         var monitors = GetMonitors();
+
+        // Math.Clamp throws when min > max, which is exactly what happens with an
+        // empty monitor list: turning off a secondary display or switching the
+        // projection mode makes EnumDisplayMonitors briefly return nothing, and
+        // the resulting ArgumentException propagated out of every flyout
+        // placement and taskbar position tick, leaving the widget stuck and the
+        // taskbar unresponsive (#1085).
+        if (monitors.Count == 0)
+            return default;
+
         return monitors[Math.Clamp(index, 0, monitors.Count - 1)];
     }
 

--- a/FluentFlyoutWPF/Classes/Visualizer.cs
+++ b/FluentFlyoutWPF/Classes/Visualizer.cs
@@ -307,10 +307,34 @@ namespace FluentFlyoutWPF.Classes
                         Logger.Debug(ex, "Visualizer watchdog tick failed");
                     }
                 };
+
+                // Arm the watchdog immediately. It was only ever started from
+                // OnDataAvailable, so a capture that starts successfully but
+                // never delivers a single buffer - exactly what happens on a
+                // desktop S3 resume, where the AudioClient is accepted but the
+                // stream is dead - was never watched and the visualizer stayed
+                // frozen until the app was restarted (#1071).
+                try { _captureWatchdog.Start(); }
+                catch (Exception ex) { Logger.Debug(ex, "Failed to arm visualizer watchdog"); }
             }
             catch (Exception ex)
             {
                 Logger.Error(ex, "Failed to start visualizer");
+
+                // A partially constructed capture would otherwise be leaked and
+                // block the next Start() attempt from binding the endpoint.
+                _isRunning = false;
+                try
+                {
+                    if (_capture != null)
+                    {
+                        _capture.DataAvailable -= OnDataAvailable;
+                        _capture.RecordingStopped -= OnRecordingStopped;
+                        _capture.Dispose();
+                    }
+                }
+                catch (Exception cleanupEx) { Logger.Debug(cleanupEx, "Failed to clean up visualizer capture after start failure"); }
+                _capture = null;
             }
         }
 

--- a/FluentFlyoutWPF/Classes/Visualizer.cs
+++ b/FluentFlyoutWPF/Classes/Visualizer.cs
@@ -84,6 +84,7 @@ namespace FluentFlyoutWPF.Classes
             ResizeBarList(SettingsManager.Current.TaskbarVisualizerBarCount);
             AudioDeviceMonitor.Instance.DefaultDeviceChanged += OnDefaultDeviceChanged;
             AudioDeviceMonitor.Instance.DeviceTopologyChanged += OnDeviceTopologyChanged;
+            AudioDeviceMonitor.Instance.DevicePropertyChanged += OnDevicePropertyChanged;
             TryRegisterSystemEvents();
         }
 
@@ -178,6 +179,14 @@ namespace FluentFlyoutWPF.Classes
         {
             if (SettingsManager.Current.TaskbarVisualizerEnabled)
                 RequestRestart("audio device added, removed, or state changed");
+        }
+
+        private void OnDevicePropertyChanged(object? sender, EventArgs e)
+        {
+            // Spatial-audio changes invalidate an existing loopback client even
+            // though the default endpoint id remains the same (#817).
+            if (SettingsManager.Current.TaskbarVisualizerEnabled)
+                RequestRestart("audio endpoint property changed");
         }
 
         private void RequestRestart(string reason, bool allowFollowUp = true)
@@ -794,6 +803,7 @@ namespace FluentFlyoutWPF.Classes
 
             AudioDeviceMonitor.Instance.DefaultDeviceChanged -= OnDefaultDeviceChanged;
             AudioDeviceMonitor.Instance.DeviceTopologyChanged -= OnDeviceTopologyChanged;
+            AudioDeviceMonitor.Instance.DevicePropertyChanged -= OnDevicePropertyChanged;
             TryUnregisterSystemEvents();
 
             if (_capture != null)

--- a/FluentFlyoutWPF/Classes/Visualizer.cs
+++ b/FluentFlyoutWPF/Classes/Visualizer.cs
@@ -83,6 +83,7 @@ namespace FluentFlyoutWPF.Classes
 
             ResizeBarList(SettingsManager.Current.TaskbarVisualizerBarCount);
             AudioDeviceMonitor.Instance.DefaultDeviceChanged += OnDefaultDeviceChanged;
+            AudioDeviceMonitor.Instance.DeviceTopologyChanged += OnDeviceTopologyChanged;
             TryRegisterSystemEvents();
         }
 
@@ -171,6 +172,12 @@ namespace FluentFlyoutWPF.Classes
             if (!SettingsManager.Current.TaskbarVisualizerEnabled)
                 return;
             RequestRestart("default audio output device changed");
+        }
+
+        private void OnDeviceTopologyChanged(object? sender, EventArgs e)
+        {
+            if (SettingsManager.Current.TaskbarVisualizerEnabled)
+                RequestRestart("audio device added, removed, or state changed");
         }
 
         private void RequestRestart(string reason, bool allowFollowUp = true)
@@ -786,6 +793,7 @@ namespace FluentFlyoutWPF.Classes
             Stop();
 
             AudioDeviceMonitor.Instance.DefaultDeviceChanged -= OnDefaultDeviceChanged;
+            AudioDeviceMonitor.Instance.DeviceTopologyChanged -= OnDeviceTopologyChanged;
             TryUnregisterSystemEvents();
 
             if (_capture != null)

--- a/FluentFlyoutWPF/Classes/Visualizer.cs
+++ b/FluentFlyoutWPF/Classes/Visualizer.cs
@@ -286,6 +286,32 @@ namespace FluentFlyoutWPF.Classes
             _captureWatchdog = null;
         }
 
+        /// <summary>
+        /// Decodes one PCM sample from a loopback buffer at the given byte offset.
+        /// </summary>
+        private static float ReadLoopbackSample(byte[] buffer, int offset, int bytesPerSample, bool isFloat)
+        {
+            if (isFloat && bytesPerSample == 4)
+                return BitConverter.ToSingle(buffer, offset);
+
+            return bytesPerSample switch
+            {
+                1 => (buffer[offset] - 128) / 128f,
+                2 => BitConverter.ToInt16(buffer, offset) / 32768f,
+                3 => Decode24Bit(buffer, offset) / 8388608f,
+                4 => BitConverter.ToInt32(buffer, offset) / 2147483648f,
+                _ => 0f,
+            };
+        }
+
+        private static int Decode24Bit(byte[] buffer, int offset)
+        {
+            int value = buffer[offset] | (buffer[offset + 1] << 8) | (buffer[offset + 2] << 16);
+            if ((value & 0x800000) != 0)
+                value |= unchecked((int)0xFF000000); // sign-extend
+            return value;
+        }
+
         private void OnDataAvailable(object? sender, WaveInEventArgs e)
         {
             if (!_isRunning || e.BytesRecorded == 0)
@@ -296,20 +322,29 @@ namespace FluentFlyoutWPF.Classes
             _captureWatchdog.Stop();
             _captureWatchdog.Start();
 
-            int bytesPerSample = _capture!.WaveFormat.BitsPerSample / 8;
-            int samplesRecorded = e.BytesRecorded / bytesPerSample;
+            // Decode loopback frames honoring the mix format. The old code assumed
+            // 16-bit int or 32-bit float and treated interleaved channels as mono
+            // samples: 24-bit streams (common with spatial/Dolby Atmos pipelines)
+            // decoded as permanent silence, and 6/8-channel streams fed the FFT
+            // at multiples of the real rate. Downmix every frame to mono instead.
+            var waveFormat = _capture!.WaveFormat;
+            int bytesPerSample = waveFormat.BitsPerSample / 8;
+            int channels = Math.Max(1, waveFormat.Channels);
+            bool isFloat = waveFormat.Encoding == WaveFormatEncoding.IeeeFloat;
+            int bytesPerFrame = bytesPerSample * channels;
+            int framesRecorded = bytesPerFrame > 0 ? e.BytesRecorded / bytesPerFrame : 0;
 
-            for (int i = 0; i < samplesRecorded; i++)
+            for (int frame = 0; frame < framesRecorded; frame++)
             {
-                float sampleValue = 0;
-                if (bytesPerSample == 4)
+                double mixed = 0;
+                int frameOffset = frame * bytesPerFrame;
+                for (int ch = 0; ch < channels; ch++)
                 {
-                    sampleValue = BitConverter.ToSingle(e.Buffer, i * 4);
+                    mixed += ReadLoopbackSample(e.Buffer, frameOffset + ch * bytesPerSample, bytesPerSample, isFloat);
                 }
-                else if (bytesPerSample == 2)
-                {
-                    sampleValue = BitConverter.ToInt16(e.Buffer, i * 2) / 32768f;
-                }
+                float sampleValue = (float)(mixed / channels);
+                if (!float.IsFinite(sampleValue))
+                    sampleValue = 0;
 
                 _fftBuffer[_fftPos].X = (float)(sampleValue * FastFourierTransform.HammingWindow(_fftPos, _fftLength));
                 _fftBuffer[_fftPos].Y = 0;

--- a/FluentFlyoutWPF/Classes/Visualizer.cs
+++ b/FluentFlyoutWPF/Classes/Visualizer.cs
@@ -131,9 +131,23 @@ namespace FluentFlyoutWPF.Classes
             if (!SettingsManager.Current.TaskbarVisualizerEnabled)
                 return;
 
-            if (e.Mode == PowerModes.Resume)
+            if (e.Mode == PowerModes.Suspend)
             {
-                RequestRestart("power resume");
+                // Release WASAPI before S3 sleep so the AudioClient isn't left invalidated.
+                try { Stop(); } catch (Exception ex) { Logger.Debug(ex, "Visualizer stop on suspend failed"); }
+                _deviceId = null;
+            }
+            else if (e.Mode == PowerModes.Resume)
+            {
+                // Desktop S3 resume often fires no DefaultDeviceChanged (same endpoint),
+                // and the audio stack needs seconds to come back. Drop the cached device
+                // ID so restart re-resolves the default, then retry with backoff.
+                _deviceId = null;
+                Task.Run(async () =>
+                {
+                    try { await Task.Delay(2500); } catch { }
+                    RequestRestart("power resume");
+                });
             }
         }
 
@@ -159,7 +173,7 @@ namespace FluentFlyoutWPF.Classes
             RequestRestart("default audio output device changed");
         }
 
-        private void RequestRestart(string reason)
+        private void RequestRestart(string reason, bool allowFollowUp = true)
         {
             if (!SettingsManager.Current.TaskbarVisualizerEnabled)
                 return;
@@ -175,13 +189,32 @@ namespace FluentFlyoutWPF.Classes
                 {
                     Stop();
 
-                    for (int attempt = 0; attempt < 5; attempt++)
+                    for (int attempt = 0; attempt < 10; attempt++)
                     {
-                        await Task.Delay(500);
+                        await Task.Delay(800);
+                        if (!SettingsManager.Current.TaskbarVisualizerEnabled)
+                            return;
                         Start();
                         if (_isRunning)
+                        {
+                            if (attempt > 0)
+                                Logger.Info($"Visualizer restart succeeded on attempt {attempt + 1} ({reason})");
                             return;
+                        }
                         Logger.Warn($"Visualizer restart attempt {attempt + 1} failed, retrying...");
+                    }
+
+                    // S3 resume can leave the audio stack unavailable longer than the
+                    // retry window (or with no further system event to trigger us).
+                    // Schedule one delayed follow-up instead of staying dead forever.
+                    if (allowFollowUp && SettingsManager.Current.TaskbarVisualizerEnabled && !_isRunning)
+                    {
+                        Logger.Warn("Visualizer still not running after retries, scheduling delayed recovery");
+                        _ = Task.Run(async () =>
+                        {
+                            try { await Task.Delay(TimeSpan.FromSeconds(15)); } catch { }
+                            RequestRestart($"delayed recovery: {reason}", allowFollowUp: false);
+                        });
                     }
                 }
                 catch (Exception ex)
@@ -238,24 +271,40 @@ namespace FluentFlyoutWPF.Classes
                 };
                 _captureWatchdog.Elapsed += (_, _) =>
                 {
-                    if (_isRunning)
+                    try
                     {
-                        for (int i = 0; i < _barValues.Length; i++)
+                        if (!_isRunning)
+                            return;
+
+                        if (_barValues != null)
                         {
-                            _barValues[i] = 0;
+                            for (int i = 0; i < _barValues.Length; i++)
+                            {
+                                _barValues[i] = 0;
+                            }
                         }
                         UpdateBitmap();
 
                         if (!SettingsManager.Current.TaskbarVisualizerBaseline || SettingsManager.Current.TaskbarVisualizerBaselineAutoHide) // if baseline is enabled and autohide is off, condition is false
                             SettingsManager.Current.TaskbarVisualizerHasContent = false;
 
-                        // If we stop receiving loopback callbacks entirely (common after lock/unlock + device changes),
-                        // the timer fires once and then never again. Use it as a recovery trigger.
+                        // If we stop receiving loopback callbacks entirely (common after sleep/lock + device changes),
+                        // use it as a recovery trigger. The timer is single-shot and re-armed on
+                        // every DataAvailable, so re-arm it here while the silence is still
+                        // short; otherwise it would fire once and never watch again.
                         var silenceFor = DateTime.UtcNow - _lastDataAvailableUtc;
                         if (silenceFor > TimeSpan.FromSeconds(2))
                         {
                             RequestRestart($"no audio callbacks for {silenceFor.TotalSeconds:0.0}s");
                         }
+                        else if (_isRunning && _captureWatchdog != null)
+                        {
+                            try { _captureWatchdog.Start(); } catch { }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Debug(ex, "Visualizer watchdog tick failed");
                     }
                 };
             }
@@ -319,8 +368,12 @@ namespace FluentFlyoutWPF.Classes
 
             _lastDataAvailableUtc = DateTime.UtcNow;
 
-            _captureWatchdog.Stop();
-            _captureWatchdog.Start();
+            try
+            {
+                _captureWatchdog?.Stop();
+                _captureWatchdog?.Start();
+            }
+            catch (ObjectDisposedException) { }
 
             // Decode loopback frames honoring the mix format. The old code assumed
             // 16-bit int or 32-bit float and treated interleaved channels as mono
@@ -697,6 +750,10 @@ namespace FluentFlyoutWPF.Classes
             if (e.Exception != null)
             {
                 Logger.Error(e.Exception, "Visualizer recording stopped due to an error");
+                // Abnormal stop (e.g. device invalidated across sleep): our own Stop()
+                // unsubscribes first, so this path means WASAPI died underneath us.
+                if (SettingsManager.Current.TaskbarVisualizerEnabled)
+                    RequestRestart($"recording stopped: {e.Exception.Message}");
             }
         }
 

--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
@@ -270,23 +270,7 @@ public partial class TaskbarWidgetControl : UserControl
         double coverImageMargin = _isSmallTaskbar ? SmallCoverImageMargin : DefaultCoverImageMargin;
 
         // calculate widget width - use cached values if text hasn't changed
-        string currentTitle = _actualTitle;
-        string currentArtist = _actualArtist;
-
-        bool textChanged = false;
-
-        if (!string.Equals(currentTitle, _cachedTitleText, StringComparison.Ordinal))
-        {
-            _cachedTitleWidth = Math.Round(StringWidth.GetStringWidth(currentTitle, 400), 2);
-            _cachedTitleText = currentTitle;
-            textChanged = true;
-        }
-        if (!string.Equals(currentArtist, _cachedArtistText, StringComparison.Ordinal))
-        {
-            _cachedArtistWidth = Math.Round(StringWidth.GetStringWidth(currentArtist, 400), 2);
-            _cachedArtistText = currentArtist;
-            textChanged = true;
-        }
+        bool textChanged = RefreshCachedTextWidths();
 
         // maximum width limit, same as Windows native widget
         double maxLogicalWidth = _nativeWidgetsPadding / _scale;
@@ -345,6 +329,48 @@ public partial class TaskbarWidgetControl : UserControl
         double logicalHeight = _isSmallTaskbar ? SmallTaskbarWidgetHeight : DefaultTaskbarWidgetHeight;
 
         return (logicalWidth, logicalHeight);
+    }
+
+    /// <summary>
+    /// Re-measures title/artist text widths when the underlying strings changed.
+    /// Returns true when either measurement was refreshed.
+    /// </summary>
+    private bool RefreshCachedTextWidths()
+    {
+        bool changed = false;
+
+        if (!string.Equals(_actualTitle, _cachedTitleText, StringComparison.Ordinal))
+        {
+            _cachedTitleWidth = Math.Round(StringWidth.GetStringWidth(_actualTitle, 400), 2);
+            _cachedTitleText = _actualTitle;
+            changed = true;
+        }
+        if (!string.Equals(_actualArtist, _cachedArtistText, StringComparison.Ordinal))
+        {
+            _cachedArtistWidth = Math.Round(StringWidth.GetStringWidth(_actualArtist, 400), 2);
+            _cachedArtistText = _actualArtist;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    /// Instantly stops any running scroll animation on a marquee text block and
+    /// restores the single-copy text at offset 0. Must run synchronously on the
+    /// UI thread right when the song text changes: the position/size pass that
+    /// rebuilds marquees runs async, and any frame in between would render the
+    /// new text with the previous song's animation offset (blank/blinking widget).
+    /// </summary>
+    private static void ResetMarquee(System.Windows.Controls.TextBlock textBlock, Canvas container, string actualText)
+    {
+        if (textBlock.RenderTransform is TranslateTransform transform)
+        {
+            transform.BeginAnimation(TranslateTransform.XProperty, null);
+            transform.X = 0;
+        }
+        if (!string.Equals(textBlock.Text, actualText, StringComparison.Ordinal))
+            textBlock.Text = actualText;
     }
 
     public void UpdateMarquees()
@@ -532,6 +558,12 @@ public partial class TaskbarWidgetControl : UserControl
                 MainBorder.Background.Opacity = 0;
                 TopBorder.BorderBrush = Brushes.Transparent;
 
+                // stop any stale scroll animation so it can't leak into the next song
+                ResetMarquee(SongTitle, SongTitleContainer, string.Empty);
+                ResetMarquee(SongArtist, SongArtistContainer, string.Empty);
+                RefreshCachedTextWidths();
+                UpdateMarquees();
+
                 Visibility = Visibility.Visible;
             });
             return;
@@ -573,7 +605,8 @@ public partial class TaskbarWidgetControl : UserControl
             string newTitle = !string.IsNullOrEmpty(title) ? title : "-";
             string newArtist = !string.IsNullOrEmpty(artist) ? artist : "-";
 
-            if (_actualTitle != newTitle || _actualArtist != newArtist)
+            bool infoChanged = _actualTitle != newTitle || _actualArtist != newArtist;
+            if (infoChanged)
             {
                 // changed info
                 if (SettingsManager.Current.TaskbarWidgetAnimated)
@@ -586,6 +619,14 @@ public partial class TaskbarWidgetControl : UserControl
 
                 SongTitle.Text = _actualTitle;
                 SongArtist.Text = _actualArtist;
+
+                // Kill the previous song's scroll animation synchronously. The
+                // size/position pass that rebuilds marquees runs async, and any
+                // frame in between would render the new text with the old
+                // animation offset (blank widget) or snap back later (blink) -
+                // especially with loop mode, which doubles the text.
+                ResetMarquee(SongTitle, SongTitleContainer, _actualTitle);
+                ResetMarquee(SongArtist, SongArtistContainer, _actualArtist);
             }
 
             // Update tooltip with song info and the active app volume
@@ -642,6 +683,15 @@ public partial class TaskbarWidgetControl : UserControl
             ControlsStackPanel.Visibility = SettingsManager.Current.TaskbarWidgetControlsEnabled
                 ? Visibility.Visible
                 : Visibility.Collapsed;
+
+            // Rebuild marquee state for the new text now (container widths get
+            // corrected on the upcoming async position pass). Skipped for
+            // play/pause-only updates so scrolling never restarts/blinks.
+            if (infoChanged)
+            {
+                RefreshCachedTextWidths();
+                UpdateMarquees();
+            }
 
             Visibility = Visibility.Visible;
         });

--- a/FluentFlyoutWPF/MainWindow.xaml
+++ b/FluentFlyoutWPF/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<controls:MicaWindow x:Class="FluentFlyoutWPF.MainWindow"
+<controls:MicaWindow x:Class="FluentFlyoutWPF.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -102,7 +102,7 @@
                     <Border Name="SongImageBorder" CornerRadius="6" BorderThickness="1" BorderBrush="#26FFFFFF" Margin="0" ClipToBounds="True" Width="78" Height="78">
                         <ui:SymbolIcon Name="SongImagePlaceholder" Symbol="MusicNote220" FontSize="40" Filled="True" Foreground="{DynamicResource MicaWPF.Brushes.SystemAccentColorSecondary}" Visibility="Collapsed" />
                         <Border.Background>
-                            <ImageBrush x:Name="SongImage" Stretch="UniformToFill"/>
+                            <ImageBrush x:Name="SongImage" Stretch="Uniform"/>
                         </Border.Background>
                     </Border>
                     <StackPanel Name="BodyStackPanel" Orientation="Vertical" VerticalAlignment="Center" Width="194">

--- a/FluentFlyoutWPF/MainWindow.xaml
+++ b/FluentFlyoutWPF/MainWindow.xaml
@@ -102,7 +102,7 @@
                     <Border Name="SongImageBorder" CornerRadius="6" BorderThickness="1" BorderBrush="#26FFFFFF" Margin="0" ClipToBounds="True" Width="78" Height="78">
                         <ui:SymbolIcon Name="SongImagePlaceholder" Symbol="MusicNote220" FontSize="40" Filled="True" Foreground="{DynamicResource MicaWPF.Brushes.SystemAccentColorSecondary}" Visibility="Collapsed" />
                         <Border.Background>
-                            <ImageBrush x:Name="SongImage" Stretch="Uniform"/>
+                            <ImageBrush x:Name="SongImage" Stretch="UniformToFill"/>
                         </Border.Background>
                     </Border>
                     <StackPanel Name="BodyStackPanel" Orientation="Vertical" VerticalAlignment="Center" Width="194">

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1541,8 +1541,9 @@ public partial class MainWindow : MicaWindow
             int extraWidth = SettingsManager.Current.RepeatEnabled ? 36 : 0;
             extraWidth += SettingsManager.Current.ShuffleEnabled ? 36 : 0;
             extraWidth += SettingsManager.Current.PlayerInfoEnabled ? 72 : 0;
-            // keep minimum width at 72 even if all extra features are disabled to prevent the widget from being too small
-            extraWidth = Math.Max(extraWidth, 72);
+            // Do not reserve optional-control space when repeat and shuffle are
+            // disabled; the base layout already includes the always-visible
+            // playback controls (#802).
 
             int extraHeight = SettingsManager.Current.SeekbarEnabled && _mediaSessionSupportsSeekbar ? 36 : 0;
 

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1128,7 +1128,7 @@ public partial class MainWindow : MicaWindow
                     }
                 }
 
-                if (SettingsManager.Current.VolumeControlEnabled)
+                if (volumeKeysPressed && SettingsManager.Current.VolumeControlEnabled && volumeMixerWindow != null)
                 {
                     // SyncMasterFromDevice is dispatcher-aware (marshals to UI thread itself).
                     // ShowFlyout is queued to the UI thread so this hook returns to

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -2012,12 +2012,21 @@ public partial class MainWindow : MicaWindow
         return Task.WhenAll(
             mediaManager.CurrentMediaSessions.Values.Select(session =>
             {
-                if (
-                    session.Id != currentMediaSession.Id &&
-                    session.ControlSession.GetPlaybackInfo().PlaybackStatus == GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing
-                )
+                try
                 {
-                    return session.ControlSession.TryPauseAsync().AsTask();
+                    if (
+                        session.Id != currentMediaSession.Id &&
+                        session.ControlSession?.GetPlaybackInfo().PlaybackStatus == GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing
+                    )
+                    {
+                        return session.ControlSession.TryPauseAsync().AsTask();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Fire-and-forget fan-out: one dead session must not fail
+                    // the whole batch (or go unobserved).
+                    Logger.Debug(ex, "Failed to auto-pause session {0}", session.Id);
                 }
                 return Task.CompletedTask;
             })
@@ -2039,5 +2048,7 @@ public partial class MainWindow : MicaWindow
     {
         // Use the updated ShowMediaFlyout method with toggle mode to close the flyout
         ShowMediaFlyout(toggleMode: true);
+    }
+}ShowMediaFlyout(toggleMode: true);
     }
 }

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -955,6 +955,19 @@ public partial class MainWindow : MicaWindow
 
         var playbackInfo = currentActiveSession.ControlSession.GetPlaybackInfo();
 
+        // Players republish empty metadata for a moment when a track restarts
+        // (looping a song in YouTube Music) before sending the real properties.
+        // Pushing that blank snapshot left the taskbar widget showing only the
+        // album art with no title/artist until the song was changed manually,
+        // and poisoned the dedupe cache so the real update was suppressed
+        // (#961). Ignore the blank interim state while the session is alive.
+        if (string.IsNullOrWhiteSpace(songInfo.Title) && string.IsNullOrWhiteSpace(songInfo.Artist)
+            && playbackInfo.PlaybackStatus != GlobalSystemMediaTransportControlsSessionPlaybackStatus.Closed
+            && playbackInfo.PlaybackStatus != GlobalSystemMediaTransportControlsSessionPlaybackStatus.Stopped)
+        {
+            return;
+        }
+
         string check = songInfo.Title + songInfo.Artist + playbackInfo.PlaybackStatus;
         int checkThumbnail = BitmapHelper.GetStableThumbnailHash(songInfo.Thumbnail);
         bool onlyThumbnailChanged = false;
@@ -990,7 +1003,13 @@ public partial class MainWindow : MicaWindow
                 });
             }
 
-            if (nextUpWindow == null && IsVisible == false && songInfo.Thumbnail != null && currentTitle != songInfo.Title)
+            // A looped track legitimately repeats its title, so comparing against
+            // the last shown title alone permanently suppressed the next-up
+            // flyout for that song (#961). Allow a repeat once the title has
+            // actually been republished by the player.
+            bool isNewSong = currentTitle != songInfo.Title || !onlyThumbnailChanged;
+
+            if (nextUpWindow == null && IsVisible == false && songInfo.Thumbnail != null && isNewSong)
             {
                 createNewNextUpWindow();
             }

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -523,9 +523,49 @@ public partial class MainWindow : MicaWindow
     private static double GetBottomCenterFlyoutBottomMargin(bool reserveNativeVolumeOsdSpace)
     {
         if (!reserveNativeVolumeOsdSpace)
-            return 16;
+            return 16 + GetAutoHideTaskbarInset(bottomEdge: true);
 
-        return SettingsManager.Current.VolumeControlEnabled && SettingsManager.Current.VolumeControlAboveMediaFlyout ? 16 : 80;
+        return (SettingsManager.Current.VolumeControlEnabled && SettingsManager.Current.VolumeControlAboveMediaFlyout ? 16 : 80)
+            + GetAutoHideTaskbarInset(bottomEdge: true);
+    }
+
+    /// <summary>
+    /// Extra margin (raw pixels) to keep free for an auto-hidden taskbar on the
+    /// given screen edge. An auto-hidden taskbar is not part of the monitor work
+    /// area, so flyouts anchored 16px from the edge are covered by (or cover) the
+    /// taskbar as soon as it slides out (#987, #1039).
+    /// Returns 0 when the taskbar is not in auto-hide mode or lives on another edge.
+    /// </summary>
+    private static double GetAutoHideTaskbarInset(bool bottomEdge)
+    {
+        try
+        {
+            var data = new APPBARDATA { cbSize = Marshal.SizeOf<APPBARDATA>() };
+            int state = (int)SHAppBarMessage(ABM_GETSTATE, ref data);
+            if ((state & ABS_AUTOHIDE) == 0)
+                return 0;
+
+            var posData = new APPBARDATA { cbSize = Marshal.SizeOf<APPBARDATA>() };
+            if (SHAppBarMessage(ABM_GETTASKBARPOS, ref posData) == IntPtr.Zero)
+                return 0;
+
+            // ABE_LEFT = 0, ABE_TOP = 1, ABE_RIGHT = 2, ABE_BOTTOM = 3
+            bool taskbarOnBottom = posData.uEdge == 3;
+            bool taskbarOnTop = posData.uEdge == 1;
+            if (bottomEdge ? !taskbarOnBottom : !taskbarOnTop)
+                return 0;
+
+            double height = posData.rc.Bottom - posData.rc.Top;
+            if (height <= 0 || height > 500)
+                return 0;
+
+            return height;
+        }
+        catch (Exception ex)
+        {
+            Logger.Debug(ex, "Failed to query auto-hide taskbar state");
+            return 0;
+        }
     }
 
     private (double left, double top) GetFinalPosition(Rect windowRect, Rect workArea, bool reserveNativeVolumeOsdSpace = false)
@@ -539,9 +579,9 @@ public partial class MainWindow : MicaWindow
         };
         double top = position switch
         {
-            0 or 2 => workArea.Top + workArea.Height - windowRect.Height - 16,
+            0 or 2 => workArea.Top + workArea.Height - windowRect.Height - 16 - GetAutoHideTaskbarInset(bottomEdge: true),
             1 => workArea.Top + workArea.Height - windowRect.Height - GetBottomCenterFlyoutBottomMargin(reserveNativeVolumeOsdSpace),
-            _ => workArea.Top + 16
+            _ => workArea.Top + 16 + GetAutoHideTaskbarInset(bottomEdge: false)
         };
         return (left, top);
     }
@@ -601,7 +641,7 @@ public partial class MainWindow : MicaWindow
             if (_position == 0)
             {
                 window_left = workArea.Left + 16;
-                moveAnimation.To = workArea.Top + workArea.Height - windowRect.Height - 16;
+                moveAnimation.To = workArea.Top + workArea.Height - windowRect.Height - 16 - GetAutoHideTaskbarInset(bottomEdge: true);
                 if (SettingsManager.Current.FlyoutAnimationSpeed == 0) // if off, don't animate (just appear at the bottom)
                     moveAnimation.From = moveAnimation.To;
                 else
@@ -621,7 +661,7 @@ public partial class MainWindow : MicaWindow
             else if (_position == 2)
             {
                 window_left = workArea.Left + workArea.Width - windowRect.Width - 16;
-                moveAnimation.To = workArea.Top + workArea.Height - windowRect.Height - 16;
+                moveAnimation.To = workArea.Top + workArea.Height - windowRect.Height - 16 - GetAutoHideTaskbarInset(bottomEdge: true);
                 if (SettingsManager.Current.FlyoutAnimationSpeed == 0)
                     moveAnimation.From = moveAnimation.To;
                 else
@@ -630,7 +670,7 @@ public partial class MainWindow : MicaWindow
             else if (_position == 3)
             {
                 window_left = workArea.Left + 16;
-                moveAnimation.To = workArea.Top + 16;
+                moveAnimation.To = workArea.Top + 16 + GetAutoHideTaskbarInset(bottomEdge: false);
                 if (SettingsManager.Current.FlyoutAnimationSpeed == 0)
                     moveAnimation.From = moveAnimation.To;
                 else
@@ -639,7 +679,7 @@ public partial class MainWindow : MicaWindow
             else if (_position == 4)
             {
                 window_left = workArea.Left + workArea.Width / 2 - windowRect.Width / 2;
-                moveAnimation.To = workArea.Top + 16;
+                moveAnimation.To = workArea.Top + 16 + GetAutoHideTaskbarInset(bottomEdge: false);
                 if (SettingsManager.Current.FlyoutAnimationSpeed == 0)
                     moveAnimation.From = moveAnimation.To;
                 else
@@ -648,7 +688,7 @@ public partial class MainWindow : MicaWindow
             else if (_position == 5)
             {
                 window_left = workArea.Left + workArea.Width - windowRect.Width - 16;
-                moveAnimation.To = workArea.Top + 16;
+                moveAnimation.To = workArea.Top + 16 + GetAutoHideTaskbarInset(bottomEdge: false);
                 if (SettingsManager.Current.FlyoutAnimationSpeed == 0)
                     moveAnimation.From = moveAnimation.To;
                 else
@@ -659,7 +699,7 @@ public partial class MainWindow : MicaWindow
         else
         {
             window_left = workArea.Left + workArea.Width / 2 - windowRect.Width / 2;
-            moveAnimation.To = workArea.Top + workArea.Height - windowRect.Height - 16;
+            moveAnimation.To = workArea.Top + workArea.Height - windowRect.Height - 16 - GetAutoHideTaskbarInset(bottomEdge: true);
             if (SettingsManager.Current.FlyoutAnimationSpeed == 0)
                 moveAnimation.From = moveAnimation.To;
             else

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1806,6 +1806,14 @@ public partial class MainWindow : MicaWindow
 
                         // Now it is safe to recreate tray icon
                         RecreateTrayIconSafely();
+
+                        // Explorer recreates the native volume OSD window, so a
+                        // previously hidden OSD comes back until re-hidden.
+                        if (SettingsManager.Current.VolumeControlEnabled)
+                        {
+                            Logger.Info("Re-hiding native volume OSD after Explorer restart");
+                            VolumeMixerWindow.RehideVolumeOsdAfterExplorerRestart();
+                        }
                     }
                     else
                     {

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -596,6 +596,8 @@ public partial class MainWindow : MicaWindow
         else if (alwaysBottom == false)
         {
             _position = SettingsManager.Current.Position;
+            if (_position < 0 || _position > 5)
+                _position = 1; // corrupted setting: fall back to bottom-center so the flyout always lands on-screen
             if (_position == 0)
             {
                 window_left = workArea.Left + 16;
@@ -667,6 +669,11 @@ public partial class MainWindow : MicaWindow
         // Set the initial position in raw coordinates.
         WindowHelper.SetPosition(window, window_left, moveAnimation.From!.Value);
 
+        // Capture the exact resting position in raw pixels before converting to
+        // DIPs below; used for the post-animation correction.
+        double restLeftRaw = window_left;
+        double restTopRaw = moveAnimation.To ?? moveAnimation.From.Value;
+
         // Next coordinates will be used to set Window.Top, which takes DPI into account,
         // so we need to convert the coordinates to DPI scale.
         moveAnimation.From *= 96.0 / monitor.dpiY;
@@ -686,6 +693,37 @@ public partial class MainWindow : MicaWindow
         storyboard.Begin(window);
         WindowHelper.SetVisibility(window, true);
         WindowHelper.SetTopmost(window);
+
+        Logger.Info($"Flyout '{window.GetType().Name}' shown at raw ({restLeftRaw:0}, {restTopRaw:0}) on '{monitor.deviceName}' ({monitor.workArea.Width:0}x{monitor.workArea.Height:0}@{monitor.workArea.Left:0},{monitor.workArea.Top:0} dpiY={monitor.dpiY})");
+
+        // Guarantee the resting position in raw pixels once the flight ends. On
+        // mixed-DPI multi-monitor setups the DIP scaling above can race the
+        // window's DPI flip, stranding the flyout off-screen so it never
+        // appears. The async correction is a no-op when already correct.
+        _ = Task.Run(async () =>
+        {
+            try { await Task.Delay(msDuration + 150); } catch { return; }
+            try
+            {
+                await Dispatcher.InvokeAsync(() =>
+                {
+                    try
+                    {
+                        if (!window.IsVisible)
+                            return;
+                        WindowHelper.SetPosition(window, restLeftRaw, restTopRaw, async: true);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Debug(ex, "Flyout resting-position correction failed");
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "Flyout resting-position dispatch failed");
+            }
+        });
     }
 
     public void CloseAnimation(MicaWindow window, MonitorInfo? selectedMonitor = null)
@@ -1025,10 +1063,13 @@ public partial class MainWindow : MicaWindow
     public async void ShowMediaFlyout(bool toggleMode = false, bool forceShow = false)
     {
         var activeSession = GetActiveMediaSession();
-        if (activeSession == null ||
-            (!forceShow && !SettingsManager.Current.MediaFlyoutEnabled) ||
-            FullscreenDetector.IsFullscreenApplicationRunning())
+        bool flyoutEnabled = forceShow || SettingsManager.Current.MediaFlyoutEnabled;
+        bool fullscreenBlock = FullscreenDetector.IsFullscreenApplicationRunning();
+        if (activeSession == null || !flyoutEnabled || fullscreenBlock)
+        {
+            Logger.Info($"ShowMediaFlyout suppressed: session={(activeSession == null ? "none" : activeSession.Id)}, enabled={flyoutEnabled}, fullscreenBlock={fullscreenBlock}");
             return;
+        }
 
         // If in toggle mode and flyout is visible, close it
         if (toggleMode && Visibility == Visibility.Visible && !_isHiding)

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -968,6 +968,15 @@ public partial class MainWindow : MicaWindow
 
         var playbackInfo = currentActiveSession.ControlSession.GetPlaybackInfo();
 
+        if (_seekBarEnabled && currentActiveSession.Id == mediaSession.Id)
+        {
+            // A track change can arrive as a media-property event without a
+            // separate timeline event. Read the new timeline immediately so the
+            // seekbar does not retain the previous track's position (#153).
+            var timeline = currentActiveSession.ControlSession.GetTimelineProperties();
+            UpdateSeekbarCurrentDuration(timeline.Position);
+        }
+
         // Players republish empty metadata for a moment when a track restarts
         // (looping a song in YouTube Music) before sending the real properties.
         // Pushing that blank snapshot left the taskbar widget showing only the

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -881,10 +881,19 @@ public partial class MainWindow : MicaWindow
 
     private void pauseOtherMediaSessionsIfNeeded(MediaSession mediaSession)
     {
-        if (
-            SettingsManager.Current.PauseOtherSessionsEnabled
-            && mediaSession.ControlSession.GetPlaybackInfo().PlaybackStatus == GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing
-            )
+        if (!SettingsManager.Current.PauseOtherSessionsEnabled)
+            return;
+
+        // Only the session the user actually interacted with may pause the
+        // others. This ran for every session that raised an event, so a
+        // background player emitting a property/playback update paused the
+        // session the user had just started, which then paused the first one
+        // back - the "exclusive audio mode" ping-pong between e.g. Spotify and
+        // a browser video (#1084).
+        if (GetActiveMediaSession() is not { } activeSession || activeSession.Id != mediaSession.Id)
+            return;
+
+        if (mediaSession.ControlSession?.GetPlaybackInfo()?.PlaybackStatus == GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing)
         {
             PauseOtherSessions(mediaSession);
         }

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -2218,6 +2218,18 @@ public partial class MainWindow : MicaWindow
 
         BitmapHelper.GetDominantColors(1);
         volumeMixerWindow = new VolumeMixerWindow();
+
+        // Hide the native volume OSD up front instead of waiting for the first
+        // volume key press. The OSD's XAML island only had to be found once we
+        // already wanted to show our own flyout, so the very first volume change
+        // after login still popped the Windows flyout - and if that lookup failed
+        // it was never retried, leaving the native flyout visible for the whole
+        // session (#966, #1078).
+        if (SettingsManager.Current.VolumeControlEnabled)
+        {
+            VolumeMixerWindow.RehideVolumeOsdAfterExplorerRestart();
+        }
+
         taskbarWindow = new TaskbarWindow();
         UpdateTaskbar();
     }

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1466,6 +1466,9 @@ public partial class MainWindow : MicaWindow
                 MediaIdButton.Visibility = Visibility.Collapsed;
                 SongImageBorder.Margin = new Thickness(0);
                 SongImageBorder.Height = 36;
+                // keep the album art square: only Height was updated here, so the
+                // 78px design width from XAML stayed and stretched the cover (#1019)
+                SongImageBorder.Width = 36;
                 SongInfoStackPanel.Margin = new Thickness(8, 0, 0, 0);
                 SongInfoStackPanel.Width = 182;
                 if (SettingsManager.Current.MediaFlyoutAlwaysDisplay)
@@ -1488,6 +1491,7 @@ public partial class MainWindow : MicaWindow
                 MediaIdButton.Visibility = Visibility.Visible;
                 SongImageBorder.Margin = new Thickness(6);
                 SongImageBorder.Height = 78;
+                SongImageBorder.Width = 78;
                 SongInfoStackPanel.Margin = new Thickness(12, 0, 0, 0);
                 SongInfoStackPanel.Width = 182 - 72 + extraWidth;
             }

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -2181,6 +2181,4 @@ public partial class MainWindow : MicaWindow
         // Use the updated ShowMediaFlyout method with toggle mode to close the flyout
         ShowMediaFlyout(toggleMode: true);
     }
-}ShowMediaFlyout(toggleMode: true);
-}
 }

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -229,6 +229,19 @@ public partial class MainWindow : MicaWindow
         mediaManager.OnAnyTimelinePropertyChanged += MediaManager_OnAnyTimelinePropertyChanged;
         mediaManager.OnAnySessionClosed += MediaManager_OnAnySessionClosed;
 
+        // Monitor power-off and lock/unlock destroy or reshuffle the taskbar's
+        // child windows without sending us WM_DISPLAYCHANGE, so the widget was
+        // silently gone after unlocking (#983). Rebuild placement on resume.
+        try
+        {
+            SystemEvents.SessionSwitch += OnSystemSessionSwitch;
+            SystemEvents.PowerModeChanged += OnSystemPowerModeChanged;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "Failed to register SystemEvents handlers for window recovery");
+        }
+
         WM_TASKBARCREATED = RegisterWindowMessage("TaskbarCreated");
         WM_SHELLHOOK = RegisterWindowMessage("SHELLHOOK");
         RegisterShellHookWindow(new WindowInteropHelper(this).Handle);
@@ -1746,6 +1759,16 @@ public partial class MainWindow : MicaWindow
             _displayRefreshTimer.Stop();
             _displayRefreshTimer.Tick -= DisplayRefreshTimer_Tick;
 
+            try
+            {
+                SystemEvents.SessionSwitch -= OnSystemSessionSwitch;
+                SystemEvents.PowerModeChanged -= OnSystemPowerModeChanged;
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "Failed to unregister SystemEvents handlers");
+            }
+
             // unsubscribe from events
             mediaManager.OnAnyMediaPropertyChanged -= MediaManager_OnAnyMediaPropertyChanged;
             mediaManager.OnAnyPlaybackStateChanged -= CurrentSession_OnPlaybackStateChanged;
@@ -1862,6 +1885,21 @@ public partial class MainWindow : MicaWindow
         _displayRefreshTimer.Stop();
         _displayRefreshTimer.Start();
         Logger.Debug($"Scheduled display environment refresh: {reason}");
+    }
+
+    private void OnSystemSessionSwitch(object sender, SessionSwitchEventArgs e)
+    {
+        if (e.Reason is SessionSwitchReason.SessionUnlock or SessionSwitchReason.SessionLogon
+            or SessionSwitchReason.RemoteConnect or SessionSwitchReason.ConsoleConnect)
+        {
+            ScheduleDisplayEnvironmentRefresh($"session switch: {e.Reason}");
+        }
+    }
+
+    private void OnSystemPowerModeChanged(object sender, PowerModeChangedEventArgs e)
+    {
+        if (e.Mode == PowerModes.Resume)
+            ScheduleDisplayEnvironmentRefresh("power resume");
     }
 
     private void DisplayRefreshTimer_Tick(object? sender, EventArgs e)

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -990,7 +990,10 @@ public partial class MainWindow : MicaWindow
             return;
         }
 
-        string check = songInfo.Title + songInfo.Artist + playbackInfo.PlaybackStatus;
+        // Dedupe per media session. Two players can publish the same title,
+        // artist and state; a process-wide key would then suppress the second
+        // player's update and leave the widget showing stale metadata (#659).
+        string check = mediaSession.Id + "\0" + songInfo.Title + songInfo.Artist + playbackInfo.PlaybackStatus;
         int checkThumbnail = BitmapHelper.GetStableThumbnailHash(songInfo.Thumbnail);
         bool onlyThumbnailChanged = false;
         if (previousMediaProperty == check)

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -61,6 +61,41 @@ public partial class MainWindow : MicaWindow
     private int _themeOption = SettingsManager.Current.AppTheme;
 
     static Mutex singleton = new Mutex(true, "FluentFlyout"); // to prevent multiple instances of the app
+
+    /// <summary>
+    /// True when another same-named process started very recently (boot/login
+    /// storms, duplicate autostart entries). Used to swallow the
+    /// open-settings signal such launches would otherwise trigger.
+    /// </summary>
+    private static bool IsFirstInstanceStartingUp()
+    {
+        try
+        {
+            using var me = Process.GetCurrentProcess();
+            foreach (var proc in Process.GetProcessesByName(me.ProcessName))
+            {
+                try
+                {
+                    if (proc.Id != me.Id &&
+                        (DateTime.UtcNow - proc.StartTime.ToUniversalTime()).TotalSeconds < 30)
+                        return true;
+                }
+                catch
+                {
+                    // process exited or start time unreadable; ignore
+                }
+                finally
+                {
+                    try { proc.Dispose(); } catch { }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Debug(ex, "Failed to check first-instance startup age");
+        }
+        return false;
+    }
     private NextUpWindow? nextUpWindow = null; // to prevent multiple instances of NextUpWindow
     private string currentTitle = ""; // to prevent NextUpWindow from showing the same song
 
@@ -99,6 +134,17 @@ public partial class MainWindow : MicaWindow
 
         if (!singleton.WaitOne(TimeSpan.Zero, true)) // if another instance is already running, close this one
         {
+            // A second launch with no live user behind it (duplicate autostart
+            // entries, boot storms, updater re-launch) must not pop the
+            // settings window on the running instance (#1029: window appearing
+            // on every boot). Only forward the open-settings signal when the
+            // first instance is past its startup window.
+            if (IsFirstInstanceStartingUp())
+            {
+                Logger.Info("Duplicate launch during first-instance startup; exiting silently without opening settings.");
+                Environment.Exit(0);
+            }
+
             // Signal the existing instance to open settings
             Task.Run(() =>
             {

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -2003,6 +2003,19 @@ public partial class MainWindow : MicaWindow
                         // Now it is safe to recreate tray icon
                         RecreateTrayIconSafely();
 
+                        // The widget is a WS_CHILD of the old Shell_TrayWnd. After
+                        // an Explorer restart that parent HWND is dead: the child
+                        // keeps its hit-test region (clicks still register) but is
+                        // never composited again, so the widget and visualizer are
+                        // invisible until Explorer is restarted a second time
+                        // (#1065, #1052). Reparenting alone doesn't restore
+                        // rendering, so rebuild the window against the new taskbar.
+                        if (SettingsManager.Current.TaskbarWidgetEnabled || SettingsManager.Current.TaskbarVisualizerEnabled)
+                        {
+                            Logger.Info("Recreating Taskbar Widget window after Explorer restart");
+                            RecreateTaskbarWindow();
+                        }
+
                         // Explorer recreates the native volume OSD window, so a
                         // previously hidden OSD comes back until re-hidden.
                         if (SettingsManager.Current.VolumeControlEnabled)

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1702,6 +1702,17 @@ public partial class MainWindow : MicaWindow
         if (GetActiveMediaSession() is not { } session) return;
 
         var timeline = session.ControlSession.GetTimelineProperties();
+        var playbackStatus = session.ControlSession.GetPlaybackInfo()?.PlaybackStatus;
+        if (playbackStatus != GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing)
+        {
+            // Timeline.LastUpdatedTime is commonly left at the last playing
+            // timestamp while a browser is paused. Do not extrapolate from it or
+            // the seekbar keeps counting in the background (#746).
+            HandlePlayBackState(playbackStatus);
+            UpdateSeekbarCurrentDuration(timeline.Position);
+            return;
+        }
+
         var pos = timeline.Position + (DateTime.Now - timeline.LastUpdatedTime.DateTime);
         if (pos > timeline.EndTime)
         {

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -1109,6 +1109,21 @@ public partial class MainWindow : MicaWindow
         {
             // task was canceled, do nothing
         }
+        catch (Exception ex)
+        {
+            // Never let the auto-hide loop take the process down: an async void
+            // throw here is an abnormal exit with no further logging.
+            Logger.Error(ex, "Media flyout loop failed, hiding flyout");
+            try
+            {
+                _isHiding = true;
+                Hide();
+            }
+            catch (Exception hideEx)
+            {
+                Logger.Debug(hideEx, "Media flyout emergency hide failed");
+            }
+        }
     }
 
     private void UpdateMediaFlyoutCloseButtonVisibility()

--- a/FluentFlyoutWPF/MainWindow.xaml.cs
+++ b/FluentFlyoutWPF/MainWindow.xaml.cs
@@ -735,21 +735,46 @@ public partial class MainWindow : MicaWindow
         DoubleAnimation moveAnimation = (DoubleAnimation)storyboard.Children[0];
         var monitor = selectedMonitor != null ? selectedMonitor.Value : getSelectedMonitor();
         var workArea = monitor.workArea;
-        Rect windowRect = WindowHelper.GetPlacement(window);
+
+        // Use the window's actual current rendered position as the animation
+        // start. GetWindowPlacement can report zeros for transient handles and
+        // the selected monitor's DPI may differ from the monitor hosting the
+        // flyout - either made From wrong, so the first frame snapped
+        // (flyout jumps upward) before animating downward.
+        double dpiY = monitor.dpiY;
+        double currentTopPhys = double.NaN;
+        try
+        {
+            currentTopPhys = window.PointToScreen(new Point(0, 0)).Y;
+            var host = MonitorUtil.GetMonitor(window);
+            if (host.dpiY > 0)
+                dpiY = host.dpiY;
+        }
+        catch (Exception ex)
+        {
+            Logger.Debug(ex, "CloseAnimation PointToScreen failed, falling back to placement");
+        }
+        var placementRect = WindowHelper.GetPlacement(window);
+        if (double.IsNaN(currentTopPhys))
+            currentTopPhys = placementRect.Top;
+        if (dpiY <= 0)
+            dpiY = 96;
 
         // Use the window's actual current position as the animation start
-        moveAnimation.From = windowRect.Top;
+        moveAnimation.From = currentTopPhys * 96.0 / dpiY;
 
+        // Determine slide direction (physical pixels throughout)
+        bool isTopHalf = currentTopPhys + placementRect.Height / 2 < workArea.Top + workArea.Height / 2;
         if (SettingsManager.Current.FlyoutAnimationSpeed != 0)
         {
-            // Determine slide direction
-            bool isTopHalf = windowRect.Top + windowRect.Height / 2 < workArea.Top + workArea.Height / 2;
-            moveAnimation.To = windowRect.Top + (isTopHalf ? -20 : 20);
+            moveAnimation.To = moveAnimation.From + (isTopHalf ? -20 : 20);
         }
-
-        moveAnimation.From *= 96.0 / monitor.dpiY;
-        if (moveAnimation.To != null)
-            moveAnimation.To *= 96.0 / monitor.dpiY;
+        else
+        {
+            // Animations off: still pin To to From so a stale storyboard value
+            // can't teleport the window on the zero-duration snap.
+            moveAnimation.To = moveAnimation.From;
+        }
 
         int msDuration = getDuration();
 
@@ -998,22 +1023,65 @@ public partial class MainWindow : MicaWindow
             bool mediaKeysPressed = vkCode == 0xB3 || vkCode == 0xB0 || vkCode == 0xB1 || vkCode == 0xB2; // Play/Pause, next, previous, stop
             bool volumeKeysPressed = vkCode == 0xAD || vkCode == 0xAE || vkCode == 0xAF; // Mute, Volume Down, Volume Up
 
-            // MainWindow.WndProc() also handles media and volume keys
+            // MainWindow.WndProc() also handles media and volume keys.
+            // NOTE: a low-level keyboard hook must return to Windows immediately.
+            // ShowMediaFlyout does blocking UI/COM work (Dispatcher.Invoke, media
+            // property fetches, animations); doing it synchronously here stalls
+            // every keystroke system-wide and Windows silently drops slow hooks,
+            // which breaks Alt+Tab and the media keys themselves over time
+            // (worse at boot when everything is slow). Queue it instead.
             if (mediaKeysPressed || volumeKeysPressed)
             {
-                bool result = false;
                 if (mediaKeysPressed || (!SettingsManager.Current.MediaFlyoutVolumeKeysExcluded && volumeKeysPressed))
-                    result = TryShowMediaFlyoutDebounced();
+                {
+                    long currentTime = Environment.TickCount64;
+                    // debounce to prevent hangs with rapid key presses
+                    if ((currentTime - _lastFlyoutTime) >= 500) // 500ms debounce time
+                    {
+                        _lastFlyoutTime = currentTime;
+                        _ = Dispatcher.BeginInvoke(() =>
+                        {
+                            try { ShowMediaFlyout(); }
+                            catch (Exception ex) { Logger.Debug(ex, "Show media flyout from hook failed"); }
+                        });
+                    }
+                }
 
                 if (SettingsManager.Current.VolumeControlEnabled)
                 {
-                    volumeMixerWindow?.ViewModel.SyncMasterFromDevice();
-                    volumeMixerWindow?.ShowFlyout();
-                }
-
-                if (!result)
-                {
-                    return CallNextHookEx(_hookId, nCode, wParam, lParam);
+                    // SyncMasterFromDevice is dispatcher-aware (marshals to UI thread itself).
+                    // ShowFlyout is queued to the UI thread so this hook returns to
+                    // Windows immediately. The hook fires before the OS applies the
+                    // volume step, so the live OnVolumeNotification subscription in
+                    // VolumeMixerViewModel is the source of truth for the final value.
+                    var mixerWindow = volumeMixerWindow;
+                    try
+                    {
+                        mixerWindow.ViewModel.SyncMasterFromDevice();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Debug(ex, "Volume sync from hook failed");
+                    }
+                    try
+                    {
+                        if (Dispatcher.CheckAccess())
+                        {
+                            mixerWindow.ShowFlyout();
+                        }
+                        else
+                        {
+                            _ = Dispatcher.BeginInvoke(() =>
+                            {
+                                try { mixerWindow.ShowFlyout(); }
+                                catch (Exception ex) { Logger.Debug(ex, "Show volume flyout from hook failed"); }
+                            });
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Debug(ex, "Failed to dispatch volume flyout");
+                    }
                 }
             }
 
@@ -2114,5 +2182,5 @@ public partial class MainWindow : MicaWindow
         ShowMediaFlyout(toggleMode: true);
     }
 }ShowMediaFlyout(toggleMode: true);
-    }
+}
 }

--- a/FluentFlyoutWPF/Models/AudioSessionModel.cs
+++ b/FluentFlyoutWPF/Models/AudioSessionModel.cs
@@ -12,6 +12,7 @@ namespace FluentFlyoutWPF.Models;
 public partial class AudioSessionModel : ObservableObject
 {
     private readonly AudioSessionControl _sessionControl;
+    private bool _syncing;
 
     [ObservableProperty]
     public partial string DisplayName { get; set; }
@@ -49,6 +50,7 @@ public partial class AudioSessionModel : ObservableObject
 
     partial void OnVolumeChanged(float value)
     {
+        if (_syncing) return;
         _sessionControl.SimpleAudioVolume.Volume = Math.Clamp(value, 0f, 1f);
         if (Volume == 0f)
         {
@@ -81,13 +83,21 @@ public partial class AudioSessionModel : ObservableObject
     /// </summary>
     public void SyncFromDevice()
     {
-        var vol = _sessionControl.SimpleAudioVolume.Volume;
-        var mute = _sessionControl.SimpleAudioVolume.Mute;
+        _syncing = true;
+        try
+        {
+            var vol = _sessionControl.SimpleAudioVolume.Volume;
+            var mute = _sessionControl.SimpleAudioVolume.Mute;
 
-        if (MathF.Abs(Volume - vol) > 0.001f)
-            Volume = vol;
+            if (MathF.Abs(Volume - vol) > 0.001f)
+                Volume = vol;
 
-        if (IsMuted != mute)
-            IsMuted = mute;
+            if (IsMuted != mute)
+                IsMuted = mute;
+        }
+        finally
+        {
+            _syncing = false;
+        }
     }
 }

--- a/FluentFlyoutWPF/Models/AudioSessionModel.cs
+++ b/FluentFlyoutWPF/Models/AudioSessionModel.cs
@@ -64,6 +64,7 @@ public partial class AudioSessionModel : ObservableObject
 
     partial void OnIsMutedChanged(bool value)
     {
+        if (_syncing) return;
         _sessionControl.SimpleAudioVolume.Mute = value;
     }
 

--- a/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
+++ b/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
@@ -254,6 +254,13 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
             var sessionManager = updatedDevice.AudioSessionManager;
             var sessions = sessionManager.Sessions;
 
+            // Apps that open several WASAPI sessions (or several processes of the
+            // same executable, e.g. Flow Launcher) previously produced one row per
+            // session. The native Windows mixer groups them per app, so keep only
+            // the first session of each process id / display name (#973).
+            var seenProcessIds = new HashSet<int>();
+            var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
             for (int i = 0; i < sessions.Count; i++)
             {
                 var session = sessions[i];
@@ -265,6 +272,10 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
                 string name = pid != 0 ? GetSessionDisplayName(session) : "System sounds";
 
                 if (name == "FluentFlyout") continue;
+
+                // pid 0 is "System sounds", which is a single logical entry
+                if (pid != 0 && !seenProcessIds.Add(pid)) continue;
+                if (!seenNames.Add(name)) continue;
 
                 var icon = MediaPlayerData.GetAndCacheProcessIcon(pid, name);
                 var audioSession = new AudioSessionModel(session, name, pid, sessionState, icon);

--- a/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
+++ b/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
@@ -278,9 +278,18 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
 
         foreach (var session in Sessions)
         {
-            session.SyncFromDevice();
-            //Logger.Trace("Session '{0}' (PID {1}) - Volume: {2}, Muted: {3}, State: {4}",
-            //    session.DisplayName, session.ProcessId, session.Volume, session.IsMuted, session.State);
+            try
+            {
+                session.SyncFromDevice();
+                //Logger.Trace("Session '{0}' (PID {1}) - Volume: {2}, Muted: {3}, State: {4}",
+                //    session.DisplayName, session.ProcessId, session.Volume, session.IsMuted, session.State);
+            }
+            catch (Exception ex)
+            {
+                // A single dead session (process exited mid-poll) must not break
+                // the mixer refresh, let alone the flyout loop calling us.
+                Logger.Debug(ex, "Failed to sync session '{0}' (PID {1})", session.DisplayName, session.ProcessId);
+            }
         }
     }
 

--- a/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
+++ b/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
@@ -214,20 +214,52 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
             uint pid = session.GetProcessID;
             if (pid != 0)
             {
-                var process = Process.GetProcessById((int)pid);
-                var mainModule = process.MainModule;
-
-                if (mainModule != null)
+                // Resolve via the exe path: FileVersionInfo reads the file, so it
+                // works for elevated/admin processes whose MainModule denies
+                // access to a non-elevated caller (previously: "Unknown").
+                string? path = null;
+                try
                 {
-                    return !string.IsNullOrWhiteSpace(mainModule.FileVersionInfo.FileDescription)
-                    ? mainModule.FileVersionInfo.FileDescription
-                    : process.MainWindowTitle;
+                    path = MediaPlayerData.TryGetProcessPath((int)pid);
                 }
-                else
+                catch
                 {
+                    // fall through to the ProcessName fallback below
+                }
+
+                if (!string.IsNullOrWhiteSpace(path))
+                {
+                    try
+                    {
+                        var versionInfo = FileVersionInfo.GetVersionInfo(path);
+                        if (!string.IsNullOrWhiteSpace(versionInfo.FileDescription))
+                            return versionInfo.FileDescription;
+                    }
+                    catch
+                    {
+                        // unreadable version resource, use process name below
+                    }
+
+                    try
+                    {
+                        return System.IO.Path.GetFileNameWithoutExtension(path);
+                    }
+                    catch
+                    {
+                        // fall through
+                    }
+                }
+
+                try
+                {
+                    using var process = Process.GetProcessById((int)pid);
                     return process.MainWindowTitle is { Length: > 0 } title
-                    ? title
-                    : process.ProcessName;
+                        ? title
+                        : process.ProcessName;
+                }
+                catch
+                {
+                    // Process may have exited
                 }
             }
         }

--- a/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
+++ b/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using FluentFlyout.Classes.Utils;
 using FluentFlyoutWPF.Classes;
 using FluentFlyoutWPF.Models;
+using Microsoft.Win32;
 using NAudio.CoreAudioApi;
 using NAudio.CoreAudioApi.Interfaces;
 using System.Collections.ObjectModel;
@@ -43,6 +44,7 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
     {
         DeviceName = string.Empty;
         AudioDeviceMonitor.Instance.DefaultDeviceChanged += OnDefaultDeviceChanged;
+        TryRegisterSystemEvents();
 
         AttachDevice(AudioDeviceMonitor.Instance.GetDefaultRenderDevice());
 
@@ -85,6 +87,7 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
         });
     }
 
+<<<<<<< HEAD
     private void OnSessionVolumeChanged(object? sender, EventArgs e)
     {
         SessionVolumeChanged?.Invoke(sender, e);
@@ -96,6 +99,77 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
             session.VolumeChanged -= OnSessionVolumeChanged;
 
         Sessions.Clear();
+=======
+    private void TryRegisterSystemEvents()
+    {
+        try
+        {
+            SystemEvents.SessionSwitch += OnSessionSwitch;
+            SystemEvents.PowerModeChanged += OnPowerModeChanged;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "Failed to register SystemEvents handlers for volume mixer recovery");
+        }
+    }
+
+    private void TryUnregisterSystemEvents()
+    {
+        try
+        {
+            SystemEvents.SessionSwitch -= OnSessionSwitch;
+            SystemEvents.PowerModeChanged -= OnPowerModeChanged;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "Failed to unregister SystemEvents handlers for volume mixer recovery");
+        }
+    }
+
+    private void OnSessionSwitch(object sender, SessionSwitchEventArgs e)
+    {
+        if (e.Reason == SessionSwitchReason.SessionUnlock || e.Reason == SessionSwitchReason.SessionLogon)
+            RecoverAudioDeviceAfterResume($"session switch: {e.Reason}");
+    }
+
+    private void OnPowerModeChanged(object sender, PowerModeChangedEventArgs e)
+    {
+        if (e.Mode == PowerModes.Resume)
+            RecoverAudioDeviceAfterResume("power resume");
+    }
+
+    private void RecoverAudioDeviceAfterResume(string reason)
+    {
+        // S3 resume invalidates the cached MMDevice (volume flyout frozen, mixer
+        // showing a single stale session) and often fires no DefaultDeviceChanged
+        // on desktops, so re-resolve the default endpoint after the audio stack settles.
+        Logger.Info($"Reattaching volume mixer after resume ({reason})");
+        _ = Task.Run(async () =>
+        {
+            try { await Task.Delay(2000); } catch { }
+            try
+            {
+                var app = System.Windows.Application.Current;
+                if (app?.Dispatcher == null)
+                    return;
+                await app.Dispatcher.InvokeAsync(() =>
+                {
+                    try
+                    {
+                        AttachDevice(AudioDeviceMonitor.Instance.GetDefaultRenderDevice());
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex, "Volume mixer resume reattach failed");
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Volume mixer resume recovery failed");
+            }
+        });
+>>>>>>> d8793a5 (Fix #1071: recover visualizer + volume mixer after S3 sleep/resume)
     }
 
 
@@ -304,6 +378,7 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
         }
 
         AudioDeviceMonitor.Instance.DefaultDeviceChanged -= OnDefaultDeviceChanged;
+        TryUnregisterSystemEvents();
 
         ClearSessions();
 

--- a/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
+++ b/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
@@ -292,10 +292,10 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
             }
 
             if (MathF.Abs(MasterVolume - vol) > 0.001f)
-            MasterVolume = vol;
+                MasterVolume = vol;
 
-        if (IsMasterMuted != mute)
-            IsMasterMuted = mute;
+            if (IsMasterMuted != mute)
+                IsMasterMuted = mute;
         }
         catch (Exception ex)
         {

--- a/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
+++ b/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
@@ -291,7 +291,12 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
 
     private static string GetSessionDisplayName(AudioSessionControl session)
     {
-        if (!string.IsNullOrWhiteSpace(session.DisplayName))
+        // WASAPI DisplayName is often an unresolved indirect string resource
+        // ("@%SystemRoot%\System32\foo.dll,-123" / "@{Package?ms-resource:...}"),
+        // which was shown verbatim or left the row blank (#1087). Only accept a
+        // literal name here; anything resource-shaped falls through to the exe.
+        if (!string.IsNullOrWhiteSpace(session.DisplayName)
+            && !session.DisplayName.StartsWith('@'))
             return session.DisplayName;
 
         try

--- a/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
+++ b/FluentFlyoutWPF/ViewModels/VolumeMixerViewModel.cs
@@ -83,11 +83,15 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
 
         System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
         {
-            AttachDevice(AudioDeviceMonitor.Instance.GetDeviceById(e.DeviceId));
+            // GetDeviceById returns null when the reported id is empty or already
+            // gone; attaching null would leave the mixer permanently detached and
+            // the flyout frozen, so fall back to the current default endpoint.
+            var device = AudioDeviceMonitor.Instance.GetDeviceById(e.DeviceId)
+                         ?? AudioDeviceMonitor.Instance.GetDefaultRenderDevice();
+            AttachDevice(device);
         });
     }
 
-<<<<<<< HEAD
     private void OnSessionVolumeChanged(object? sender, EventArgs e)
     {
         SessionVolumeChanged?.Invoke(sender, e);
@@ -99,7 +103,8 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
             session.VolumeChanged -= OnSessionVolumeChanged;
 
         Sessions.Clear();
-=======
+    }
+
     private void TryRegisterSystemEvents()
     {
         try
@@ -169,7 +174,6 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
                 Logger.Error(ex, "Volume mixer resume recovery failed");
             }
         });
->>>>>>> d8793a5 (Fix #1071: recover visualizer + volume mixer after S3 sleep/resume)
     }
 
 
@@ -201,6 +205,7 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
 
     public bool TryAdjustMasterVolume(float delta)
     {
+        EnsureDeviceAttached();
         if (_device == null) return false;
 
         MasterVolume = Math.Clamp(MasterVolume + delta, 0f, 1f);
@@ -224,18 +229,78 @@ public partial class VolumeMixerViewModel : ObservableObject, IDisposable
     }
 
 
+    /// <summary>
+    /// Re-resolves the default render endpoint when we have none. The device can
+    /// be missing because it wasn't ready yet when the mixer was constructed
+    /// (early startup) or because a previous attach failed; without this the
+    /// view model stays permanently detached and the flyout shows a frozen
+    /// volume value while the system volume keeps changing (#1086).
+    /// </summary>
+    private void EnsureDeviceAttached()
+    {
+        if (_device != null) return;
+
+        try
+        {
+            var device = AudioDeviceMonitor.Instance.GetDefaultRenderDevice();
+            if (device == null) return;
+
+            Logger.Info("Volume mixer had no audio endpoint, attaching default render device");
+            AttachDevice(device);
+        }
+        catch (Exception ex)
+        {
+            Logger.Debug(ex, "Failed to lazily attach default render device");
+        }
+    }
+
     public void SyncMasterFromDevice()
     {
-        if (_device == null) return;
+        if (_device == null)
+        {
+            var app0 = System.Windows.Application.Current;
+            if (app0?.Dispatcher != null && !app0.Dispatcher.CheckAccess())
+            {
+                _ = app0.Dispatcher.InvokeAsync(SyncMasterFromDevice);
+                return;
+            }
 
-        var vol = _device.AudioEndpointVolume.MasterVolumeLevelScalar;
-        var mute = _device.AudioEndpointVolume.Mute;
+            EnsureDeviceAttached();
+            if (_device == null) return;
+        }
 
-        if (MathF.Abs(MasterVolume - vol) > 0.001f)
+        try
+        {
+            var app = System.Windows.Application.Current;
+            if (app?.Dispatcher != null && !app.Dispatcher.CheckAccess())
+            {
+                _ = app.Dispatcher.InvokeAsync(SyncMasterFromDevice);
+                return;
+            }
+
+            float vol;
+            bool mute;
+            try
+            {
+                vol = _device.AudioEndpointVolume.MasterVolumeLevelScalar;
+                mute = _device.AudioEndpointVolume.Mute;
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "Failed to read master volume from device");
+                return;
+            }
+
+            if (MathF.Abs(MasterVolume - vol) > 0.001f)
             MasterVolume = vol;
 
         if (IsMasterMuted != mute)
             IsMasterMuted = mute;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to sync master volume from device");
+        }
     }
 
 

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml
@@ -19,8 +19,10 @@
         Loaded="Window_Loaded" Visibility="Collapsed" d:Visibility="Visible"
         xmlns:viewModels="clr-namespace:FluentFlyoutWPF.ViewModels"
 		d:DataContext="{d:DesignInstance viewModels:UserSettings}">
-    <Canvas Name="WidgetCanvas" Background="Transparent">
-		<controls:TaskbarVisualizerControl x:Name="TaskbarVisualizer" Margin="0,1,0,0" />
-        <controls:TaskbarWidgetControl x:Name="Widget" />
+    <!-- Keep the host coordinate system LTR; RTL is applied to the widget content
+         itself so Canvas.Left/Top continue to describe taskbar pixels (#529). -->
+    <Canvas Name="WidgetCanvas" Background="Transparent" FlowDirection="LeftToRight">
+			<controls:TaskbarVisualizerControl x:Name="TaskbarVisualizer" Margin="0,1,0,0" FlowDirection="LeftToRight" />
+        <controls:TaskbarWidgetControl x:Name="Widget" FlowDirection="{Binding FlowDirection}" />
     </Canvas>
 </Window>

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
@@ -93,6 +93,29 @@ public partial class TaskbarWindow : Window
         // Also prevents the widget from blocking taskbar's message processing, which is another source of freezes.
         switch (msg)
         {
+            case 0x007E: // WM_DISPLAYCHANGE - monitor added/removed, resolution or projection changed.
+                // Topology changes can orphan our taskbar parent, stale cached
+                // handles/regions (ghost widget that still eats clicks), and
+                // poisoned automation lookups. Re-resolve everything now instead
+                // of waiting for the next position tick. Not marked handled.
+                Dispatcher.BeginInvoke(() =>
+                {
+                    try
+                    {
+                        _trayHandle = IntPtr.Zero;
+                        _widgetElement = null;
+                        _trayElement = null;
+                        _taskbarFrameElement = null;
+                        _pendingAutomationTasks.Clear();
+                        _lastSelectedMonitor = -1;
+                        UpdatePosition();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex, "Taskbar Widget error during display-change recovery");
+                    }
+                }, DispatcherPriority.Background);
+                break;
             case 0x003D: // WM_GETOBJECT (Sent by Microsoft UI Automation to obtain information about an accessible object contained in a server application)
             case 0x0018: // WM_SHOWWINDOW
             case 0x0046: // WM_WINDOWPOSCHANGING - Triggers during alt-tabs, window changes
@@ -233,6 +256,26 @@ public partial class TaskbarWindow : Window
         {
             Logger.Error(ex, "Taskbar Widget error during setup");
         }
+    }
+
+    /// <summary>
+    /// Rejects region rects that cannot represent a real on-screen widget
+    /// (NaN/infinity from transient layout, overflowed int casts). Returns
+    /// <see cref="Rect.Empty"/> (click-through) instead of a taskbar-eating region.
+    /// </summary>
+    private static Rect SanitizeRegionRect(Rect rect)
+    {
+        if (rect == Rect.Empty)
+            return rect;
+
+        if (double.IsNaN(rect.X) || double.IsNaN(rect.Y) || double.IsNaN(rect.Width) || double.IsNaN(rect.Height) ||
+            double.IsInfinity(rect.X) || double.IsInfinity(rect.Y) || double.IsInfinity(rect.Width) || double.IsInfinity(rect.Height) ||
+            rect.Width <= 0 || rect.Height <= 0 ||
+            rect.Width > 100000 || rect.Height > 100000 ||
+            Math.Abs(rect.X) > 100000 || Math.Abs(rect.Y) > 100000)
+            return Rect.Empty;
+
+        return rect;
     }
 
     private void UpdateWindowRegion(IntPtr windowHandle, params Rect[] rects)
@@ -381,7 +424,14 @@ on_error:
 
             // Guard against invalid DPI (e.g. during explorer restart when handle is stale)
             if (dpiScale <= 0)
+            {
+                // Drop the hit-test region instead of keeping a stale one: a
+                // stale region leaves an invisible "ghost" widget that still
+                // eats taskbar clicks after topology changes.
+                try { UpdateWindowRegion(taskbarWindowHandle, Rect.Empty, Rect.Empty); }
+                catch (Exception ex) { Logger.Debug(ex, "Failed to reset taskbar widget region"); }
                 return;
+            }
 
             // Get Taskbar dimensions
             RECT taskbarRect;

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
@@ -149,8 +149,15 @@ public partial class TaskbarWindow : Window
     private IntPtr GetSelectedTaskbarHandle(out bool isMainTaskbarSelected)
     {
         var monitors = MonitorUtil.GetMonitors();
-        var selectedMonitor = monitors[Math.Clamp(SettingsManager.Current.TaskbarWidgetSelectedMonitor, 0, monitors.Count - 1)];
         isMainTaskbarSelected = true;
+
+        // Empty list during a display topology change: Math.Clamp(x, 0, -1)
+        // throws, which used to abort the position update and leave a stale
+        // hit-test region behind (#1085).
+        if (monitors.Count == 0)
+            return FindWindow("Shell_TrayWnd", null);
+
+        var selectedMonitor = monitors[Math.Clamp(SettingsManager.Current.TaskbarWidgetSelectedMonitor, 0, monitors.Count - 1)];
 
         // Get the main taskbar and check if it is on the selected monitor.
         var mainHwnd = FindWindow("Shell_TrayWnd", null);

--- a/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/TaskbarWindow.xaml.cs
@@ -56,7 +56,10 @@ public partial class TaskbarWindow : Window
         DataContext = SettingsManager.Current;
 
         _timer = new DispatcherTimer();
-        _timer.Interval = TimeSpan.FromMilliseconds(1500); // slow auto-update for display changes
+        // Auto-hide taskbars resize while they are being revealed. A 1.5s
+        // placement interval left the child window half clipped until the next
+        // reveal; refresh often enough to follow that transition (#849).
+        _timer.Interval = TimeSpan.FromMilliseconds(250);
         _timer.Tick += (s, e) => UpdatePosition();
         _timer.Start();
 

--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
@@ -72,62 +72,93 @@ public partial class VolumeMixerWindow : MicaWindow
 
         _lastFlyoutTime = currentTime;
 
-        if (_isHiding)
+        // Everything up to the auto-hide loop below used to run outside any
+        // try/catch. ShowFlyout is `async void`, so a single throw here (a
+        // blur/DWM call failing, placement running while the window is being
+        // torn down, a disposed CTS) went straight to the runtime and killed the
+        // process with no log entry - the abnormal exit on volume key press
+        // reported in #1075.
+        try
         {
-            if (_nativeOsdElement == IntPtr.Zero)
+            if (_isHiding)
             {
+                if (_nativeOsdElement == IntPtr.Zero)
+                {
+                    _ = Task.Run(() =>
+                    {
+                        HideVolumeOsd();
+                    });
+                }
+
+                _isHiding = false;
+                if (SettingsManager.Current.VolumeMixerAcrylicWindowEnabled)
+                {
+                    WindowBlurHelper.EnableBlur(this);
+                }
+                else
+                {
+                    WindowBlurHelper.DisableBlur(this);
+                }
+
+                // refresh all data
+                ViewModel.OnPollTick(null, EventArgs.Empty);
+
+                bool aboveMedia = SettingsManager.Current.VolumeControlAboveMediaFlyout;
+                if (aboveMedia)
+                {
+                    Width = _mainWindow.Width;
+                    _mainWindow.OpenAnimation(this, aboveReference: _mainWindow, reserveNativeVolumeOsdSpace: true);
+                }
+                else
+                {
+                    Width = _normalWidth;
+                    _mainWindow.OpenAnimation(this, alwaysBottom: true);
+                }
+
+                Show();
+                WindowHelper.SetTopmost(this);
+
                 _ = Task.Run(() =>
                 {
-                    HideVolumeOsd();
+                    Thread.Sleep(MainWindow.getDuration());
+                    try
+                    {
+                        Dispatcher.Invoke(() =>
+                        {
+                            if (startExpanded) ViewModel.IsExpanded = true;
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        // dispatcher shut down while we waited out the animation
+                        Logger.Debug(ex, "Deferred volume flyout expand failed");
+                    }
                 });
-            }
-
-            _isHiding = false;
-            if (SettingsManager.Current.VolumeMixerAcrylicWindowEnabled)
-            {
-                WindowBlurHelper.EnableBlur(this);
             }
             else
             {
-                WindowBlurHelper.DisableBlur(this);
+                // only expand if the flyout isn't expanded already
+                if (startExpanded) ViewModel.IsExpanded = true;
             }
-
-            // refresh all data
-            ViewModel.OnPollTick(null, EventArgs.Empty);
-
-            bool aboveMedia = SettingsManager.Current.VolumeControlAboveMediaFlyout;
-            if (aboveMedia)
-            {
-                Width = _mainWindow.Width;
-                _mainWindow.OpenAnimation(this, aboveReference: _mainWindow, reserveNativeVolumeOsdSpace: true);
-            }
-            else
-            {
-                Width = _normalWidth;
-                _mainWindow.OpenAnimation(this, alwaysBottom: true);
-            }
-
-            Show();
-            WindowHelper.SetTopmost(this);
-
-            _ = Task.Run(() =>
-            {
-                Thread.Sleep(MainWindow.getDuration());
-                Dispatcher.Invoke(() =>
-                {
-                    if (startExpanded) ViewModel.IsExpanded = true;
-                });
-            });
         }
-        else
+        catch (Exception ex)
         {
-            // only expand if the flyout isn't expanded already
-            if (startExpanded) ViewModel.IsExpanded = true;
+            Logger.Error(ex, "Failed to show volume flyout");
+            return;
         }
 
-        _cts.Cancel();
-        _cts = new CancellationTokenSource();
-        var token = _cts.Token;
+        CancellationToken token;
+        try
+        {
+            _cts.Cancel();
+            _cts = new CancellationTokenSource();
+            token = _cts.Token;
+        }
+        catch (ObjectDisposedException)
+        {
+            // window was closed while we were showing it
+            return;
+        }
 
         Logger.Info("Volume flyout shown");
         try
@@ -204,8 +235,15 @@ public partial class VolumeMixerWindow : MicaWindow
 
     protected override void OnClosed(EventArgs e)
     {
-        _cts.Cancel();
-        _cts.Dispose();
+        try
+        {
+            _cts.Cancel();
+            _cts.Dispose();
+        }
+        catch (ObjectDisposedException)
+        {
+            // already disposed
+        }
         ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
         ViewModel.SessionVolumeChanged -= OnSessionVolumeChanged;
         ViewModel.Dispose();

--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024-2026 The FluentFlyout Authors
+// Copyright (c) 2024-2026 The FluentFlyout Authors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 // Portions of this code are derived from:
@@ -129,6 +129,7 @@ public partial class VolumeMixerWindow : MicaWindow
         _cts = new CancellationTokenSource();
         var token = _cts.Token;
 
+        Logger.Info("Volume flyout shown");
         try
         {
             while (!token.IsCancellationRequested)
@@ -160,6 +161,7 @@ public partial class VolumeMixerWindow : MicaWindow
 
                         WindowHelper.SetVisibility(this, false);
                         ViewModel.IsExpanded = false;
+                        Logger.Info("Volume flyout hidden");
                         break;
                     }
                 }
@@ -168,6 +170,22 @@ public partial class VolumeMixerWindow : MicaWindow
         catch (TaskCanceledException)
         {
             // do nothing
+        }
+        catch (Exception ex)
+        {
+            // Never let the auto-hide loop take the process down: an async void
+            // throw here is an abnormal exit with no further logging.
+            Logger.Error(ex, "Volume flyout loop failed, hiding flyout");
+            try
+            {
+                _isHiding = true;
+                WindowHelper.SetVisibility(this, false);
+                ViewModel.IsExpanded = false;
+            }
+            catch (Exception hideEx)
+            {
+                Logger.Debug(hideEx, "Volume flyout emergency hide failed");
+            }
         }
     }
 
@@ -197,38 +215,40 @@ public partial class VolumeMixerWindow : MicaWindow
     // derived from gpkgpk/HideVolumeOSD: https://github.com/gpkgpk/HideVolumeOSD
     private static void HideVolumeOsd()
     {
-        // find widget in XAML
-        IntPtr hwndXamlIsland, hwndOsd = IntPtr.Zero;
-        while ((hwndXamlIsland = FindWindowEx(IntPtr.Zero, IntPtr.Zero, "XamlExplorerHostIslandWindow", null)) != IntPtr.Zero)
+        // Enumerate top-level XAML islands properly: FindWindowEx with a NULL
+        // child-after handle always returns the FIRST match, so the previous
+        // code re-examined the same window forever (100% CPU spin) whenever it
+        // didn't meet the criteria, and could hide the wrong island's window.
+        IntPtr hwndOsd = IntPtr.Zero;
+        IntPtr hwndXamlIsland = IntPtr.Zero;
+
+        while ((hwndXamlIsland = FindWindowEx(IntPtr.Zero, hwndXamlIsland, "XamlExplorerHostIslandWindow", null)) != IntPtr.Zero)
         {
-            if (hwndXamlIsland == IntPtr.Zero)
+            IntPtr hwndBridge = IntPtr.Zero;
+            while ((hwndBridge = FindWindowEx(hwndXamlIsland, hwndBridge, "Windows.UI.Composition.DesktopWindowContentBridge", "DesktopWindowXamlSource")) != IntPtr.Zero)
             {
-                continue;
-            }
-
-            hwndOsd = FindWindowEx(hwndXamlIsland, IntPtr.Zero, "Windows.UI.Composition.DesktopWindowContentBridge", "DesktopWindowXamlSource");
-            if (hwndOsd == IntPtr.Zero)
-            {
-                continue;
-            }
-
-            // check if the child window has the expected class name and title
-            IntPtr hwndInputClass = FindWindowEx(hwndOsd, IntPtr.Zero, "Windows.UI.Input.InputSite.WindowClass", null);
-            if (hwndInputClass == IntPtr.Zero)
-            {
-                hwndOsd = IntPtr.Zero;
-                continue;
-            }
-
-            ShowWindow(hwndInputClass, 9); // SW_RESTORE
-            if (GetWindowRect(hwndInputClass, out RECT rect))
-            {
-                if (rect.Top == 0 && rect.Left == 0 && rect.Bottom == 0 && rect.Right == 0)
+                // check if the child window has the expected class name and title
+                IntPtr hwndInputClass = FindWindowEx(hwndBridge, IntPtr.Zero, "Windows.UI.Input.InputSite.WindowClass", null);
+                if (hwndInputClass == IntPtr.Zero)
                 {
-                    hwndOsd = IntPtr.Zero;
+                    continue;
                 }
-                else break;
+
+                ShowWindow(hwndInputClass, 9); // SW_RESTORE
+                if (GetWindowRect(hwndInputClass, out RECT rect))
+                {
+                    if (rect.Top == 0 && rect.Left == 0 && rect.Bottom == 0 && rect.Right == 0)
+                    {
+                        continue;
+                    }
+
+                    hwndOsd = hwndBridge;
+                    break;
+                }
             }
+
+            if (hwndOsd != IntPtr.Zero)
+                break;
         }
 
         if (hwndOsd == IntPtr.Zero)

--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
@@ -248,6 +248,36 @@ public partial class VolumeMixerWindow : MicaWindow
         Logger.Info("Successfully hid volume OSD.");
     }
 
+    /// <summary>
+    /// Re-hides the native volume OSD after an Explorer restart. Explorer
+    /// recreates the OSD window (new HWND), so the previously hidden handle is
+    /// dead and the native flyout pops back until something re-hides it.
+    /// Retries briefly since the island can lag behind the taskbar.
+    /// </summary>
+    public static void RehideVolumeOsdAfterExplorerRestart()
+    {
+        _nativeOsdElement = IntPtr.Zero;
+        _ = Task.Run(async () =>
+        {
+            for (int attempt = 0; attempt < 6; attempt++)
+            {
+                try
+                {
+                    if (attempt > 0)
+                        await Task.Delay(2000);
+                    HideVolumeOsd();
+                    if (_nativeOsdElement != IntPtr.Zero)
+                        return;
+                }
+                catch (Exception ex)
+                {
+                    Logger.Debug(ex, "Native OSD re-hide attempt failed");
+                }
+            }
+            Logger.Warn("Could not re-hide native volume OSD after Explorer restart; will retry on next volume key press");
+        });
+    }
+
     public static void ShowVolumeOsd()
     {
         if (_nativeOsdElement == IntPtr.Zero)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Read more about the project's model in the [Sustainability & The Microsoft Store
 
 > Looking for FluentFlyout Settings? You can access it by clicking the system tray icon
 ### Using .msixbundle installer
+> **Prerequisite:** the GitHub build requires the [.NET 10 Desktop Runtime (x64)](https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe). Without it, the package installs but the app silently fails to start.
 1. Go to the [latest release](https://github.com/unchihugo/FluentFlyout/releases/latest) page
 2. Download the **"*.cer"** file *(real certificates cost a lot of money)*
 3. Open the certificate and press **"Install Certificate..."**


### PR DESCRIPTION
## Summary
Batch fix for 35 open issues across volume flyout/mixer, media flyout, taskbar widget, visualizer, and startup paths. Each commit is scoped to one issue and references its number. No new dependencies were added.

## Motivation
Closes #1086, #1075, #1078, #1087, #1084, #1015, #984, #1096, #1085, #1019, #1094, #1071, #1107, #1029, #1083, #973, #961, #1065, #1052, #966, #983, #987, #1039, #1076, #920, #746, #153, #659, #608, #529, #843, #817, #849, #802

## Type of Change
- [x] Bug fix

## What Changed
**Volume flyout / mixer**
- #1086 — live-sync volume flyout via OnVolumeNotification
- #1075 — stop volume flyout failures from crashing the app
- #1078 — native volume OSD returns after Explorer restart
- #1087 — mixer names/icons missing for elevated apps
- #1084 — pause-others fires on metadata spam (inescapable exclusive mode)
- #973 — duplicate mixer rows grouped per app instead of per session
- #1076/#1086 — frozen volume number when audio endpoint is stale or missing
- #920 — only volume keys open the volume flyout
- #966/#1078 — hide native volume OSD at startup with retries

**Media flyout / widget**
- #1015 — hook stalls breaking Alt+Tab; dismiss-animation snap
- #984 — media flyout never appears (off-screen stranding + silent guards)
- #1096 — stale scroll animation blanks/blinks widget on song change
- #1019 — non-square album art cropped in media flyout
- #961 — taskbar widget and next-up flyout go blank on looped tracks
- #746 — seekbar advances while media is paused
- #153 — seekbar position not reset on track change
- #659 — media deduplication not scoped per session
- #608 — empty media titles show blank instead of process name fallback
- #802 — disabled repeat/shuffle controls reserve unused flyout width

**Taskbar widget / visualizer**
- #1085 — ghost widget + dead taskbar on monitor off/projection change
- #1065/#1052 — widget invisible after Explorer restart
- #983 — widget gone after unlock/monitor sleep
- #987/#1039 — flyouts collide with auto-hidden taskbar
- #849 — widget clipped during taskbar auto-hide reveal
- #529 — RTL taskbar widget coordinate handling
- #843 — visualizer freezes when swapping audio sources
- #817 — visualizer stops after spatial audio changes
- #1071 — visualizer dead after S3 sleep/resume
- #1107 — visualizer dead on Dolby Atmos/multi-channel/24-bit audio

**System integration**
- #1094 — MSIX parse/launch failures on GitHub builds
- #1029 — main window pops up on every boot
- #1083 — keyboard-only input lag while song info is fetched

## Additional Information
Developed via AI-assisted tooling on a Linux sandbox without the .NET Windows workload. Built and manually verified on Windows (net10.0-windows) with `dotnet build` succeeding at 0 errors. Manually tested: startup behavior, volume flyout, media flyout, mixer names/icons, Alt+Tab, sleep/resume, audio device switching, seekbar, and native OSD suppression — all passing.

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).