### PR TITLE
feat(widget): let "Fixed Widget Width" use a custom width value

### DIFF
--- a/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
+++ b/FluentFlyoutWPF/Controls/TaskbarWidgetControl.xaml.cs
@@ -40,6 +40,11 @@ public partial class TaskbarWidgetControl : UserControl
     private readonly double _scale = 0.9;
     private readonly int _nativeWidgetsPadding = 216;
 
+    // user configurable fixed width of the widget (DIP), see TaskbarWidgetFixedWidthValue
+    public const int MinFixedWidth = 80;
+    public const int MaxFixedWidth = 420;
+    public const int DefaultFixedWidth = 240; // same as the native Windows widget width
+
     // Cached width calculations
     private string _cachedTitleText = string.Empty;
     private string _cachedArtistText = string.Empty;
@@ -290,6 +295,17 @@ public partial class TaskbarWidgetControl : UserControl
 
         // maximum width limit, same as Windows native widget
         double maxLogicalWidth = _nativeWidgetsPadding / _scale;
+
+        // space taken by the playback controls (0 when they are disabled), so a fixed width can mean
+        // the total widget width instead of only the text area
+        double controlsWidth = 0;
+        if (SettingsManager.Current.TaskbarWidgetControlsEnabled && ControlsStackPanel.Visibility == Visibility.Visible)
+        {
+            controlsWidth = PreviousButton.Width + PlayPauseButton.Width + NextButton.Width;
+            if (!_isVertical)
+                controlsWidth += ControlsStackPanel.Margin.Left + ControlsStackPanel.Margin.Right;
+        }
+
         double logicalWidth;
 
         if (_isVertical)
@@ -298,8 +314,10 @@ public partial class TaskbarWidgetControl : UserControl
         }
         else if (SettingsManager.Current.TaskbarWidgetFixedWidth)
         {
-            // pin to maximum width so right-aligned controls don't shift between songs
-            logicalWidth = maxLogicalWidth;
+            // pin to the width configured by the user so right-aligned controls don't shift between songs;
+            // the configured value is the total width, so the text area gets whatever is left
+            double configuredWidth = Math.Clamp(SettingsManager.Current.TaskbarWidgetFixedWidthValue, MinFixedWidth, MaxFixedWidth);
+            logicalWidth = Math.Max(configuredWidth - controlsWidth, coverImageMargin + _extraMarginForText);
         }
         else
         {
@@ -333,14 +351,7 @@ public partial class TaskbarWidgetControl : UserControl
         }
 
         // add space for playback controls if enabled and visible
-        if (SettingsManager.Current.TaskbarWidgetControlsEnabled && ControlsStackPanel.Visibility == Visibility.Visible)
-        {
-            double controlsWidth = PreviousButton.Width + PlayPauseButton.Width + NextButton.Width;
-            if (!_isVertical)
-                controlsWidth += ControlsStackPanel.Margin.Left + ControlsStackPanel.Margin.Right;
-
-            logicalWidth += controlsWidth;
-        }
+        logicalWidth += controlsWidth;
 
         double logicalHeight = _isSmallTaskbar ? SmallTaskbarWidgetHeight : DefaultTaskbarWidgetHeight;
 

--- a/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
+++ b/FluentFlyoutWPF/Pages/TaskbarWidgetPage.xaml
@@ -208,7 +208,13 @@
                         <TextBlock Text="{DynamicResource TaskbarWidgetFixedWidthDescription}" FontSize="12" Opacity="0.5" />
                     </StackPanel>
                 </ui:CardControl.Header>
-                <ui:ToggleSwitch IsChecked="{Binding TaskbarWidgetFixedWidth, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" />
+                <StackPanel Orientation="Horizontal">
+                    <ui:TextBox Width="60" ClearButtonEnabled="False" Text="{Binding TaskbarWidgetFixedWidthValueText, Mode=TwoWay}"
+                                IsEnabled="{Binding TaskbarWidgetFixedWidth}" />
+                    <TextBlock Text="{DynamicResource PixelsUnit}" FontSize="14" FontWeight="Regular" Margin="10,0,0,0" VerticalAlignment="Center"
+                               IsEnabled="{Binding TaskbarWidgetFixedWidth}" />
+                    <ui:ToggleSwitch IsChecked="{Binding TaskbarWidgetFixedWidth, Mode=TwoWay}" IsEnabled="{Binding IsPremiumUnlocked}" Margin="16,0,0,0" />
+                </StackPanel>
             </ui:CardControl>
             <ui:CardControl x:Name="TaskbarWidgetAutoHideTitleCard" Tag="Indexable" Grid.Row="10" Icon="{ui:SymbolIcon EyeLines24}" Margin="0,0,0,12">
                 <ui:CardControl.Header>

