### PR TITLE
fix: infinite loop in HideVolumeOsd causes sustained high CPU

### DIFF
--- a/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
+++ b/FluentFlyoutWPF/Windows/VolumeMixerWindow.xaml.cs
@@ -197,15 +197,11 @@ public partial class VolumeMixerWindow : MicaWindow
     // derived from gpkgpk/HideVolumeOSD: https://github.com/gpkgpk/HideVolumeOSD
     private static void HideVolumeOsd()
     {
-        // find widget in XAML
-        IntPtr hwndXamlIsland, hwndOsd = IntPtr.Zero;
-        while ((hwndXamlIsland = FindWindowEx(IntPtr.Zero, IntPtr.Zero, "XamlExplorerHostIslandWindow", null)) != IntPtr.Zero)
+        // find widget in XAML; FindWindowEx must be given the previous handle as hwndChildAfter,
+        // otherwise it returns the same first island forever and this loop never terminates
+        IntPtr hwndXamlIsland = IntPtr.Zero, hwndOsd = IntPtr.Zero;
+        while ((hwndXamlIsland = FindWindowEx(IntPtr.Zero, hwndXamlIsland, "XamlExplorerHostIslandWindow", null)) != IntPtr.Zero)
         {
-            if (hwndXamlIsland == IntPtr.Zero)
-            {
-                continue;
-            }
-
             hwndOsd = FindWindowEx(hwndXamlIsland, IntPtr.Zero, "Windows.UI.Composition.DesktopWindowContentBridge", "DesktopWindowXamlSource");
             if (hwndOsd == IntPtr.Zero)
             {
@@ -220,7 +216,7 @@ public partial class VolumeMixerWindow : MicaWindow
                 continue;
             }
 
-            ShowWindow(hwndInputClass, 9); // SW_RESTORE
+            ShowWindow(hwndInputClass, SW_RESTORE);
             if (GetWindowRect(hwndInputClass, out RECT rect))
             {
                 if (rect.Top == 0 && rect.Left == 0 && rect.Bottom == 0 && rect.Right == 0)


### PR DESCRIPTION
> This patch is generated by AI. I'm not familiar with Windows native development, so I can't help that much. I'm really sorry for this. If you mind, close this and make a fix by yourself.

## Summary

`VolumeMixerWindow.HideVolumeOsd()` spins forever when the first enumerated `XamlExplorerHostIslandWindow` is not the volume OSD, pinning one CPU core. This restores the `hwndChildAfter` cursor the port dropped, so the enumeration terminates. Fixes #827.

## Motivation

Closes #827. Trace taken while the reported CPU burn was in progress:

| function | inclusive | exclusive |
| --- | --- | --- |
| `VolumeMixerWindow.HideVolumeOsd()` | 13.87% | 13.87% |
| `VolumeMixerWindow.HideVolumeOsd()` (second capture) | 16.34% | 16.34% |

Equal inclusive and exclusive means it is a leaf: the frame itself is the work, it is not waiting on anything. On a 12-thread machine the reported ~8% is one full core, and nothing else in the process is close.

## Type of Change

- [x] Bug fix

## What Changed

**The cursor.** `FindWindowEx(hwndParent, hwndChildAfter, className, windowName)` — `hwndChildAfter` is a cursor; the search starts at the window *after* that handle. `NULL` means "start at the first child", so the original call returned the same island on every iteration:

```
FindWindowEx(0, 0, "XamlExplorerHostIslandWindow", null), called 6 times:
  call 1..6: 0x304C6   (1 distinct handle out of 6)

FindWindowEx(0, <previous handle>, ...):
  0x304C6 -> 0x8029C -> NULL
```

None of the three `continue` branches advances the cursor, so if the first island fails the rect test the loop has no exit. Passing `hwndXamlIsland` as `hwndChildAfter` walks the islands and terminates. The upstream this file is derived from (`gpkgpk/HideVolumeOSD`, `Windows11` branch) passes the previous `hwndHost`; the port dropped it.

**The removed `if`.** The `if (hwndXamlIsland == IntPtr.Zero) continue;` was inside the loop body, and the loop condition already guarantees the value is non-zero there, so it was unreachable. It reads like a cursor guard but is not one. Cleanup, not part of the fix.

**The all-zero rect guard is unchanged.** It works: the laid-out OSD island's `InputSite` reads `(1163,1378,1163,1378)` while showing and `(1195,1379,1195,1379)` while hidden — degenerate, zero size, but positioned — while the second, never-positioned island reads exactly `(0,0,0,0)` and is skipped. An earlier comment of mine proposed replacing it with `IsWindowVisible`; that was wrong, and the measurements are below.

**Trigger.** `MainWindow.HookCallback` calls `volumeMixerWindow?.ShowFlyout()` on every media/volume key (0xB0-0xB3, 0xAD-0xAF) when `VolumeControlEnabled` is set, which starts `Task.Run(HideVolumeOsd)`. Each further key press stacks another spinning thread.

## Additional Information

**How the CPU was located.** A watcher on the machine samples total CPU every 2s and, when usage stays above 3% for 6 consecutive samples, captures a `dotnet-trace` of the running process. Two captures, both on FluentFlyout 2.15.0 (Store build), both while the burn was still in progress:

| capture | peak CPU | trigger |
| --- | --- | --- |
| 2026-09-09 19:24:17 | 7.75% of total (12 logical cores) | sustained >= 3% for 6s |
| 2026-09-09 19:27:57 | 8.46% of total | sustained >= 3% for 180s |

Both used `Microsoft-DotNETCore-SampleProfiler` (sampled thread time), reported with `dotnet-trace report ... topN`. `dotnet-stack` on the live process gave two managed threads marked `CPU_TIME`, the same shape in both captures:

```
Thread (0x9AC):            Thread (0x540C):
  CPU_TIME                   CPU_TIME
  FluentFlyout!FluentFlyoutWPF.Windows.VolumeMixerWindow.HideVolumeOsd()
  FluentFlyout!FluentFlyoutWPF.Windows.VolumeMixerWindow+<>c.<ShowFlyout>b__16_0()
  System.Threading.Tasks.Task.InnerInvoke()
  System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(...)
  System.Threading.Tasks.Task.ExecuteWithThreadLocal(...)
  System.Threading.ThreadPoolWorkQueue.Dispatch()
```

**Upstream comparison.** The source this follows is the `Windows11` branch of `gpkgpk/HideVolumeOSD` (it defines the same three window classes and carries the same zero-rect comment), and the differences are adaptations, not inventions:

| | upstream (`Windows11`) | this port |
| --- | --- | --- |
| rect measured | `GetClientRect(hwndHost)` — the island | `GetWindowRect(hwndInputClass)` — the `InputSite` child |
| restored before measuring | `ShowWindow(hwndHost, 9)` | `ShowWindow(hwndInputClass, 9)` |
| multiple matches | counts, errors on 0 or 2+ | takes the first |

On a current build the port's variant discriminates better: upstream's host-client-rect test returns non-zero for *both* islands here (`(0,0,169,61)` for the OSD, `(0,0,2560,1440)` for the full-screen one), so it would hit its own "Multiple pairs found!" error, while the port's `InputSite` test excludes the second cleanly. That is why the guard is left alone and only the cursor is restored.

**Corrections to my earlier comments.** Two claims I made were wrong and are retracted here: that the rect guard cannot discriminate (it can — table above), and that `IsWindowVisible` should replace it (it cannot discriminate — two runs with FluentFlyout stopped gave `true/true` in one and `false/false` in the other for the same two islands).

**One loose end, for the maintainer.** `ShowWindow(hwndInputClass, SW_RESTORE)` does not restore what this app minimizes: the success path ends with `ShowWindow(_nativeOsdElement, SW_MINIMIZE)`, i.e. the host island. Measured after a FluentFlyout-style hide:

| step | host iconic | host clientRect | `InputSite` winRect |
| --- | --- | --- | --- |
| after `ShowWindow(host, SW_MINIMIZE)` | true | `(0,0,0,0)` | `(0,1412,0,1412)` |
| after `ShowWindow(input, SW_RESTORE)` (this port) | true | `(0,0,0,0)` | `(0,1412,0,1412)` |
| after `ShowWindow(host, SW_RESTORE)` (upstream) | false | `(0,0,169,61)` | `(-32768,-32768,-32768,-32768)` |

The `InputSite` rect is non-zero either way, and applying `SW_RESTORE` to the `InputSite` of a never-positioned island does not make its rect non-zero, so the call looks inert for this predicate. Upstream needs its host restore because it reads the host's client rect, which minimize zeroes out. If that line is doing something I am not seeing, I would like to know. (The `if (GetWindowRect(...))` also has no `else`, so a failure neither breaks nor clears `hwndOsd` — inherited from upstream, never observed to fail.)

**Where that leaves this.** That locates the main cause with reasonable confidence; what to do about the loop is the maintainer's call. If this patch is not how you want it, fix it your own way and close this PR — I have no attachment to it.

**Disclosure.** I found the root cause and produced the traces; the patch itself was written with AI assistance. I reproduced the loop and ran the fixed end-to-end build myself, but I cannot answer questions about Windows internals beyond what is written here.

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project.
- [x] Self-review of changes is done.
- [x] AI tools were used (I reviewed and fully understand the changes myself).
