### PR TITLE
Fix Chinese characters not becoming bold in lock flyout

### DIFF
--- a/FluentFlyoutWPF/Windows/LockWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/LockWindow.xaml.cs
@@ -50,7 +50,11 @@ public partial class LockWindow : MicaWindow
             }
             else LockTextBlock.Text = key + " " + (isOn ? FindResource("LockWindow_LockOn").ToString() : FindResource("LockWindow_LockOff").ToString());
 
-            LockTextBlock.FontWeight = SettingsManager.Current.LockKeysBoldUi ? FontWeights.Medium : FontWeights.Normal;
+            LockTextBlock.FontWeight = SettingsManager.Current.LockKeysBoldUi
+                ? SettingsManager.Current.AppLanguage == "zh-CN" || SettingsManager.Current.AppLanguage == "zh-TW"
+                    ? FontWeights.Bold
+                    : FontWeights.Medium
+                : FontWeights.Normal;
 
             double targetOpacity = isOn ? 1.0 : 0.2;
             double targetWidth = isOn ? 60.0 : 36.0;


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it concise but clear. -->
Fixes issue where Chinese characters don't become bold in lock flyout if the option is enabled

## Motivation

<!-- Why is this change needed? Link issues if applicable. -->

Closes #1115 

## Type of Change

<!-- Please check the type of change your PR introduces: -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other
