### PR TITLE
Fix Play/Pause button losing album art accent color on hover and press

### DIFF
--- a/FluentFlyoutWPF/MainWindow.xaml
+++ b/FluentFlyoutWPF/MainWindow.xaml
@@ -37,11 +37,10 @@
                                 Background="{TemplateBinding Background}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding CornerRadius}"
-                                Style="{DynamicResource MicaWPF.Styles.GradientBorder.Accent}">
-                                <ContentPresenter
-                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                    VerticalAlignment="Center" />
-                            </corecontrols:GradientBorder>
+                                Style="{DynamicResource MicaWPF.Styles.GradientBorder.Accent}" />
+                            <ContentPresenter
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="Center" />
                         </Grid>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">

--- a/FluentFlyoutWPF/MainWindow.xaml
+++ b/FluentFlyoutWPF/MainWindow.xaml
@@ -6,6 +6,7 @@
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:tray="http://schemas.lepo.co/wpfui/2022/xaml/tray"
     xmlns:controls="clr-namespace:MicaWPF.Controls;assembly=MicaWPF"
+    xmlns:corecontrols="clr-namespace:MicaWPF.Core.Controls;assembly=MicaWPF.Core"
     Height="116" Width="310" Top="-9999"
     WindowStyle="None" mc:Ignorable="d" ShowInTaskbar="False"
     ResizeMode="NoResize" MouseEnter="MicaWindow_MouseEnter"
@@ -17,6 +18,44 @@
     xmlns:viewModels="clr-namespace:FluentFlyoutWPF.ViewModels"
     d:DataContext="{d:DesignInstance viewModels:UserSettings}"
     >
+    <controls:MicaWindow.Resources>
+        <!--
+            Same appearance as MicaWPF.Styles.AccentedButton, but the hover/pressed states dim the accent
+            color instead of animating it to the system accent shade, so the album art accent color
+            (ControlPlayPause.Background) is preserved in every state.
+        -->
+        <Style x:Key="PlayPauseButtonStyle" TargetType="{x:Type controls:Button}"
+               BasedOn="{StaticResource MicaWPF.Styles.AccentedButton}">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type controls:Button}">
+                        <Grid>
+                            <corecontrols:GradientBorder
+                                x:Name="ContentBorder"
+                                Margin="-2"
+                                Padding="{TemplateBinding Padding}"
+                                Background="{TemplateBinding Background}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding CornerRadius}"
+                                Style="{DynamicResource MicaWPF.Styles.GradientBorder.Accent}">
+                                <ContentPresenter
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="Center" />
+                            </corecontrols:GradientBorder>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="ContentBorder" Property="Opacity" Value="0.9" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="ContentBorder" Property="Opacity" Value="0.8" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </controls:MicaWindow.Resources>
     <Window.Triggers>
         <EventTrigger RoutedEvent="Window.Loaded">
             <EventTrigger.Actions>
@@ -127,7 +166,7 @@
                                 <controls:Button
                                     Height="32" Width="32" Name="ControlPlayPause"
                                     Margin="8,0,0,0" Click="PlayPause_Click" Focusable="False"
-                                    Style="{StaticResource MicaWPF.Styles.AccentedButton}" VerticalAlignment="Center">
+                                    Style="{StaticResource PlayPauseButtonStyle}" VerticalAlignment="Center">
                                     <ui:SymbolIcon Name="SymbolPlayPause" Symbol="Pause16" Filled="True"/>
                                 </controls:Button>
                                 <controls:Button


### PR DESCRIPTION
## Summary

Keep the album art accent color on the play/pause button in hover and pressed states instead of switching to the system accent shade.

## Motivation

Closes #910. Supersedes #913.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed

- Added `PlayPauseButtonStyle` in `MainWindow.xaml`, based on `MicaWPF.Styles.AccentedButton`, keeping the same `GradientBorder` template but replacing the `MouseOver`/`Pressed` visual-state color animations with opacity triggers (`IsMouseOver` → 0.9, `IsPressed` → 0.8).
- `ControlPlayPause` now uses that style.

## Additional Information

Root cause: the `AccentedButton` template animates `ContentBorder.Background.Color` to `AccentFillColorSecondary`/`Tertiary` in the `MouseOver`/`Pressed` visual states. Animations outrank the local `Background` set by `UpdateUI`, so the album art color only survived in the normal state — hover/press fell back to the system accent, and disabled used `AccentFillColorDisabled`.

Why not #913's approach: it replaces `GradientBorder` with a plain `Border`, losing the accent inner stroke and the `Margin="-2"` extension, so the button renders smaller and flatter than the other `AccentedButton`s; it also strips the file BOM and is based on stale code (already conflicting). This PR keeps the original template and only removes the color animation. The opacity values match Fluent's own accent hover/press fills (0.9/0.8), so hover intensity is unchanged; disabled keeps the album art color dimmed by the existing `Opacity = 0.35`.

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).