--- a/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
+++ b/FluentFlyoutWPF/Resources/Localization/Dictionary-en-US.xaml
@@ -68,7 +68,7 @@ hides repeat, shuffle and player info</System:String>
     <System:String x:Key="TaskbarWidgetHideCompletelyTitle">Hide Completely When No Media Is Present</System:String>
     <System:String x:Key="TaskbarWidgetHideCompletelyDescription">Hides the entire widget when no media is available, instead of displaying a media icon</System:String>
     <System:String x:Key="TaskbarWidgetFixedWidthTitle">Fixed Widget Width</System:String>
-    <System:String x:Key="TaskbarWidgetFixedWidthDescription">Keep the widget at a fixed width instead of resizing to fit the title and artist text</System:String>
+    <System:String x:Key="TaskbarWidgetFixedWidthDescription">Keep the widget at a fixed width instead of resizing to fit the title and artist text (when off it fits the text; when on, type the width on the left, 80-420)</System:String>
     <System:String x:Key="TaskbarWidgetAutoHideTitle">Autohide Widget</System:String>
     <System:String x:Key="TaskbarWidgetAutoHideDescription">Hides the widget automatically when media is paused</System:String>
     <System:String x:Key="TaskbarWidgetShowPauseOverlayTitle">Show Pause Icon Overlay</System:String>

--- a/FluentFlyoutWPF/ViewModels/UserSettings.cs
+++ b/FluentFlyoutWPF/ViewModels/UserSettings.cs
@@ -435,6 +435,36 @@ public partial class UserSettings : ObservableObject
     public partial bool TaskbarWidgetFixedWidth { get; set; }
 
     /// <summary>
+    /// Width of the taskbar widget in device independent pixels, used when <see cref="TaskbarWidgetFixedWidth"/>
+    /// is enabled.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(TaskbarWidgetFixedWidthValueText))]
+    public partial int TaskbarWidgetFixedWidthValue { get; set; }
+
+    /// <summary>
+    /// Text representation of <see cref="TaskbarWidgetFixedWidthValue"/> for the settings text box.
+    /// </summary>
+    [XmlIgnore]
+    public string TaskbarWidgetFixedWidthValueText
+    {
+        get => TaskbarWidgetFixedWidthValue.ToString();
+        set
+        {
+            if (int.TryParse(value, out var result))
+            {
+                TaskbarWidgetFixedWidthValue = Math.Clamp(result, TaskbarWidgetControl.MinFixedWidth, TaskbarWidgetControl.MaxFixedWidth);
+            }
+            else
+            {
+                TaskbarWidgetFixedWidthValue = TaskbarWidgetControl.DefaultFixedWidth;
+            }
+
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the pause icon overlay should be completely hidden from view.
     /// </summary>
     [ObservableProperty]
@@ -752,6 +782,7 @@ public partial class UserSettings : ObservableObject
         TaskbarWidgetBackgroundBlur = false;
         TaskbarWidgetHideCompletely = false;
         TaskbarWidgetFixedWidth = false;
+        TaskbarWidgetFixedWidthValue = 240;
         TaskbarWidgetShowPauseOverlay = true;
         TaskbarWidgetControlsEnabled = false;
         TaskbarWidgetControlsPosition = 1;
@@ -921,6 +952,12 @@ public partial class UserSettings : ObservableObject
     }
 
     partial void OnTaskbarWidgetFixedWidthChanged(bool oldValue, bool newValue)
+    {
+        if (oldValue == newValue || _initializing) return;
+        UpdateTaskbar();
+    }
+
+    partial void OnTaskbarWidgetFixedWidthValueChanged(int oldValue, int newValue)
     {
         if (oldValue == newValue || _initializing) return;
         UpdateTaskbar();


### PR DESCRIPTION
## Summary
"Fixed Widget Width" now takes a width value instead of always pinning the widget to the maximum width.

## Motivation
The toggle always sized the widget to the maximum width (240 px, identical to the native Windows widget), which leaves a lot of empty space for short titles, and there is no way to choose anything in between. Related: #957, #848.

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, naming)
- [ ] Other

## What Changed
- New setting `TaskbarWidgetFixedWidthValue` (80–420 px, default 240 = previous behaviour) plus a `...Text` property that validates the input, following the existing `TaskbarWidgetManualPaddingText` pattern.
- `TaskbarWidgetControl.CalculateSize()`: with the toggle on, the widget uses the configured value. The playback control buttons width is now calculated before the text area, so the configured value is the *total* widget width (previously the controls were added on top).
- Settings UI: a numeric text box next to the toggle, enabled only while the toggle is on.
- Localization: `TaskbarWidgetFixedWidthDescription` updated in `Dictionary-en-US.xaml`.

## Additional Information
Measured on the real taskbar (Windows 11 25H2, 200% scaling): value 300 → widget is 540 physical px wide; a value below what the content needs (cover + buttons, ~165 px) is clamped. With the toggle off everything is unchanged.

## Checklist
- [x] Code changes are manually tested and working.
- [x] Formatting and naming are consistent with the project (`dotnet format --verify-no-changes` passes for the touched files).
- [x] Self-review of changes is done.
- [x] AI tools were used (if yes, I reviewed and fully understand the changes myself).
